### PR TITLE
fix:Update build.sh 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ else
   git tag -d beta || true
   # Always true if there's no tag
   version=$(git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0")
-  webVersion=$(curl -fsSL --max-time 2 $githubAuthHeader $githubAuthValue "https://api.github.com/repos/OpenListTeam/OpenList-Frontend/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" '{print $2}' | sed 's/\"//g;s/,//g;s/ //g')
+  webVersion=$(curl -fsSL --max-time 2 $githubAuthHeader "$githubAuthValue" "https://api.github.com/repos/OpenListTeam/OpenList-Frontend/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" '{print $2}' | sed 's/\"//g;s/,//g;s/ //g')
 fi
 
 echo "backend version: $version"


### PR DESCRIPTION
请求头这个字符串变量中会有空格，需要使用双引号包裹变量。由于仓库是公开的，所以目前脚本获取webVersion没有问题，只是消除了一个`curl: (6) Could not resolve host: Bearer`报错