### PR TITLE
fix: change app name in cmd

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -26,8 +26,8 @@ var AdminCmd = &cobra.Command{
 		} else {
 			utils.Log.Infof("Admin user's username: %s", admin.Username)
 			utils.Log.Infof("The password can only be output at the first startup, and then stored as a hash value, which cannot be reversed")
-			utils.Log.Infof("You can reset the password with a random string by running [alist admin random]")
-			utils.Log.Infof("You can also set a new password by running [alist admin set NEW_PASSWORD]")
+			utils.Log.Infof("You can reset the password with a random string by running [openlist admin random]")
+			utils.Log.Infof("You can also set a new password by running [openlist admin set NEW_PASSWORD]")
 		}
 	},
 }

--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -1,15 +1,16 @@
 package cmd
 
 import (
+	"os"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // KillCmd represents the kill command
 var KillCmd = &cobra.Command{
 	Use:   "kill",
-	Short: "Force kill alist server process by daemon/pid file",
+	Short: "Force kill openlist server process by daemon/pid file",
 	Run: func(cmd *cobra.Command, args []string) {
 		kill()
 	},
@@ -18,7 +19,7 @@ var KillCmd = &cobra.Command{
 func kill() {
 	initDaemon()
 	if pid == -1 {
-		log.Info("Seems not have been started. Try use `alist start` to start server.")
+		log.Info("Seems not have been started. Try use `openlist start` to start server.")
 		return
 	}
 	process, err := os.FindProcess(pid)

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -10,7 +10,7 @@ import (
 // RestartCmd represents the restart command
 var RestartCmd = &cobra.Command{
 	Use:   "restart",
-	Short: "Restart alist server by daemon/pid file",
+	Short: "Restart openlist server by daemon/pid file",
 	Run: func(cmd *cobra.Command, args []string) {
 		stop()
 		start()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,7 @@ import (
 )
 
 var RootCmd = &cobra.Command{
-	Use:   "alist",
+	Use:   "openlist",
 	Short: "A file list program that supports multiple storage.",
 	Long: `A file list program that supports multiple storage,
 built with love by Xhofe and friends in Go/Solid.js.

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -16,7 +16,7 @@ import (
 // StartCmd represents the start command
 var StartCmd = &cobra.Command{
 	Use:   "start",
-	Short: "Silent start alist server with `--force-bin-dir`",
+	Short: "Silent start openlist server with `--force-bin-dir`",
 	Run: func(cmd *cobra.Command, args []string) {
 		start()
 	},
@@ -27,7 +27,7 @@ func start() {
 	if pid != -1 {
 		_, err := os.FindProcess(pid)
 		if err == nil {
-			log.Info("alist already started, pid ", pid)
+			log.Info("openlist already started, pid ", pid)
 			return
 		}
 	}
@@ -52,7 +52,7 @@ func start() {
 	log.Infof("success start pid: %d", cmd.Process.Pid)
 	err = os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0666)
 	if err != nil {
-		log.Warn("failed to record pid, you may not be able to stop the program with `./alist stop`")
+		log.Warn("failed to record pid, you may not be able to stop the program with `./openlist stop`")
 	}
 }
 

--- a/cmd/stop_default.go
+++ b/cmd/stop_default.go
@@ -13,7 +13,7 @@ import (
 // StopCmd represents the stop command
 var StopCmd = &cobra.Command{
 	Use:   "stop",
-	Short: "Stop alist server by daemon/pid file",
+	Short: "Stop openlist server by daemon/pid file",
 	Run: func(cmd *cobra.Command, args []string) {
 		stop()
 	},
@@ -22,7 +22,7 @@ var StopCmd = &cobra.Command{
 func stop() {
 	initDaemon()
 	if pid == -1 {
-		log.Info("Seems not have been started. Try use `alist start` to start server.")
+		log.Info("Seems not have been started. Try use `openlist start` to start server.")
 		return
 	}
 	process, err := os.FindProcess(pid)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,7 +15,7 @@ import (
 // VersionCmd represents the version command
 var VersionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Show current version of AList",
+	Short: "Show current version of OpenList",
 	Run: func(cmd *cobra.Command, args []string) {
 		goVersion := fmt.Sprintf("%s %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
 


### PR DESCRIPTION
Rename the application from `alist` to `openlist` across various commands and log messages. `openlist` is used as app name in `build.sh`
