### PR TITLE
docs(README_cn): format document links as list to sync with other languages.

### DIFF
--- a/README_cn.md
+++ b/README_cn.md
@@ -93,8 +93,8 @@
 
 ## 文档
 
-<https://docs.oplist.org>
-<https://docs.openlist.team>
+- https://docs.oplist.org
+- https://docs.openlist.team
 
 ## Demo
 


### PR DESCRIPTION
## 更改内容
- 将中文 README 文档中的链接格式从改为列表

## 修改原因
使中文 README 文档中的链接格式与英文和日文的 README 文档保持一致：
1. 英文版本 ([README.md](https://github.com/OpenListTeam/OpenList/blob/main/README.md)) 
2. 日文版本 ([README_ja.md](https://github.com/OpenListTeam/OpenList/blob/main/README_ja.md))