### PR TITLE
feat: add file visibility checks for windows

### DIFF
--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	stdpath "path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -128,9 +129,19 @@ func (d *Local) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 	}
 	var files []model.Obj
 	for _, f := range rawFiles {
-		if !d.ShowHidden && strings.HasPrefix(f.Name(), ".") {
-			continue
+		if !d.ShowHidden {
+			fileName := f.Name()
+			if runtime.GOOS == "windows" {
+				if isHiddenOnWindows(f, fullPath) {
+					continue
+				}
+			} else {
+				if strings.HasPrefix(fileName, ".") {
+					continue
+				}
+			}
 		}
+
 		file := d.FileInfoToObj(ctx, f, args.ReqPath, fullPath)
 		files = append(files, file)
 	}

--- a/drivers/local/util.go
+++ b/drivers/local/util.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/OpenListTeam/OpenList/internal/conf"
 	"github.com/OpenListTeam/OpenList/internal/model"
@@ -150,4 +151,17 @@ func (d *Local) getThumb(file model.Obj) (*bytes.Buffer, *string, error) {
 		}
 	}
 	return &buf, nil, nil
+}
+
+func isHiddenOnWindows(f fs.FileInfo, fullPath string) bool {
+	filePath := filepath.Join(fullPath, f.Name())
+	namePtr, err := syscall.UTF16PtrFromString(filePath)
+	if err != nil {
+		return false
+	}
+	attrs, err := syscall.GetFileAttributes(namePtr)
+	if err != nil {
+		return false
+	}
+	return attrs&syscall.FILE_ATTRIBUTE_HIDDEN != 0
 }


### PR DESCRIPTION

Adding support for detecting hidden files on windows. In current version, the hidden file is detected by start with `.` in filename, which is not suitable for windows.