### PR TITLE
fix(cloudreve_v4): reference error in the refreshToken method

### DIFF
--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -175,8 +175,7 @@ func (d *CloudreveV4) doLogin(needCaptcha bool) error {
 }
 
 func (d *CloudreveV4) refreshToken() error {
-	var token Token
-	if token.RefreshToken == "" {
+	if d.RefreshToken == "" {
 		if d.Username != "" {
 			err := d.login()
 			if err != nil {
@@ -185,6 +184,7 @@ func (d *CloudreveV4) refreshToken() error {
 		}
 		return nil
 	}
+	var token Token
 	err := d.request(http.MethodPost, "/session/token/refresh", func(req *resty.Request) {
 		req.SetBody(base.Json{
 			"refresh_token": d.RefreshToken,


### PR DESCRIPTION
The previous code had a problem that would cause it to skip the refresh token step and make direct requests when the access token is empty or invalid, resulting in a CC attack against the target server.