### PR TITLE
fix(ci): update OpenListTeam/cgo-actions to v1.2.2 to fix loongarch64 build

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -93,7 +93,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        uses: OpenListTeam/cgo-actions@v1.2.1
+        uses: OpenListTeam/cgo-actions@v1.2.2
         with:
           targets: ${{ matrix.target }}
           musl-target-format: $os-$musl-$arch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        uses: OpenListTeam/cgo-actions@v1.2.1
+        uses: OpenListTeam/cgo-actions@v1.2.2
         with:
           targets: ${{ matrix.target }}
           musl-target-format: $os-$musl-$arch


### PR DESCRIPTION
同步OpenListTeam/cgo-actions 更改，以修复龙架构构建中出现的问题
1. 修复ABI1.0使用的Go版本问题导致的下载失败
2. 修复不同龙架构ABI同时构建出现的问题