### PR TITLE
fix(cloudreve_v4): change upS3 callback method from POST to GET

### DIFF
--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -469,7 +469,7 @@ func (d *CloudreveV4) upS3(ctx context.Context, file model.FileStreamer, u FileU
 	}
 
 	// 上传成功发送回调请求
-	return d.request(http.MethodPost, "/callback/s3/"+u.SessionID+"/"+u.CallbackSecret, func(req *resty.Request) {
+	return d.request(http.MethodGet, "/callback/s3/"+u.SessionID+"/"+u.CallbackSecret, func(req *resty.Request) {
 		req.SetBody("{}")
 	}, nil)
 }


### PR DESCRIPTION
A 404 error message occurs when uploading an S3 storage policy to Cloudreve V4. Files are deleted immediately after they are uploaded to S3, resulting in failed uploads.

![](https://github.com/user-attachments/assets/6e1cb896-10e7-44f2-8669-e32e78ffba69)

According to the request on the browser side, the callback for the S3 storage policy should be a GET request. And the callback for the OneDrive storage policy is a POST request. 

![](https://github.com/user-attachments/assets/a072f4bd-34f7-47ee-9bf9-8ab0b084a1dc)

![](https://github.com/user-attachments/assets/7cbba9fd-047d-4977-9ca3-a8d844429e61)

So the callback for S3 should be GET, and the callback for OneDrive should be POST. Both are currently POST, so this PR needs to change S3 to GET.
