### PR TITLE
chore(ci): update cgo-actions to 1.2.1 & add patch version define for go

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - target: "!(*musl*|*windows-arm64*|*android*|*freebsd*)" # xgo
+          - target: "!(*musl*|*windows-arm64*|*android*|*freebsd*)" # xgo and loongarch
             hash: "md5"
           - target: "linux-!(arm*)-musl*" #musl-not-arm
             hash: "md5-linux-musl"
@@ -85,7 +85,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.24.3"
 
       - name: Setup web
         run: bash build.sh dev web
@@ -93,10 +93,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        uses: OpenListTeam/cgo-actions@v1.1.2
+        uses: OpenListTeam/cgo-actions@v1.2.1
         with:
           targets: ${{ matrix.target }}
           musl-target-format: $os-$musl-$arch
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           out-dir: build
           output: openlist-$target$ext
           musl-base-url: "https://github.com/OpenListTeam/musl-compilers/releases/latest/download/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.24.3"
 
       - name: Setup web
         run: bash build.sh dev web
@@ -41,10 +41,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        uses: OpenListTeam/cgo-actions@v1.1.2
+        uses: OpenListTeam/cgo-actions@v1.2.1
         with:
           targets: ${{ matrix.target }}
           musl-target-format: $os-$musl-$arch
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           out-dir: build
           x-flags: |
             github.com/OpenListTeam/OpenList/v4/internal/conf.BuiltAt=$built_at


### PR DESCRIPTION
# 改动内容

1. 升级 `cgo-actions` 到 1.2.1，详细更新见[此页面](https://github.com/OpenListTeam/cgo-actions/releases/tag/v1.2.1)，主要改动如下
  a. 完善了龙架构（LoongArch64）的支持， 新增了目标 `linux-loong64` 和 `linux-loong64-abi1.0`
  b. 将工具链下载统一替换为 `curl -fsSL --retry 3`, 并添加 GitHub Token 认证以避免 rate limit
2. 将 build 的 go 版本细化为 `1.24.3`，因为龙芯暂未发布 `1.24.3` 以上的适用于 abi1.0 的 go。