### PR TITLE
fix(123&123open): repair etag format

### DIFF
--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -195,7 +196,7 @@ func (d *Pan123) Put(ctx context.Context, dstDir model.Obj, file model.FileStrea
 	data := base.Json{
 		"driveId":      0,
 		"duplicate":    2, // 2->覆盖 1->重命名 0->默认
-		"etag":         etag,
+		"etag":         strings.ToLower(etag),
 		"fileName":     file.GetName(),
 		"parentFileId": dstDir.GetID(),
 		"size":         file.GetSize(),

--- a/drivers/123_open/upload.go
+++ b/drivers/123_open/upload.go
@@ -3,6 +3,7 @@ package _123_open
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/OpenListTeam/OpenList/drivers/base"
@@ -21,7 +22,7 @@ func (d *Open123) create(parentFileID int64, filename string, etag string, size 
 		req.SetBody(base.Json{
 			"parentFileId": parentFileID,
 			"filename":     filename,
-			"etag":         etag,
+			"etag":         strings.ToLower(etag),
 			"size":         size,
 			"duplicate":    duplicate,
 			"containDir":   containDir,


### PR DESCRIPTION
修复 `123云盘` 和 `123云盘（Open）` 驱动中文件上传接口所需的 `etag` 格式错误