### PR TITLE
Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 >
 > This fork is not yet stable. A large number of external links point to unaudited content, posing a supply chain attack risk, including related documentation websites, etc. Do not trust!
 >
-> Currently, only links confirmed to be outside the original author's control (such as `alistgo.com`) have been removed.
+> Currently, only links confirmed to be outside the original author's control (such as `alistgo.com`) have been removed, The detailed migration progress of the project can be viewed in the [OpenList Migration Summary](https://github.com/OpenListTeam/OpenList/issues/6).
 
 English | [中文](./README_cn.md) | [日本語](./README_ja.md) | [Contributing](./CONTRIBUTING.md) | [CODE_OF_CONDUCT](./CODE_OF_CONDUCT.md)
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -34,7 +34,8 @@
 > 我们诚挚地感谢原作者 [xhofe/alist](https://github.com/xhofe/alist) 为原项目做出的重大贡献。
 >
 > 本 Fork 尚未稳定, 大量外部链接指向的内容尚未得到审计, 存在投毒风险, 含相关文档网站等. 切勿盲目信任!
-
+>
+> 当前仅移除了被确认超出原作者控制范围的外部链接（如`alistgo.com`），项目具体迁移进度可在[OpenList 迁移工作总结](https://github.com/OpenListTeam/OpenList/issues/6)中查看
 [English](./README.md) | 中文 | [日本語](./README_ja.md) | [Contributing](./CONTRIBUTING.md) | [CODE_OF_CONDUCT](./CODE_OF_CONDUCT.md)
 
 ## 功能

--- a/README_cn.md
+++ b/README_cn.md
@@ -36,6 +36,7 @@
 > 本 Fork 尚未稳定, 大量外部链接指向的内容尚未得到审计, 存在投毒风险, 含相关文档网站等. 切勿盲目信任!
 >
 > 当前仅移除了被确认超出原作者控制范围的外部链接（如`alistgo.com`），项目具体迁移进度可在[OpenList 迁移工作总结](https://github.com/OpenListTeam/OpenList/issues/6)中查看
+
 [English](./README.md) | 中文 | [日本語](./README_ja.md) | [Contributing](./CONTRIBUTING.md) | [CODE_OF_CONDUCT](./CODE_OF_CONDUCT.md)
 
 ## 功能

--- a/README_ja.md
+++ b/README_ja.md
@@ -35,7 +35,7 @@
 > 
 > 本フォークはまだ安定していません。多数の外部リンクが未検証のコンテンツを指しており、ドキュメントサイトなどを含め、サプライチェーン攻撃のリスクがあります。信頼しないでください！
 > 
-> 現時点では、オリジナル作者の管理下にないことが確認されているリンク（例：`alistgo.com`）のみ削除されています，本プロジェクトの具体的な移行進捗状況は、[OpenList 移行作業報告書]（https://github.com/OpenListTeam/OpenList/issues/6）でご確認いただけます。
+> 現時点では、オリジナル作者の管理下にないことが確認されているリンク（例：`alistgo.com`）のみ削除されています，本プロジェクトの具体的な移行進捗状況は、[OpenList 移行作業報告書]（https://github.com/OpenListTeam/OpenList/issues/6)でご確認いただけます。
 
 [English](./README.md) | [中文](./README_cn.md) | 日本語 | [Contributing](./CONTRIBUTING.md) | [CODE_OF_CONDUCT](./CODE_OF_CONDUCT.md)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -35,7 +35,7 @@
 > 
 > 本フォークはまだ安定していません。多数の外部リンクが未検証のコンテンツを指しており、ドキュメントサイトなどを含め、サプライチェーン攻撃のリスクがあります。信頼しないでください！
 > 
-> 現時点では、オリジナル作者の管理下にないことが確認されているリンク（例：`alistgo.com`）のみ削除されています。
+> 現時点では、オリジナル作者の管理下にないことが確認されているリンク（例：`alistgo.com`）のみ削除されています，本プロジェクトの具体的な移行進捗状況は、[OpenList 移行作業報告書]（https://github.com/OpenListTeam/OpenList/issues/6）でご確認いただけます。
 
 [English](./README.md) | [中文](./README_cn.md) | 日本語 | [Contributing](./CONTRIBUTING.md) | [CODE_OF_CONDUCT](./CODE_OF_CONDUCT.md)
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -35,7 +35,7 @@
 > 
 > 本フォークはまだ安定していません。多数の外部リンクが未検証のコンテンツを指しており、ドキュメントサイトなどを含め、サプライチェーン攻撃のリスクがあります。信頼しないでください！
 > 
-> 現時点では、オリジナル作者の管理下にないことが確認されているリンク（例：`alistgo.com`）のみ削除されています，本プロジェクトの具体的な移行進捗状況は、[OpenList 移行作業報告書]（https://github.com/OpenListTeam/OpenList/issues/6)でご確認いただけます。
+> 現時点では、オリジナル作者の管理下にないことが確認されているリンク（例：`alistgo.com`）のみ削除されています，本プロジェクトの具体的な移行進捗状況は、[OpenList 移行作業報告書](https://github.com/OpenListTeam/OpenList/issues/6)でご確認いただけます。
 
 [English](./README.md) | [中文](./README_cn.md) | 日本語 | [Contributing](./CONTRIBUTING.md) | [CODE_OF_CONDUCT](./CODE_OF_CONDUCT.md)
 


### PR DESCRIPTION
README.md增加The detailed migration progress of the project can be viewed in the [OpenList Migration Summary] (https://github.com/OpenListTeam/OpenList/issues/6).文本

README.md Add "The detailed migration progress of the project can be viewed in the [OpenList Migration Summary] (https://github.com/OpenListTeam/OpenList/issues/6)."Texts

README_cn.md增加”当前仅移除了被确认超出原作者控制范围的外部链接（如 alistgo.com）”和”项目具体迁移进度可在[OpenList 迁移工作总结](https://github.com/OpenListTeam/OpenList/issues/6)中查看“

README_ja.md追加しました“本プロジェクトの具体的な移行進捗状況は、[OpenList 移行作業報告書](https://github.com/OpenListTeam/OpenList/issues/6)でご確認いただけます。”
