### PR TITLE
fix: http2 content-length

### DIFF
--- a/server/handles/fsup.go
+++ b/server/handles/fsup.go
@@ -51,6 +51,9 @@ func FsStream(c *gin.Context) {
 	}
 	dir, name := stdpath.Split(path)
 	sizeStr := c.GetHeader("Content-Length")
+	if sizeStr == "" {
+		sizeStr = "0"
+	}
 	size, err := strconv.ParseInt(sizeStr, 10, 64)
 	if err != nil {
 		common.ErrorResp(c, err, 400)


### PR DESCRIPTION
Close #216

See [rfc7230#section-3.3.2](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2) and [rfc7540#section-8.1.2.6](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.6)
It may not exist, but if it does exist it must be zero at worst.