### PR TITLE
fix(189pc): crashes when upload cancelled

### DIFF
--- a/drivers/189pc/utils.go
+++ b/drivers/189pc/utils.go
@@ -531,7 +531,8 @@ func (y *Cloud189PC) StreamUpload(ctx context.Context, dstDir model.Obj, file mo
 		// 读取块
 		silceMd5.Reset()
 		if _, err := io.ReadFull(teeReader, byteData); err != io.EOF && err != nil {
-			sem.Release(1)
+			// 此处不需要释放信号量，因为信号量的创建和释放完全由 threadG 处理
+			// 此处释放会导致 semaphore: released more than held
 			return nil, err
 		}
 

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -97,9 +97,9 @@ type Put interface {
 	//    before uploading the file or file chunks. Or you can directly call `driver.ServerUploadLimitWaitN`
 	//    if your file chunks are sufficiently small (less than about 50KB).
 	// NOTE that the network speed may be significantly slower than the stream's read speed. Therefore, if
-	// you use a `errgroup.Group` to upload each chunk in parallel, you should consider using a recursive
-	// mutex like `semaphore.Weighted` to limit the maximum number of upload threads, preventing excessive
-	// memory usage caused by buffering too many file chunks awaiting upload.
+	// you use a `errgroup.Group` to upload each chunk in parallel, you should use `Group.SetLimit` to
+	// limit the maximum number of upload threads, preventing excessive memory usage caused by buffering
+	// too many file chunks awaiting upload.
 	Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up UpdateProgress) error
 }
 
@@ -156,9 +156,9 @@ type PutResult interface {
 	//    before uploading the file or file chunks. Or you can directly call `driver.ServerUploadLimitWaitN`
 	//    if your file chunks are sufficiently small (less than about 50KB).
 	// NOTE that the network speed may be significantly slower than the stream's read speed. Therefore, if
-	// you use a `errgroup.Group` to upload each chunk in parallel, you should consider using a recursive
-	// mutex like `semaphore.Weighted` to limit the maximum number of upload threads, preventing excessive
-	// memory usage caused by buffering too many file chunks awaiting upload.
+	// you use a `errgroup.Group` to upload each chunk in parallel, you should use `Group.SetLimit` to
+	// limit the maximum number of upload threads, preventing excessive memory usage caused by buffering
+	// too many file chunks awaiting upload.
 	Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up UpdateProgress) (model.Obj, error)
 }
 


### PR DESCRIPTION
This PR will fix this panic:
```
panic: semaphore: released more than held

goroutine 46665 [running]:
golang.org/x/sync/semaphore.(*Weighted).Release(0xc000598550, 0xc0018a6000?)
        /home/runner/go/pkg/mod/golang.org/x/sync@v0.12.0/semaphore/semaphore.go:127 +0xb8
github.com/alist-org/alist/v3/drivers/189pc.(*Cloud189PC).StreamUpload.func2({0x3f39ae8, 0xc0005984b0})
        /home/runner/work/alist/alist/drivers/189pc/utils.go:547 +0x418
```

Which is caused by extra semaphore release.