### PR TITLE
fix(ci):Exclude FreeBSD patch releases from version detection

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -278,6 +278,7 @@ BuildReleaseFreeBSD() {
   freebsd_version=$(eval "curl -fsSL --max-time 2 $githubAuthArgs \"https://api.github.com/repos/freebsd/freebsd-src/tags\"" | \
     jq -r '.[].name' | \
     grep '^release/14\.' | \
+    grep -v -- '-p[0-9]*$' | \
     sort -V | \
     tail -1 | \
     sed 's/release\///' | \


### PR DESCRIPTION
Modify version detection to exclude FreeBSD patch releases, ensuring only relevant release versions are considered.