### PR TITLE
chore(README): 真正的上游与源项目

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The `OpenList` is open-source software licensed under the [AGPL-3.0](https://www
 
 ## Contributors
 
-We sincerely thank the author [Xhofe](https://github.com/Xhofe) of the original project [AlistGo/alist](https://github.com/AlistGo/alist) and all other contributors.
+We sincerely thank the author [Xhofe](https://github.com/Xhofe) of the original project [alist-org/alist](https://github.com/alist-org/alist) and all other contributors.
 
 Thanks goes to these wonderful people:
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -113,7 +113,7 @@ N/A（待重建）
 
 ## 贡献者
 
-我们衷心感谢原项目 [AlistGo/alist](https://github.com/AlistGo/alist) 的作者 [Xhofe](https://github.com/Xhofe) 及所有其他贡献者。
+我们衷心感谢原项目 [alist-org/alist](https://github.com/alist-org/alist) 的作者 [Xhofe](https://github.com/Xhofe) 及所有其他贡献者。
 
 感谢这些优秀的人：
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -113,7 +113,7 @@ N/A（再構築中）
 
 ## コントリビューター
 
-オリジナルプロジェクト [AlistGo/alist](https://github.com/AlistGo/alist) の作者 [Xhofe](https://github.com/Xhofe) およびその他すべての貢献者に心より感謝いたします。
+オリジナルプロジェクト [alist-org/alist](https://github.com/alist-org/alist) の作者 [Xhofe](https://github.com/Xhofe) およびその他すべての貢献者に心より感謝いたします。
 
 素晴らしい皆様に感謝します：
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -113,7 +113,7 @@ Stel algemene vragen in [*Discussions*](https://github.com/OpenListTeam/OpenList
 
 ## Bijdragers
 
-Wij danken de auteur [Xhofe](https://github.com/Xhofe) van het originele project [AlistGo/alist](https://github.com/AlistGo/alist) en alle andere bijdragers.
+Wij danken de auteur [Xhofe](https://github.com/Xhofe) van het originele project [alist-org/alist](https://github.com/alist-org/alist) en alle andere bijdragers.
 
 Dank aan deze geweldige mensen:
 


### PR DESCRIPTION
OpenList 源自于 Alist，但但其精神已然不是现在那个 AlistGo 下的 Alist 了。

GitHub 会为已易主的 repo 保留既往的 link。[[docs]](https://docs.github.com/zh/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-user-account-settings/changing-your-github-username#repository-references)

我们应该铭记：

- https://github.com/Xhofe/alist
- https://github.com/alist-org/alist

> 碎碎念 & 私心满满，介意可 Close。