### PR TITLE
fix(offline_download): add more description in log

### DIFF
--- a/internal/bootstrap/offline_download.go
+++ b/internal/bootstrap/offline_download.go
@@ -9,9 +9,9 @@ func InitOfflineDownloadTools() {
 	for k, v := range tool.Tools {
 		res, err := v.Init()
 		if err != nil {
-			utils.Log.Warnf("init tool %s failed: %s", k, err)
+			utils.Log.Warnf("init offline download tool %s failed: %s", k, err)
 		} else {
-			utils.Log.Infof("init tool %s success: %s", k, res)
+			utils.Log.Infof("init offline download tool %s success: %s", k, res)
 		}
 	}
 }

--- a/internal/offline_download/tool/add.go
+++ b/internal/offline_download/tool/add.go
@@ -72,13 +72,13 @@ func AddURL(ctx context.Context, args *AddURLArgs) (task.TaskExtensionInfo, erro
 	// get tool
 	tool, err := Tools.Get(args.Tool)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed get tool")
+		return nil, errors.Wrapf(err, "failed get offline download tool")
 	}
 	// check tool is ready
 	if !tool.IsReady() {
 		// try to init tool
 		if _, err := tool.Init(); err != nil {
-			return nil, errors.Wrapf(err, "failed init tool %s", args.Tool)
+			return nil, errors.Wrapf(err, "failed init offline download tool %s", args.Tool)
 		}
 	}
 


### PR DESCRIPTION
The original log output, such as `INFO[2025-07-08 20:41:59] init tool 115 Cloud success: ok`, is unclear and may easily lead to user misunderstandings. It could be interpreted as the loading of the storage driver. To improve readability and accuracy, a new description has been added: "offline download tool," to clarify that the log indicates the loading of the offline download tool, rather than the initialization of the corresponding storage driver.

原先的日志输出类似 `INFO[2025-07-08 20:41:59] init tool 115 Cloud success: ok` 表意不明，容易引起用户误解，可能被理解为加载存储驱动。为提升可读性与准确性，现新增描述 `offline download tool` 以明确该日志表示正在加载离线下载工具，而非初始化对应的存储驱动。