### PR TITLE
perf(cloudreve): use `retry-go` for `net/http` uploads

### DIFF
--- a/drivers/cloudreve/util.go
+++ b/drivers/cloudreve/util.go
@@ -20,6 +20,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/internal/setting"
 	"github.com/OpenListTeam/OpenList/v4/pkg/cookie"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
+	"github.com/avast/retry-go"
 	"github.com/go-resty/resty/v2"
 	jsoniter "github.com/json-iterator/go"
 )
@@ -240,8 +241,6 @@ func (d *Cloudreve) upRemote(ctx context.Context, stream model.FileStreamer, u U
 	var finish int64 = 0
 	var chunk int = 0
 	DEFAULT := int64(u.ChunkSize)
-	retryCount := 0
-	maxRetries := 3
 	for finish < stream.GetSize() {
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
@@ -255,53 +254,48 @@ func (d *Cloudreve) upRemote(ctx context.Context, stream model.FileStreamer, u U
 		if err != nil {
 			return err
 		}
-		req, err := http.NewRequest("POST", uploadUrl+"?chunk="+strconv.Itoa(chunk),
-			driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+		err = retry.Do(
+			func() error {
+				req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadUrl+"?chunk="+strconv.Itoa(chunk),
+					driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+				if err != nil {
+					return err
+				}
+				req.ContentLength = byteSize
+				req.Header.Set("Authorization", fmt.Sprint(credential))
+				req.Header.Set("User-Agent", d.getUA())
+				res, err := base.HttpClient.Do(req)
+				if err != nil {
+					return err
+				}
+				defer res.Body.Close()
+				if res.StatusCode != 200 {
+					return fmt.Errorf("server error: %d", res.StatusCode)
+				}
+				body, err := io.ReadAll(res.Body)
+				if err != nil {
+					return err
+				}
+				var up Resp
+				err = json.Unmarshal(body, &up)
+				if err != nil {
+					return err
+				}
+				if up.Code != 0 {
+					return errors.New(up.Msg)
+				}
+				return nil
+			},
+			retry.Attempts(3),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Delay(time.Second),
+		)
 		if err != nil {
 			return err
 		}
-		req = req.WithContext(ctx)
-		req.ContentLength = byteSize
-		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
-		req.Header.Set("Authorization", fmt.Sprint(credential))
-		req.Header.Set("User-Agent", d.getUA())
-		err = func() error {
-			res, err := base.HttpClient.Do(req)
-			if err != nil {
-				return err
-			}
-			defer res.Body.Close()
-			if res.StatusCode != 200 {
-				return errors.New(res.Status)
-			}
-			body, err := io.ReadAll(res.Body)
-			if err != nil {
-				return err
-			}
-			var up Resp
-			err = json.Unmarshal(body, &up)
-			if err != nil {
-				return err
-			}
-			if up.Code != 0 {
-				return errors.New(up.Msg)
-			}
-			return nil
-		}()
-		if err == nil {
-			retryCount = 0
-			finish += byteSize
-			up(float64(finish) * 100 / float64(stream.GetSize()))
-			chunk++
-		} else {
-			retryCount++
-			if retryCount > maxRetries {
-				return fmt.Errorf("upload failed after %d retries due to server errors, error: %s", maxRetries, err)
-			}
-			backoff := time.Duration(1<<retryCount) * time.Second
-			utils.Log.Warnf("[Cloudreve-Remote] server errors while uploading, retrying after %v...", backoff)
-			time.Sleep(backoff)
-		}
+		finish += byteSize
+		up(float64(finish) * 100 / float64(stream.GetSize()))
+		chunk++
 	}
 	return nil
 }
@@ -310,8 +304,6 @@ func (d *Cloudreve) upOneDrive(ctx context.Context, stream model.FileStreamer, u
 	uploadUrl := u.UploadURLs[0]
 	var finish int64 = 0
 	DEFAULT := int64(u.ChunkSize)
-	retryCount := 0
-	maxRetries := 3
 	for finish < stream.GetSize() {
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
@@ -325,40 +317,40 @@ func (d *Cloudreve) upOneDrive(ctx context.Context, stream model.FileStreamer, u
 		if err != nil {
 			return err
 		}
-		req, err := http.NewRequest("PUT", uploadUrl, driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+		err = retry.Do(
+			func() error {
+				req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadUrl,
+					driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+				if err != nil {
+					return err
+				}
+				req.ContentLength = byteSize
+				req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, stream.GetSize()))
+				req.Header.Set("User-Agent", d.getUA())
+				res, err := base.HttpClient.Do(req)
+				if err != nil {
+					return err
+				}
+				defer res.Body.Close()
+				// https://learn.microsoft.com/zh-cn/onedrive/developer/rest-api/api/driveitem_createuploadsession
+				switch {
+				case res.StatusCode >= 500 && res.StatusCode <= 504:
+					return fmt.Errorf("server error: %d", res.StatusCode)
+				case res.StatusCode != 201 && res.StatusCode != 202 && res.StatusCode != 200:
+					data, _ := io.ReadAll(res.Body)
+					return errors.New(string(data))
+				default:
+					return nil
+				}
+			}, retry.Attempts(3),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Delay(time.Second),
+		)
 		if err != nil {
 			return err
 		}
-		req = req.WithContext(ctx)
-		req.ContentLength = byteSize
-		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
-		req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, stream.GetSize()))
-		req.Header.Set("User-Agent", d.getUA())
-		res, err := base.HttpClient.Do(req)
-		if err != nil {
-			return err
-		}
-		// https://learn.microsoft.com/zh-cn/onedrive/developer/rest-api/api/driveitem_createuploadsession
-		switch {
-		case res.StatusCode >= 500 && res.StatusCode <= 504:
-			retryCount++
-			if retryCount > maxRetries {
-				res.Body.Close()
-				return fmt.Errorf("upload failed after %d retries due to server errors, error %d", maxRetries, res.StatusCode)
-			}
-			backoff := time.Duration(1<<retryCount) * time.Second
-			utils.Log.Warnf("[Cloudreve-OneDrive] server errors %d while uploading, retrying after %v...", res.StatusCode, backoff)
-			time.Sleep(backoff)
-		case res.StatusCode != 201 && res.StatusCode != 202 && res.StatusCode != 200:
-			data, _ := io.ReadAll(res.Body)
-			res.Body.Close()
-			return errors.New(string(data))
-		default:
-			res.Body.Close()
-			retryCount = 0
-			finish += byteSize
-			up(float64(finish) * 100 / float64(stream.GetSize()))
-		}
+		finish += byteSize
+		up(float64(finish) * 100 / float64(stream.GetSize()))
 	}
 	// 上传成功发送回调请求
 	return d.request(http.MethodPost, "/callback/onedrive/finish/"+u.SessionID, func(req *resty.Request) {
@@ -371,8 +363,6 @@ func (d *Cloudreve) upS3(ctx context.Context, stream model.FileStreamer, u Uploa
 	var chunk int = 0
 	var etags []string
 	DEFAULT := int64(u.ChunkSize)
-	retryCount := 0
-	maxRetries := 3
 	for finish < stream.GetSize() {
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
@@ -386,39 +376,41 @@ func (d *Cloudreve) upS3(ctx context.Context, stream model.FileStreamer, u Uploa
 		if err != nil {
 			return err
 		}
-		req, err := http.NewRequest("PUT", u.UploadURLs[chunk],
-			driver.NewLimitedUploadStream(ctx, bytes.NewBuffer(byteData)))
+		err = retry.Do(
+			func() error {
+				req, err := http.NewRequestWithContext(ctx, http.MethodPut, u.UploadURLs[chunk],
+					driver.NewLimitedUploadStream(ctx, bytes.NewBuffer(byteData)))
+				if err != nil {
+					return err
+				}
+				req.ContentLength = byteSize
+				req.Header.Set("User-Agent", d.getUA())
+				res, err := base.HttpClient.Do(req)
+				if err != nil {
+					return err
+				}
+				etag := res.Header.Get("ETag")
+				res.Body.Close()
+				switch {
+				case res.StatusCode != 200:
+					return fmt.Errorf("server error: %d", res.StatusCode)
+				case etag == "":
+					return errors.New("failed to get ETag from header")
+				default:
+					etags = append(etags, etag)
+					return nil
+				}
+			}, retry.Attempts(3),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Delay(time.Second),
+		)
 		if err != nil {
 			return err
 		}
-		req = req.WithContext(ctx)
-		req.ContentLength = byteSize
-		res, err := base.HttpClient.Do(req)
-		if err != nil {
-			return err
-		}
-		etag := res.Header.Get("ETag")
-		res.Body.Close()
-		switch {
-		case res.StatusCode != 200:
-			retryCount++
-			if retryCount > maxRetries {
-				return fmt.Errorf("upload failed after %d retries due to server errors, error %d", maxRetries, res.StatusCode)
-			}
-			backoff := time.Duration(1<<retryCount) * time.Second
-			utils.Log.Warnf("[Cloudreve-S3] server errors %d while uploading, retrying after %v...", res.StatusCode, backoff)
-			time.Sleep(backoff)
-		case etag == "":
-			return errors.New("failed to get ETag from header")
-		default:
-			retryCount = 0
-			etags = append(etags, etag)
-			finish += byteSize
-			up(float64(finish) * 100 / float64(stream.GetSize()))
-			chunk++
-		}
+		finish += byteSize
+		up(float64(finish) * 100 / float64(stream.GetSize()))
+		chunk++
 	}
-
 	// s3LikeFinishUpload
 	// https://github.com/cloudreve/frontend/blob/b485bf297974cbe4834d2e8e744ae7b7e5b2ad39/src/component/Uploader/core/api/index.ts#L204-L252
 	bodyBuilder := &strings.Builder{}
@@ -431,8 +423,8 @@ func (d *Cloudreve) upS3(ctx context.Context, stream model.FileStreamer, u Uploa
 		))
 	}
 	bodyBuilder.WriteString("</CompleteMultipartUpload>")
-	req, err := http.NewRequest(
-		"POST",
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodPost,
 		u.CompleteURL,
 		strings.NewReader(bodyBuilder.String()),
 	)

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -20,6 +20,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
 	"github.com/OpenListTeam/OpenList/v4/internal/setting"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
+	"github.com/avast/retry-go"
 	"github.com/go-resty/resty/v2"
 	jsoniter "github.com/json-iterator/go"
 )
@@ -258,8 +259,6 @@ func (d *CloudreveV4) upRemote(ctx context.Context, file model.FileStreamer, u F
 	var finish int64 = 0
 	var chunk int = 0
 	DEFAULT := int64(u.ChunkSize)
-	retryCount := 0
-	maxRetries := 3
 	for finish < file.GetSize() {
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
@@ -273,53 +272,48 @@ func (d *CloudreveV4) upRemote(ctx context.Context, file model.FileStreamer, u F
 		if err != nil {
 			return err
 		}
-		req, err := http.NewRequest("POST", uploadUrl+"?chunk="+strconv.Itoa(chunk),
-			driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+		err = retry.Do(
+			func() error {
+				req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadUrl+"?chunk="+strconv.Itoa(chunk),
+					driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+				if err != nil {
+					return err
+				}
+
+				req.ContentLength = byteSize
+				req.Header.Set("Authorization", fmt.Sprint(credential))
+				req.Header.Set("User-Agent", d.getUA())
+				res, err := base.HttpClient.Do(req)
+				if err != nil {
+					return err
+				}
+				defer res.Body.Close()
+				if res.StatusCode != 200 {
+					return fmt.Errorf("server error: %d", res.StatusCode)
+				}
+				body, err := io.ReadAll(res.Body)
+				if err != nil {
+					return err
+				}
+				var up Resp
+				err = json.Unmarshal(body, &up)
+				if err != nil {
+					return err
+				}
+				if up.Code != 0 {
+					return errors.New(up.Msg)
+				}
+				return nil
+			}, retry.Attempts(3),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Delay(time.Second),
+		)
 		if err != nil {
 			return err
 		}
-		req = req.WithContext(ctx)
-		req.ContentLength = byteSize
-		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
-		req.Header.Set("Authorization", fmt.Sprint(credential))
-		req.Header.Set("User-Agent", d.getUA())
-		err = func() error {
-			res, err := base.HttpClient.Do(req)
-			if err != nil {
-				return err
-			}
-			defer res.Body.Close()
-			if res.StatusCode != 200 {
-				return errors.New(res.Status)
-			}
-			body, err := io.ReadAll(res.Body)
-			if err != nil {
-				return err
-			}
-			var up Resp
-			err = json.Unmarshal(body, &up)
-			if err != nil {
-				return err
-			}
-			if up.Code != 0 {
-				return errors.New(up.Msg)
-			}
-			return nil
-		}()
-		if err == nil {
-			retryCount = 0
-			finish += byteSize
-			up(float64(finish) * 100 / float64(file.GetSize()))
-			chunk++
-		} else {
-			retryCount++
-			if retryCount > maxRetries {
-				return fmt.Errorf("upload failed after %d retries due to server errors, error: %s", maxRetries, err)
-			}
-			backoff := time.Duration(1<<retryCount) * time.Second
-			utils.Log.Warnf("[Cloudreve-Remote] server errors while uploading, retrying after %v...", backoff)
-			time.Sleep(backoff)
-		}
+		finish += byteSize
+		up(float64(finish) * 100 / float64(file.GetSize()))
+		chunk++
 	}
 	return nil
 }
@@ -328,8 +322,6 @@ func (d *CloudreveV4) upOneDrive(ctx context.Context, file model.FileStreamer, u
 	uploadUrl := u.UploadUrls[0]
 	var finish int64 = 0
 	DEFAULT := int64(u.ChunkSize)
-	retryCount := 0
-	maxRetries := 3
 	for finish < file.GetSize() {
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
@@ -343,40 +335,41 @@ func (d *CloudreveV4) upOneDrive(ctx context.Context, file model.FileStreamer, u
 		if err != nil {
 			return err
 		}
-		req, err := http.NewRequest(http.MethodPut, uploadUrl, driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+		err = retry.Do(
+			func() error {
+				req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadUrl,
+					driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+				if err != nil {
+					return err
+				}
+
+				req.ContentLength = byteSize
+				req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, file.GetSize()))
+				req.Header.Set("User-Agent", d.getUA())
+				res, err := base.HttpClient.Do(req)
+				if err != nil {
+					return err
+				}
+				defer res.Body.Close()
+				// https://learn.microsoft.com/zh-cn/onedrive/developer/rest-api/api/driveitem_createuploadsession
+				switch {
+				case res.StatusCode >= 500 && res.StatusCode <= 504:
+					return fmt.Errorf("server error: %d", res.StatusCode)
+				case res.StatusCode != 201 && res.StatusCode != 202 && res.StatusCode != 200:
+					data, _ := io.ReadAll(res.Body)
+					return errors.New(string(data))
+				default:
+					return nil
+				}
+			}, retry.Attempts(3),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Delay(time.Second),
+		)
 		if err != nil {
 			return err
 		}
-		req = req.WithContext(ctx)
-		req.ContentLength = byteSize
-		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
-		req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, file.GetSize()))
-		req.Header.Set("User-Agent", d.getUA())
-		res, err := base.HttpClient.Do(req)
-		if err != nil {
-			return err
-		}
-		// https://learn.microsoft.com/zh-cn/onedrive/developer/rest-api/api/driveitem_createuploadsession
-		switch {
-		case res.StatusCode >= 500 && res.StatusCode <= 504:
-			retryCount++
-			if retryCount > maxRetries {
-				res.Body.Close()
-				return fmt.Errorf("upload failed after %d retries due to server errors, error %d", maxRetries, res.StatusCode)
-			}
-			backoff := time.Duration(1<<retryCount) * time.Second
-			utils.Log.Warnf("[CloudreveV4-OneDrive] server errors %d while uploading, retrying after %v...", res.StatusCode, backoff)
-			time.Sleep(backoff)
-		case res.StatusCode != 201 && res.StatusCode != 202 && res.StatusCode != 200:
-			data, _ := io.ReadAll(res.Body)
-			res.Body.Close()
-			return errors.New(string(data))
-		default:
-			res.Body.Close()
-			retryCount = 0
-			finish += byteSize
-			up(float64(finish) * 100 / float64(file.GetSize()))
-		}
+		finish += byteSize
+		up(float64(finish) * 100 / float64(file.GetSize()))
 	}
 	// 上传成功发送回调请求
 	return d.request(http.MethodPost, "/callback/onedrive/"+u.SessionID+"/"+u.CallbackSecret, func(req *resty.Request) {
@@ -389,8 +382,6 @@ func (d *CloudreveV4) upS3(ctx context.Context, file model.FileStreamer, u FileU
 	var chunk int = 0
 	var etags []string
 	DEFAULT := int64(u.ChunkSize)
-	retryCount := 0
-	maxRetries := 3
 	for finish < file.GetSize() {
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
@@ -404,37 +395,41 @@ func (d *CloudreveV4) upS3(ctx context.Context, file model.FileStreamer, u FileU
 		if err != nil {
 			return err
 		}
-		req, err := http.NewRequest(http.MethodPut, u.UploadUrls[chunk],
-			driver.NewLimitedUploadStream(ctx, bytes.NewBuffer(byteData)))
+		err = retry.Do(
+			func() error {
+				req, err := http.NewRequestWithContext(ctx, http.MethodPut, u.UploadUrls[chunk],
+					driver.NewLimitedUploadStream(ctx, bytes.NewBuffer(byteData)))
+				if err != nil {
+					return err
+				}
+				req.ContentLength = byteSize
+				req.Header.Set("User-Agent", d.getUA())
+				res, err := base.HttpClient.Do(req)
+				if err != nil {
+					return err
+				}
+				etag := res.Header.Get("ETag")
+				res.Body.Close()
+				switch {
+				case res.StatusCode != 200:
+					return fmt.Errorf("server error: %d", res.StatusCode)
+				case etag == "":
+					return errors.New("failed to get ETag from header")
+				default:
+					etags = append(etags, etag)
+					return nil
+				}
+			},
+			retry.Attempts(3),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Delay(time.Second),
+		)
 		if err != nil {
 			return err
 		}
-		req = req.WithContext(ctx)
-		req.ContentLength = byteSize
-		res, err := base.HttpClient.Do(req)
-		if err != nil {
-			return err
-		}
-		etag := res.Header.Get("ETag")
-		res.Body.Close()
-		switch {
-		case res.StatusCode != 200:
-			retryCount++
-			if retryCount > maxRetries {
-				return fmt.Errorf("upload failed after %d retries due to server errors", maxRetries)
-			}
-			backoff := time.Duration(1<<retryCount) * time.Second
-			utils.Log.Warnf("server error %d, retrying after %v...", res.StatusCode, backoff)
-			time.Sleep(backoff)
-		case etag == "":
-			return errors.New("failed to get ETag from header")
-		default:
-			retryCount = 0
-			etags = append(etags, etag)
-			finish += byteSize
-			up(float64(finish) * 100 / float64(file.GetSize()))
-			chunk++
-		}
+		finish += byteSize
+		up(float64(finish) * 100 / float64(file.GetSize()))
+		chunk++
 	}
 
 	// s3LikeFinishUpload
@@ -448,8 +443,8 @@ func (d *CloudreveV4) upS3(ctx context.Context, file model.FileStreamer, u FileU
 		))
 	}
 	bodyBuilder.WriteString("</CompleteMultipartUpload>")
-	req, err := http.NewRequest(
-		"POST",
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodPost,
 		u.CompleteURL,
 		strings.NewReader(bodyBuilder.String()),
 	)

--- a/drivers/onedrive/util.go
+++ b/drivers/onedrive/util.go
@@ -16,6 +16,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
+	"github.com/avast/retry-go"
 	"github.com/go-resty/resty/v2"
 	jsoniter "github.com/json-iterator/go"
 )
@@ -230,7 +231,7 @@ func toAPIMetadata(stream model.FileStreamer) Metadata {
 
 func (d *Onedrive) upBig(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) error {
 	url := d.GetMetaUrl(false, stdpath.Join(dstDir.GetPath(), stream.GetName())) + "/createUploadSession"
-	metadata := map[string]interface{}{"item": toAPIMetadata(stream)}
+	metadata := map[string]any{"item": toAPIMetadata(stream)}
 	res, err := d.Request(url, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(metadata).SetContext(ctx)
 	}, nil)
@@ -240,8 +241,6 @@ func (d *Onedrive) upBig(ctx context.Context, dstDir model.Obj, stream model.Fil
 	uploadUrl := jsoniter.Get(res, "uploadUrl").ToString()
 	var finish int64 = 0
 	DEFAULT := d.ChunkSize * 1024 * 1024
-	retryCount := 0
-	maxRetries := 3
 	for finish < stream.GetSize() {
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
@@ -255,39 +254,40 @@ func (d *Onedrive) upBig(ctx context.Context, dstDir model.Obj, stream model.Fil
 		if err != nil {
 			return err
 		}
-		req, err := http.NewRequest("PUT", uploadUrl, driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+		err = retry.Do(
+			func() error {
+				req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadUrl,
+					driver.NewLimitedUploadStream(ctx, bytes.NewReader(byteData)))
+				if err != nil {
+					return err
+				}
+				req.ContentLength = byteSize
+				req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, stream.GetSize()))
+				res, err := base.HttpClient.Do(req)
+				if err != nil {
+					return err
+				}
+				defer res.Body.Close()
+				// https://learn.microsoft.com/zh-cn/onedrive/developer/rest-api/api/driveitem_createuploadsession
+				switch {
+				case res.StatusCode >= 500 && res.StatusCode <= 504:
+					return fmt.Errorf("server error: %d", res.StatusCode)
+				case res.StatusCode != 201 && res.StatusCode != 202 && res.StatusCode != 200:
+					data, _ := io.ReadAll(res.Body)
+					return errors.New(string(data))
+				default:
+					return nil
+				}
+			},
+			retry.Attempts(3),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Delay(time.Second),
+		)
 		if err != nil {
 			return err
 		}
-		req = req.WithContext(ctx)
-		req.ContentLength = byteSize
-		// req.Header.Set("Content-Length", strconv.Itoa(int(byteSize)))
-		req.Header.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", finish, finish+byteSize-1, stream.GetSize()))
-		res, err := base.HttpClient.Do(req)
-		if err != nil {
-			return err
-		}
-		// https://learn.microsoft.com/zh-cn/onedrive/developer/rest-api/api/driveitem_createuploadsession
-		switch {
-		case res.StatusCode >= 500 && res.StatusCode <= 504:
-			retryCount++
-			if retryCount > maxRetries {
-				res.Body.Close()
-				return fmt.Errorf("upload failed after %d retries due to server errors, error %d", maxRetries, res.StatusCode)
-			}
-			backoff := time.Duration(1<<retryCount) * time.Second
-			utils.Log.Warnf("[Onedrive] server errors %d while uploading, retrying after %v...", res.StatusCode, backoff)
-			time.Sleep(backoff)
-		case res.StatusCode != 201 && res.StatusCode != 202 && res.StatusCode != 200:
-			data, _ := io.ReadAll(res.Body)
-			res.Body.Close()
-			return errors.New(string(data))
-		default:
-			res.Body.Close()
-			retryCount = 0
-			finish += byteSize
-			up(float64(finish) * 100 / float64(stream.GetSize()))
-		}
+		finish += byteSize
+		up(float64(finish) * 100 / float64(stream.GetSize()))
 	}
 	return nil
 }

--- a/drivers/onedrive_app/util.go
+++ b/drivers/onedrive_app/util.go
@@ -41,7 +41,7 @@ var onedriveHostMap = map[string]Host{
 }
 
 func (d *OnedriveAPP) GetMetaUrl(auth bool, path string) string {
-	host, _ := onedriveHostMap[d.Region]
+	host := onedriveHostMap[d.Region]
 	path = utils.EncodePath(path, true)
 	if auth {
 		return host.Oauth


### PR DESCRIPTION
Improved retry handling for `net/http`. Should be better than my previous implementation.

Migrate from https://github.com/OpenListTeam/OpenList/pull/554 .
