### PR TITLE
fix(drivers): update time-related fields to int64

### DIFF
--- a/drivers/doubao/types.go
+++ b/drivers/doubao/types.go
@@ -129,7 +129,7 @@ type BuiAuditInfo struct {
 	AuditInfo      AuditInfo `json:"audit_info"`
 	IsAuditing     bool      `json:"is_auditing"`
 	AuditStatus    int       `json:"audit_status"`
-	LastUpdateTime int       `json:"last_update_time"`
+	LastUpdateTime int64     `json:"last_update_time"`
 	UnpassReason   string    `json:"unpass_reason"`
 	Details        Details   `json:"details"`
 }
@@ -184,7 +184,7 @@ type UserInfo struct {
 	SecUserID             string                `json:"sec_user_id"`
 	SessionKey            string                `json:"session_key"`
 	UseHmRegion           bool                  `json:"use_hm_region"`
-	UserCreateTime        int                   `json:"user_create_time"`
+	UserCreateTime        int64                 `json:"user_create_time"`
 	UserID                int64                 `json:"user_id"`
 	UserIDStr             string                `json:"user_id_str"`
 	UserVerified          bool                  `json:"user_verified"`

--- a/drivers/doubao_share/types.go
+++ b/drivers/doubao_share/types.go
@@ -79,11 +79,11 @@ type ShareInfo struct {
 		RiskReviewStatus    int    `json:"risk_review_status"`
 		ConversationID      string `json:"conversation_id"`
 		ParentID            string `json:"parent_id"`
-		CreateTime          int    `json:"create_time"`
-		UpdateTime          int    `json:"update_time"`
+		CreateTime          int64  `json:"create_time"`
+		UpdateTime          int64  `json:"update_time"`
 	} `json:"first_node"`
 	NodeCount      int    `json:"node_count"`
-	CreateTime     int    `json:"create_time"`
+	CreateTime     int64  `json:"create_time"`
 	Channel        string `json:"channel"`
 	InfluencerType int    `json:"influencer_type"`
 }
@@ -111,8 +111,8 @@ type FilePath []struct {
 	RiskReviewStatus    int    `json:"risk_review_status"`
 	ConversationID      string `json:"conversation_id"`
 	ParentID            string `json:"parent_id"`
-	CreateTime          int    `json:"create_time"`
-	UpdateTime          int    `json:"update_time"`
+	CreateTime          int64  `json:"create_time"`
+	UpdateTime          int64  `json:"update_time"`
 }
 
 type GetFileUrlResp struct {

--- a/drivers/quark_uc/types.go
+++ b/drivers/quark_uc/types.go
@@ -1,8 +1,9 @@
 package quark
 
 import (
-	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 )
@@ -159,7 +160,7 @@ type TranscodingResp struct {
 					Codec    string  `json:"codec"`
 					Channels int     `json:"channels"`
 				} `json:"audio"`
-				UpdateTime int    `json:"update_time"`
+				UpdateTime int64  `json:"update_time"`
 				URL        string `json:"url"`
 				Resolution string `json:"resolution"`
 				HlsType    string `json:"hls_type"`


### PR DESCRIPTION
- In doubao/types.go:
  - Change LastUpdateTime from int to int64
  - Change UserCreateTime from int to int64
- In doubao_share/types.go:
  - Change CreateTime and UpdateTime from int to int64 in ShareInfo and FilePath
- In quark_uc/types.go:
  - Change UpdateTime from int to int64 in TranscodingResp

These changes ensure consistent and accurate representation of timestamp data across the project.