### PR TITLE
fix(cloudreve): remove unnecessary finish increment in upload functions

### DIFF
--- a/drivers/cloudreve/util.go
+++ b/drivers/cloudreve/util.go
@@ -334,7 +334,6 @@ func (d *Cloudreve) upOneDrive(ctx context.Context, stream model.FileStreamer, u
 		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
 		req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, stream.GetSize()))
 		req.Header.Set("User-Agent", d.getUA())
-		finish += byteSize
 		res, err := base.HttpClient.Do(req)
 		if err != nil {
 			return err
@@ -394,7 +393,6 @@ func (d *Cloudreve) upS3(ctx context.Context, stream model.FileStreamer, u Uploa
 		}
 		req = req.WithContext(ctx)
 		req.ContentLength = byteSize
-		finish += byteSize
 		res, err := base.HttpClient.Do(req)
 		if err != nil {
 			return err
@@ -411,7 +409,7 @@ func (d *Cloudreve) upS3(ctx context.Context, stream model.FileStreamer, u Uploa
 			utils.Log.Warnf("[Cloudreve-S3] server errors %d while uploading, retrying after %v...", res.StatusCode, backoff)
 			time.Sleep(backoff)
 		case etag == "":
-			return errors.New("faild to get ETag from header")
+			return errors.New("failed to get ETag from header")
 		default:
 			retryCount = 0
 			etags = append(etags, etag)

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -352,7 +352,6 @@ func (d *CloudreveV4) upOneDrive(ctx context.Context, file model.FileStreamer, u
 		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
 		req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, file.GetSize()))
 		req.Header.Set("User-Agent", d.getUA())
-		finish += byteSize
 		res, err := base.HttpClient.Do(req)
 		if err != nil {
 			return err
@@ -428,7 +427,7 @@ func (d *CloudreveV4) upS3(ctx context.Context, file model.FileStreamer, u FileU
 			utils.Log.Warnf("server error %d, retrying after %v...", res.StatusCode, backoff)
 			time.Sleep(backoff)
 		case etag == "":
-			return errors.New("faild to get ETag from header")
+			return errors.New("failed to get ETag from header")
 		default:
 			retryCount = 0
 			etags = append(etags, etag)


### PR DESCRIPTION
- Fixed the bug that 'finish += byteSize' was added twice in the upload function, which caused the upload to end early and failed to upload large files

- Fixed a typo in the log

Migrated from: https://github.com/AlistGo/alist/pull/8580