### PR TITLE
fix(cloudreve_v4): remove deprecated authn check for login

### DIFF
--- a/drivers/cloudreve_v4/types.go
+++ b/drivers/cloudreve_v4/types.go
@@ -47,7 +47,13 @@ type BasicConfigResp struct {
 
 type SiteLoginConfigResp struct {
 	LoginCaptcha bool `json:"login_captcha"`
-	Authn        bool `json:"authn"`
+	// RegCaptcha bool `json:"reg_captcha"`
+	// ForgetCaptcha bool `json:"forget_captcha"`
+	// RegisterEnabled bool `json:"register_enabled"`
+	// TosURL string `json:"tos_url"`
+	// PrivacyPolicyURL string `json:"privacy_policy_url"`
+	// SsoDisplayName string `json:"sso_display_name"`
+	// OidcDisplayName string `json:"oidc_display_name"`
 }
 
 type PrepareLoginResp struct {

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -95,9 +95,9 @@ func (d *CloudreveV4) login() error {
 	if err != nil {
 		return err
 	}
-	if !siteConfig.Authn {
-		return errors.New("authn not support")
-	}
+	// if !siteConfig.Authn {
+	// 	return errors.New("authn not support")
+	// }
 	var prepareLogin PrepareLoginResp
 	err = d.request(http.MethodGet, "/session/prepare?email="+d.Addition.Username, nil, &prepareLogin)
 	if err != nil {

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -95,9 +95,6 @@ func (d *CloudreveV4) login() error {
 	if err != nil {
 		return err
 	}
-	// if !siteConfig.Authn {
-	// 	return errors.New("authn not support")
-	// }
 	var prepareLogin PrepareLoginResp
 	err = d.request(http.MethodGet, "/session/prepare?email="+d.Addition.Username, nil, &prepareLogin)
 	if err != nil {


### PR DESCRIPTION
Cloudreve (可能是 Pro?）更新了站点登录配置的返回，导致无法判断是否允许密码登录

Close: #622