### PR TITLE
fix(cloudreve_v4): update rename api path to `/file/rename`

### DIFF
--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -173,13 +173,12 @@ func (d *CloudreveV4) Move(ctx context.Context, srcObj, dstDir model.Obj) error 
 }
 
 func (d *CloudreveV4) Rename(ctx context.Context, srcObj model.Obj, newName string) error {
-	return d.request(http.MethodPost, "/file/create", func(req *resty.Request) {
+	return d.request(http.MethodPost, "/file/rename", func(req *resty.Request) {
 		req.SetBody(base.Json{
 			"new_name": newName,
 			"uri":      srcObj.GetPath(),
 		})
 	}, nil)
-
 }
 
 func (d *CloudreveV4) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {


### PR DESCRIPTION
Early Cloudreve V4 used the `/file/create` interface for renaming. It has now been changed to `/file/rename`, causing issues with OpenList renaming. Since overwrite upload requires the use of renaming, it also fails.