### PR TITLE
refactor(security): update static hash salt to OpenList repo

### DIFF
--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -20,7 +20,7 @@ const (
 	ADMIN
 )
 
-const StaticHashSalt = "https://github.com/alist-org/alist"
+const StaticHashSalt = "https://github.com/OpenListTeam/OpenList"
 
 var LoginCache = cache.NewMemCache[int]()
 


### PR DESCRIPTION
Change the StaticHashSalt constant from alist-org to OpenListTeam's repository URL to align with project ownership. This ensures consistency with the current project namespace.

No breaking changes introduced.