### PR TITLE
chore(docs&ci): change the links in build files & fix github workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,14 +16,14 @@ body:
         您必须勾选以下所有内容，否则您的issue可能会被直接关闭。或者您可以去[讨论区](https://github.com/alist-org/alist/discussions)
       options:
         - label: |
-            I have read the [documentation](https://alist.nn.ci).
-            我已经阅读了[文档](https://alist.nn.ci)。
+            I have read the [documentation](https://alistteam.github.io/docs).
+            我已经阅读了[文档](https://alistteam.github.io/docs)。
         - label: |
             I'm sure there are no duplicate issues or discussions.
             我确定没有重复的issue或讨论。
         - label: |
-            I'm sure it's due to `AList` and not something else(such as [Network](https://alist.nn.ci/faq/howto.html#tls-handshake-timeout-read-connection-reset-by-peer-dns-lookup-failed-connect-connection-refused-client-timeout-exceeded-while-awaiting-headers-no-such-host) ,`Dependencies` or `Operational`).
-            我确定是`AList`的问题，而不是其他原因（例如[网络](https://alist.nn.ci/zh/faq/howto.html#tls-handshake-timeout-read-connection-reset-by-peer-dns-lookup-failed-connect-connection-refused-client-timeout-exceeded-while-awaiting-headers-no-such-host)，`依赖`或`操作`）。
+            I'm sure it's due to `AList` and not something else(such as [Network](https://alistteam.github.io/docs/faq/howto.html#tls-handshake-timeout-read-connection-reset-by-peer-dns-lookup-failed-connect-connection-refused-client-timeout-exceeded-while-awaiting-headers-no-such-host) ,`Dependencies` or `Operational`).
+            我确定是`AList`的问题，而不是其他原因（例如[网络](https://alistteam.github.io/docs/zh/faq/howto.html#tls-handshake-timeout-read-connection-reset-by-peer-dns-lookup-failed-connect-connection-refused-client-timeout-exceeded-while-awaiting-headers-no-such-host)，`依赖`或`操作`）。
         - label: |
             I'm sure this issue is not fixed in the latest version.
             我确定这个问题在最新版本中没有被修复。

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
       label: Please make sure of the following things
       description: You may select more than one, even select all.
       options:
-        - label: I have read the [documentation](https://alist.nn.ci).
+        - label: I have read the [documentation](https://alistteam.github.io/docs).
         - label: I'm sure there are no duplicate issues or discussions.
         - label: I'm sure this feature is not implemented.
         - label: I'm sure it's a reasonable and popular requirement.

--- a/.github/workflows/auto_lang.yml
+++ b/.github/workflows/auto_lang.yml
@@ -1,14 +1,15 @@
 name: auto_lang
 
 on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'drivers/**'
-      - 'internal/bootstrap/data/setting.go'
-      - 'internal/conf/const.go'
-      - 'cmd/lang.go'
+  # Disable tranlation generation, enable it after everythis is setup.
+  # push:
+  #   branches:
+  #     - 'main'
+  #   paths:
+  #     - 'drivers/**'
+  #     - 'internal/bootstrap/data/setting.go'
+  #     - 'internal/conf/const.go'
+  #     - 'cmd/lang.go'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -41,15 +41,22 @@ jobs:
         run: |
           git tag -l
           npx changelogithub --output CHANGELOG.md
-#          npx changelogen@latest --output CHANGELOG.md
 
+      # Disable this right now, use github workflow assets for easier manipulation
+      # - name: Upload assets
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     body_path: "See CHANGELOG.md"
+      #     files: CHANGELOG.md
+      #     prerelease: true
+      #     tag_name: beta
       - name: Upload assets
-        uses: softprops/action-gh-release@v2
+        uses: actions/upload-artifact@v4
         with:
-          body_path: CHANGELOG.md
-          files: CHANGELOG.md
-          prerelease: true
-          tag_name: beta
+          name: beta changelog
+          path: ${{ github.workspace }}/CHANGELOG.md
+          compression-level: 0
+          if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
   release:
     needs:
@@ -102,37 +109,47 @@ jobs:
       - name: Compress
         run: |
           bash build.sh zip ${{ matrix.hash }}
-          
+
+      # See above           
+      # - name: Upload assets
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     files: build/compress/*
+      #     prerelease: true
+      #     tag_name: beta
+
       - name: Upload assets
-        uses: softprops/action-gh-release@v2
+        uses: actions/upload-artifact@v4
         with:
-          files: build/compress/*
-          prerelease: true
-          tag_name: beta
-          
-  desktop:
-    needs:
-      - release
-    name: Beta Release Desktop
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          repository: alist-org/desktop-release
-          ref: main
-          persist-credentials: false
-          fetch-depth: 0
+          name: beta builds
+          path: ${{ github.workspace }}/build/compress/*
+          compression-level: 0
+          if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
-      - name: Commit
-        run: |
-          git config --local user.email "bot@nn.ci"
-          git config --local user.name "IlaBot"
-          git commit --allow-empty -m "Trigger build for ${{ github.sha }}"
+  # TODO: We do not have desktop clients right now.        
+  # desktop:
+  #   needs:
+  #     - release
+  #   name: Beta Release Desktop
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: alist-org/desktop-release
+  #         ref: main
+  #         persist-credentials: false
+  #         fetch-depth: 0
 
-      - name: Push commit
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.MY_TOKEN }}
-          branch: main
-          repository: alist-org/desktop-release
+  #     - name: Commit
+  #       run: |
+  #         git config --local user.email "bot@nn.ci"
+  #         git config --local user.name "IlaBot"
+  #         git commit --allow-empty -m "Trigger build for ${{ github.sha }}"
+
+  #     - name: Push commit
+  #       uses: ad-m/github-push-action@master
+  #       with:
+  #         github_token: ${{ secrets.MY_TOKEN }}
+  #         branch: main
+  #         repository: alist-org/desktop-release

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-i@nn.ci.
+reported to the community leaders responsible for enforcement at the Community.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 appName="alist"
 builtAt="$(date +'%F %T %z')"
-gitAuthor="Xhofe <i@nn.ci>"
+gitAuthor="OpenList <github-workflow@noreply.example.com>"
 gitCommit=$(git log --pretty=format:"%h" -1)
 
 if [ "$1" = "dev" ]; then
@@ -12,6 +12,7 @@ elif [ "$1" = "beta" ]; then
 else
   git tag -d beta
   version=$(git describe --abbrev=0 --tags)
+  # TODO: Repleace this assets with our new frontend if needed
   webVersion=$(wget -qO- -t1 -T2 "https://api.github.com/repos/alist-org/alist-web/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" '{print $2}' | sed 's/\"//g;s/,//g;s/ //g')
 fi
 
@@ -59,7 +60,7 @@ BuildDev() {
   rm -rf .git/
   mkdir -p "dist"
   muslflags="--extldflags '-static -fpic' $ldflags"
-  BASE="https://musl.nn.ci/"
+  BASE="https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/"
   FILES=(x86_64-linux-musl-cross aarch64-linux-musl-cross)
   for i in "${FILES[@]}"; do
     url="${BASE}${i}.tgz"
@@ -158,7 +159,7 @@ BuildReleaseLinuxMusl() {
   rm -rf .git/
   mkdir -p "build"
   muslflags="--extldflags '-static -fpic' $ldflags"
-  BASE="https://musl.nn.ci/"
+  BASE="https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/"
   FILES=(x86_64-linux-musl-cross aarch64-linux-musl-cross mips-linux-musl-cross mips64-linux-musl-cross mips64el-linux-musl-cross mipsel-linux-musl-cross powerpc64le-linux-musl-cross s390x-linux-musl-cross)
   for i in "${FILES[@]}"; do
     url="${BASE}${i}.tgz"
@@ -184,7 +185,7 @@ BuildReleaseLinuxMuslArm() {
   rm -rf .git/
   mkdir -p "build"
   muslflags="--extldflags '-static -fpic' $ldflags"
-  BASE="https://musl.nn.ci/"
+  BASE="https://github.com/musl-cc/musl.cc/releases/download/v0.0.1/"
 #  FILES=(arm-linux-musleabi-cross arm-linux-musleabihf-cross armeb-linux-musleabi-cross armeb-linux-musleabihf-cross armel-linux-musleabi-cross armel-linux-musleabihf-cross armv5l-linux-musleabi-cross armv5l-linux-musleabihf-cross armv6-linux-musleabi-cross armv6-linux-musleabihf-cross armv7l-linux-musleabihf-cross armv7m-linux-musleabi-cross armv7r-linux-musleabihf-cross)
   FILES=(arm-linux-musleabi-cross arm-linux-musleabihf-cross armel-linux-musleabi-cross armel-linux-musleabihf-cross armv5l-linux-musleabi-cross armv5l-linux-musleabihf-cross armv6-linux-musleabi-cross armv6-linux-musleabihf-cross armv7l-linux-musleabihf-cross armv7m-linux-musleabi-cross armv7r-linux-musleabihf-cross)
   for i in "${FILES[@]}"; do

--- a/drivers/aliyundrive_open/meta.go
+++ b/drivers/aliyundrive_open/meta.go
@@ -11,7 +11,7 @@ type Addition struct {
 	RefreshToken       string `json:"refresh_token" required:"true"`
 	OrderBy            string `json:"order_by" type:"select" options:"name,size,updated_at,created_at"`
 	OrderDirection     string `json:"order_direction" type:"select" options:"ASC,DESC"`
-	OauthTokenURL      string `json:"oauth_token_url" default:"https://api.nn.ci/alist/ali_open/token"`
+	OauthTokenURL      string `json:"oauth_token_url" default:"https://example.com/alist/ali_open/token"` // TODO: Replace this with a community hosted api endpoint
 	ClientID           string `json:"client_id" required:"false" help:"Keep it empty if you don't have one"`
 	ClientSecret       string `json:"client_secret" required:"false" help:"Keep it empty if you don't have one"`
 	RemoveWay          string `json:"remove_way" required:"true" type:"select" options:"trash,delete"`

--- a/drivers/onedrive/meta.go
+++ b/drivers/onedrive/meta.go
@@ -11,7 +11,7 @@ type Addition struct {
 	IsSharepoint bool   `json:"is_sharepoint"`
 	ClientID     string `json:"client_id" required:"true"`
 	ClientSecret string `json:"client_secret" required:"true"`
-	RedirectUri  string `json:"redirect_uri" required:"true" default:"https://alist.nn.ci/tool/onedrive/callback"`
+	RedirectUri  string `json:"redirect_uri" required:"true" default:"https://example.com/tool/onedrive/callback"` // TODO: Replace this with a community hosted api endpoint
 	RefreshToken string `json:"refresh_token" required:"true"`
 	SiteId       string `json:"site_id"`
 	ChunkSize    int64  `json:"chunk_size" type:"number" default:"5"`

--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -155,7 +155,7 @@ func InitialSettings() []model.SettingItem {
 ([[:xdigit:]]{1,4}(?::[[:xdigit:]]{1,4}){7}|::|:(?::[[:xdigit:]]{1,4}){1,6}|[[:xdigit:]]{1,4}:(?::[[:xdigit:]]{1,4}){1,5}|(?:[[:xdigit:]]{1,4}:){2}(?::[[:xdigit:]]{1,4}){1,4}|(?:[[:xdigit:]]{1,4}:){3}(?::[[:xdigit:]]{1,4}){1,3}|(?:[[:xdigit:]]{1,4}:){4}(?::[[:xdigit:]]{1,4}){1,2}|(?:[[:xdigit:]]{1,4}:){5}:[[:xdigit:]]{1,4}|(?:[[:xdigit:]]{1,4}:){1,6}:)
 (?U)access_token=(.*)&`,
 			Type: conf.TypeText, Group: model.GLOBAL, Flag: model.PRIVATE},
-		{Key: conf.OcrApi, Value: "https://api.nn.ci/ocr/file/json", Type: conf.TypeString, Group: model.GLOBAL},
+		{Key: conf.OcrApi, Value: "https://api.nn.ci/ocr/file/json", Type: conf.TypeString, Group: model.GLOBAL}, // TODO: This can be replace by a community-hosted endpoint, see https://github.com/xhofe/ocr_api_server
 		{Key: conf.FilenameCharMapping, Value: `{"/": "|"}`, Type: conf.TypeText, Group: model.GLOBAL},
 		{Key: conf.ForwardDirectLinkParams, Value: "false", Type: conf.TypeBool, Group: model.GLOBAL},
 		{Key: conf.IgnoreDirectLinkParams, Value: "sign,alist_ts", Type: conf.TypeString, Group: model.GLOBAL},

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -19,7 +19,7 @@ const (
 	ADMIN
 )
 
-const StaticHashSalt = "https://github.com/alist-org/alist"
+const StaticHashSalt = "https://github.com/AlistTeam/OpenList"
 
 type User struct {
 	ID       uint   `json:"id" gorm:"primaryKey"`                      // unique key
@@ -177,5 +177,5 @@ func (u *User) WebAuthnCredentials() []webauthn.Credential {
 }
 
 func (u *User) WebAuthnIcon() string {
-	return "https://alist.nn.ci/logo.svg"
+	return "https://jsd.nn.ci/gh/alist-org/logo@main/logo.svg"
 }


### PR DESCRIPTION
# Changes 
 - Change musl download link to the mirror provided in https://github.com/musl-cc/musl.cc/releases/tag/v0.0.1 (This should work better in GitHub)
 - Change the docs URL in issue templates
 - Change the default API endpoint URL to example.com, which should be change back into a community hosted one when it is ready
 - Disable the beta release, instead, the build artifacts are now uploaded to the GitHub workflow's artifact section. We can always track the latest uploaded artifacts using links provided by https://nightly.link/ to avoid the needs to login GitHub accounts.
 