### PR TITLE
feat(quark_uc_tv): add streaming link api

### DIFF
--- a/drivers/quark_uc_tv/meta.go
+++ b/drivers/quark_uc_tv/meta.go
@@ -14,6 +14,8 @@ type Addition struct {
 	DeviceID string `json:"device_id"  required:"false" default:""`
 	// 登陆所用的数据 无需手动填写
 	QueryToken string `json:"query_token" required:"false" default:"" help:"don't edit'"`
+	// 视频文件链接获取方式 download(可获取源视频) or streaming(获取转码后的视频)
+	VideoLinkMethod string `json:"link_method" required:"true" type:"select" options:"download,streaming" default:"download"`
 }
 
 type Conf struct {
@@ -38,8 +40,8 @@ func init() {
 				api:      "https://open-api-drive.quark.cn",
 				clientID: "d3194e61504e493eb6222857bccfed94",
 				signKey:  "kw2dvtd7p4t3pjl2d9ed9yc8yej8kw2d",
-				appVer:   "1.5.6",
-				channel:  "CP",
+				appVer:   "1.8.2.2",
+				channel:  "GENERAL",
 				codeApi:  "http://api.extscreen.com/quarkdrive",
 			},
 		}
@@ -56,7 +58,7 @@ func init() {
 				api:      "https://open-api-drive.uc.cn",
 				clientID: "5acf882d27b74502b7040b0c65519aa7",
 				signKey:  "l3srvtd7p42l0d0x1u8d7yc8ye9kki4d",
-				appVer:   "1.6.5",
+				appVer:   "1.7.2.2",
 				channel:  "UCTVOFFICIALWEB",
 				codeApi:  "http://api.extscreen.com/ucdrive",
 			},

--- a/drivers/quark_uc_tv/types.go
+++ b/drivers/quark_uc_tv/types.go
@@ -92,7 +92,32 @@ type FilesData struct {
 	} `json:"data"`
 }
 
-type FileLink struct {
+type StreamingFileLink struct {
+	CommonRsp
+	Data struct {
+		DefaultResolution string `json:"default_resolution"`
+		LastPlayTime      int    `json:"last_play_time"`
+		VideoInfo         []struct {
+			Resolution  string  `json:"resolution"`
+			Accessable  int     `json:"accessable"`
+			TransStatus string  `json:"trans_status"`
+			Duration    int     `json:"duration,omitempty"`
+			Size        int64   `json:"size,omitempty"`
+			Format      string  `json:"format,omitempty"`
+			Width       int     `json:"width,omitempty"`
+			Height      int     `json:"height,omitempty"`
+			URL         string  `json:"url,omitempty"`
+			Bitrate     float64 `json:"bitrate,omitempty"`
+			DolbyVision struct {
+				Profile int `json:"profile"`
+				Level   int `json:"level"`
+			} `json:"dolby_vision,omitempty"`
+		} `json:"video_info"`
+		AudioInfo []interface{} `json:"audio_info"`
+	} `json:"data"`
+}
+
+type DownloadFileLink struct {
 	CommonRsp
 	Data struct {
 		Fid         string `json:"fid"`

--- a/drivers/quark_uc_tv/util.go
+++ b/drivers/quark_uc_tv/util.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"net/http"
 	"strconv"
 	"time"
@@ -209,4 +210,48 @@ func (d *QuarkUCTV) generateReqSign(method string, pathname string, key string) 
 	xPanTokenHex := hex.EncodeToString(xPanToken[:])
 
 	return timestamp, xPanTokenHex, reqIDHex
+}
+
+func (d *QuarkUCTV) getTranscodingLink(ctx context.Context, file model.Obj) (*model.Link, error) {
+	var fileLink StreamingFileLink
+	_, err := d.request(ctx, "/file", "GET", func(req *resty.Request) {
+		req.SetQueryParams(map[string]string{
+			"method":     "streaming",
+			"group_by":   "source",
+			"fid":        file.GetID(),
+			"resolution": "low,normal,high,super,2k,4k",
+			"support":    "dolby_vision",
+		})
+	}, &fileLink)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.Link{
+		URL:         fileLink.Data.VideoInfo[0].URL,
+		Concurrency: 3,
+		PartSize:    10 * utils.MB,
+	}, nil
+}
+
+func (d *QuarkUCTV) getDownloadLink(ctx context.Context, file model.Obj) (*model.Link, error) {
+	var fileLink DownloadFileLink
+	_, err := d.request(ctx, "/file", "GET", func(req *resty.Request) {
+		req.SetQueryParams(map[string]string{
+			"method":     "download",
+			"group_by":   "source",
+			"fid":        file.GetID(),
+			"resolution": "low,normal,high,super,2k,4k",
+			"support":    "dolby_vision",
+		})
+	}, &fileLink)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.Link{
+		URL:         fileLink.Data.DownloadURL,
+		Concurrency: 3,
+		PartSize:    10 * utils.MB,
+	}, nil
 }


### PR DESCRIPTION
为 `夸克TV` 和 `UCTV` 驱动添加了新的选择项，可选择使用`download`或者`streaming`方式下载文件---**只对视频文件生效**

说明：
- `download` 方式**可获取源视频文件**，但**有下列限速规则**
  - **当且仅当 `400MB * 线程数 ＞ 文件大小` 时，不限速**
  - 播放操作基本都是单线程，因此可认为播放的视频文件大小＞400MB时，**限速**
- `streaming` 方式**仅可获取转码后的视频文件**，无明显限速规则