### PR TITLE
fix(upload): revert #79

### DIFF
--- a/drivers/123_open/upload.go
+++ b/drivers/123_open/upload.go
@@ -82,7 +82,6 @@ func (d *Open123) Upload(ctx context.Context, file model.FileStreamer, createRes
 		retry.Attempts(3),
 		retry.Delay(time.Second),
 		retry.DelayType(retry.BackOffDelay))
-	threadG.SetLimit(3)
 
 	for partIndex := int64(0); partIndex < uploadNums; partIndex++ {
 		if utils.IsCanceled(uploadCtx) {

--- a/drivers/189pc/utils.go
+++ b/drivers/189pc/utils.go
@@ -504,7 +504,6 @@ func (y *Cloud189PC) StreamUpload(ctx context.Context, dstDir model.Obj, file mo
 		retry.Attempts(3),
 		retry.Delay(time.Second),
 		retry.DelayType(retry.BackOffDelay))
-	threadG.SetLimit(3)
 
 	count := int(size / sliceSize)
 	lastPartSize := size % sliceSize

--- a/drivers/baidu_netdisk/driver.go
+++ b/drivers/baidu_netdisk/driver.go
@@ -295,7 +295,6 @@ func (d *BaiduNetdisk) Put(ctx context.Context, dstDir model.Obj, stream model.F
 		retry.Attempts(1),
 		retry.Delay(time.Second),
 		retry.DelayType(retry.BackOffDelay))
-	threadG.SetLimit(3)
 
 	for i, partseq := range precreateResp.BlockList {
 		if utils.IsCanceled(upCtx) {

--- a/drivers/baidu_photo/driver.go
+++ b/drivers/baidu_photo/driver.go
@@ -342,7 +342,6 @@ func (d *BaiduPhoto) Put(ctx context.Context, dstDir model.Obj, stream model.Fil
 			retry.Attempts(3),
 			retry.Delay(time.Second),
 			retry.DelayType(retry.BackOffDelay))
-		threadG.SetLimit(3)
 
 		for i, partseq := range precreateResp.BlockList {
 			if utils.IsCanceled(upCtx) {

--- a/drivers/mopan/driver.go
+++ b/drivers/mopan/driver.go
@@ -298,7 +298,6 @@ func (d *MoPan) Put(ctx context.Context, dstDir model.Obj, stream model.FileStre
 			retry.Attempts(3),
 			retry.Delay(time.Second),
 			retry.DelayType(retry.BackOffDelay))
-		threadG.SetLimit(3)
 
 		// step.3
 		parts, err := d.client.GetAllMultiUploadUrls(initUpdload.UploadFileID, initUpdload.PartInfos)


### PR DESCRIPTION
恢复 #79 的改动，这主要是因为`limit`的初始值可以通过
https://github.com/OpenListTeam/OpenList/blob/fc8b99c8623b830037ae5b774afacea3b9da09b6/drivers/189pc/utils.go#L503
的参数`uploadThread`设置，并不需要手动调用`SetLimit`。

感谢 @ljcbaby 指出这一问题。