### PR TITLE
fix(security): driver uncontrolled data used in path expression injection

### DIFF
--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -251,6 +251,10 @@ func (d *Local) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (
 }
 
 func (d *Local) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {
+	// Validate dirName to ensure it does not contain invalid characters
+	if strings.Contains(dirName, "/") || strings.Contains(dirName, "\\") || strings.Contains(dirName, "..") {
+		return fmt.Errorf("invalid directory name: %s", dirName)
+	}
 	fullPath := filepath.Join(parentDir.GetPath(), dirName)
 	err := os.MkdirAll(fullPath, os.FileMode(d.mkdirPerm))
 	if err != nil {


### PR DESCRIPTION
https://github.com/OpenListTeam/OpenList/blob/0c461991f939a2d2718aeb102cee20eada902344/drivers/local/driver.go#L255-L255

Accessing files using paths constructed from user-controlled data can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files. paths that are naively constructed from data controlled by a user may be absolute paths, or may contain unexpected special characters such as "..". Such a path could point anywhere on the file system.




fix the issue, we need to validate the `dirName` parameter to ensure it does not contain any path traversal sequences (`../`, `..`, or path separators like `/` or `\`). Since `dirName` is expected to be a single directory name, we can enforce this by rejecting any input that contains these invalid characters.
- Adding a validation step for `dirName` before constructing the `fullPath`.
- Rejecting the input with an appropriate error if it contains invalid characters.

The changes will be made in the `MakeDir` function in `drivers/local/driver.go`.