### PR TITLE
修改保活策略为 runit，增加 aria2 日志支持

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /opt/openlist/
 
 RUN apk update && \
     apk upgrade --no-cache && \
-    apk add --no-cache bash ca-certificates su-exec tzdata; \
+    apk add --no-cache bash ca-certificates su-exec tzdata runit; \
     [ "$INSTALL_FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
     [ "$INSTALL_ARIA2" = "true" ] && apk add --no-cache curl aria2 && \
         mkdir -p /opt/aria2/.aria2 && \
@@ -28,9 +28,24 @@ RUN apk update && \
         sed -i 's|/root/.aria2|/opt/aria2/.aria2|g' /opt/aria2/.aria2/script.conf && \
         sed -i 's|/root|/opt/aria2|g' /opt/aria2/.aria2/aria2.conf && \
         sed -i 's|/root|/opt/aria2|g' /opt/aria2/.aria2/script.conf && \
+        mkdir -p /opt/service/aria2/log && \
+        echo '#!/bin/sh' > /opt/service/aria2/run && \
+        echo 'exec 2>&1' >> /opt/service/aria2/run && \
+        echo 'exec aria2c --enable-rpc --rpc-allow-origin-all --conf-path=/opt/aria2/.aria2/aria2.conf' >> /opt/service/aria2/run && \
+        echo '#!/bin/sh' > /opt/service/aria2/log/run && \
+        echo 'mkdir -p /opt/openlist/data/log/aria2 2>/dev/null' >> /opt/service/aria2/log/run && \
+        echo 'exec svlogd /opt/openlist/data/log/aria2' >> /opt/service/aria2/log/run && \
+        chmod +x /opt/service/aria2/run /opt/service/aria2/log/run && \
         touch /opt/aria2/.aria2/aria2.session && \
         /opt/aria2/.aria2/tracker.sh ; \
     rm -rf /var/cache/apk/*
+    
+RUN mkdir -p /opt/service/openlist && \
+    echo '#!/bin/sh' > /opt/service/openlist/run && \
+    echo 'exec 2>&1' >> /opt/service/openlist/run && \
+    echo 'cd /opt/openlist' >> /opt/service/openlist/run && \
+    echo 'exec ./openlist server --no-prefix' >> /opt/service/openlist/run && \
+    chmod +x /opt/service/openlist/run
 
 COPY --chmod=755 --from=builder /app/bin/openlist ./
 COPY --chmod=755 entrypoint.sh /entrypoint.sh

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -9,7 +9,7 @@ WORKDIR /opt/openlist/
 
 RUN apk update && \
     apk upgrade --no-cache && \
-    apk add --no-cache bash ca-certificates su-exec tzdata; \
+    apk add --no-cache bash ca-certificates su-exec tzdata runit; \
     [ "$INSTALL_FFMPEG" = "true" ] && apk add --no-cache ffmpeg; \
     [ "$INSTALL_ARIA2" = "true" ] && apk add --no-cache curl aria2 && \
         mkdir -p /opt/aria2/.aria2 && \
@@ -20,9 +20,24 @@ RUN apk update && \
         sed -i 's|/root/.aria2|/opt/aria2/.aria2|g' /opt/aria2/.aria2/script.conf && \
         sed -i 's|/root|/opt/aria2|g' /opt/aria2/.aria2/aria2.conf && \
         sed -i 's|/root|/opt/aria2|g' /opt/aria2/.aria2/script.conf && \
+        mkdir -p /opt/service/aria2/log && \
+        echo '#!/bin/sh' > /opt/service/aria2/run && \
+        echo 'exec 2>&1' >> /opt/service/aria2/run && \
+        echo 'exec aria2c --enable-rpc --rpc-allow-origin-all --conf-path=/opt/aria2/.aria2/aria2.conf' >> /opt/service/aria2/run && \
+        echo '#!/bin/sh' > /opt/service/aria2/log/run && \
+        echo 'mkdir -p /opt/openlist/data/log/aria2 2>/dev/null' >> /opt/service/aria2/log/run && \
+        echo 'exec svlogd /opt/openlist/data/log/aria2' >> /opt/service/aria2/log/run && \
+        chmod +x /opt/service/aria2/run /opt/service/aria2/log/run && \
         touch /opt/aria2/.aria2/aria2.session && \
         /opt/aria2/.aria2/tracker.sh ; \
     rm -rf /var/cache/apk/*
+    
+RUN mkdir -p /opt/service/openlist && \
+    echo '#!/bin/sh' > /opt/service/openlist/run && \
+    echo 'exec 2>&1' >> /opt/service/openlist/run && \
+    echo 'cd /opt/openlist' >> /opt/service/openlist/run && \
+    echo 'exec ./openlist server --no-prefix' >> /opt/service/openlist/run && \
+    chmod +x /opt/service/openlist/run
 
 COPY --chmod=755 /build/${TARGETPLATFORM}/openlist ./
 COPY --chmod=755 entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,15 +5,7 @@ umask ${UMASK}
 if [ "$1" = "version" ]; then
   ./openlist version
 else
-  if [ "$RUN_ARIA2" = "true" ]; then
-    chown -R ${PUID}:${PGID} /opt/aria2/
-    exec su-exec ${PUID}:${PGID} nohup aria2c \
-      --enable-rpc \
-      --rpc-allow-origin-all \
-      --conf-path=/opt/aria2/.aria2/aria2.conf \
-      >/dev/null 2>&1 &
-  fi
 
   chown -R ${PUID}:${PGID} /opt/openlist/
-  exec su-exec ${PUID}:${PGID} ./openlist server --no-prefix
+  exec su-exec ${PUID}:${PGID} runsvdir /opt/service
 fi


### PR DESCRIPTION
- 将进程保活方式从原有策略改为使用 runit 管理
- 增加 aria2 下载日志输出，便于调试和监控