### PR TITLE
feat:support multi server use one database

### DIFF
--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -95,6 +95,7 @@ type SFTP struct {
 }
 
 type Config struct {
+	ServerID              string      `json:"server_id" env:"SERVER_ID"`
 	Force                 bool        `json:"force" env:"FORCE"`
 	SiteURL               string      `json:"site_url" env:"SITE_URL"`
 	Cdn                   string      `json:"cdn" env:"CDN"`

--- a/internal/model/storage.go
+++ b/internal/model/storage.go
@@ -6,6 +6,7 @@ import (
 
 type Storage struct {
 	ID              uint      `json:"id" gorm:"primaryKey"`                        // unique key
+	ServerID        string    `json:"server_id"`                                   // server id used to identify the server when multi server use the same database(e.g.MySQL)
 	MountPath       string    `json:"mount_path" gorm:"unique" binding:"required"` // must be standardized
 	Order           int       `json:"order"`                                       // use to sort
 	Driver          string    `json:"driver"`                                      // driver used

--- a/internal/op/storage.go
+++ b/internal/op/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -229,6 +230,24 @@ func UpdateStorage(ctx context.Context, storage model.Storage) error {
 	go callStorageHooks("update", storageDriver)
 	log.Debugf("storage %+v is update", storageDriver)
 	return err
+}
+
+func DeleteMemoryStorage(dbMountPaths []string) {
+	keys := storagesMap.Keys()
+	for _, v := range keys {
+		if slices.Contains(dbMountPaths, v) {
+			continue
+		}
+		storageDriver, ok := storagesMap.Load(v)
+		if !ok {
+			continue
+		}
+		//ignore err
+		storageDriver.Drop(context.Background())
+		//delete
+		storagesMap.Delete(v)
+
+	}
 }
 
 func DeleteStorageById(ctx context.Context, id uint) error {

--- a/pkg/generic_sync/map.go
+++ b/pkg/generic_sync/map.go
@@ -352,6 +352,16 @@ func (m *MapOf[K, V]) Values() []V {
 	return values
 }
 
+// Keys returns a slice of the keys in the map.
+func (m *MapOf[K, V]) Keys() []K {
+	var keys []K
+	m.Range(func(key K, value V) bool {
+		keys = append(keys, key)
+		return true
+	})
+	return keys
+}
+
 func (m *MapOf[K, V]) Count() int {
 	return len(m.dirty)
 }


### PR DESCRIPTION
### 问题描述：
1. 多个服务（A，B，C）使用同一个数据库，都挂载了本地盘，在访问B服务时，仍然会展示A，C的挂载目录，其实是无法访问的。
2. A，B服务共用数据库。A中新增存储F（不是本地驱动），B在**存储管理**页面刷新列表，可以看到A新增的F，但是在**文件列表**刷新，无法看到存储F挂载的目录，必须要重启B的alist服务才可以；同理，如果A，B都有存储F，A中删除存储F，B中文件列表也不会删除F的挂载目录
### 问题1修复思路
1. config.json里面增加一个server_id字段用于标识服务器id，自己配置就可以
2. 代码里面Config结构体增加对应的字段
3. 数据表x_storages增加server_id字段（这个字段只对驱动类型为Local的存储有意义）
4. 编辑驱动类型为Local的存储时，自动添加当前服务id到数据表
5. 获取存储时，过滤掉驱动为Local且server_id与配置的server_id不一致的存储
后续如果有需要用到需要区分服务器的场景，都可以使用server_id字段来区分具体的服务器。

### 问题2修复思路
1. 获取**存储列表**是直接从**数据库**获取的，所以每次获取存储列表都是最新的
2. 获取**文件列表**时，使用的是内存中的storagesMap变量，而内存是和服务器绑定的，所以就导致获取文件列表使用的不是最新的
3. 本来通过存储管理界面的Relaod All按钮可以更新内存中的storagesMap，但是更新出现了问题，修复bug，更新storagesMap时，始终与数据库中的数据保持一致