### PR TITLE
feat(patch): add migration from Alist V3 driver to OpenList

### DIFF
--- a/internal/bootstrap/patch/all.go
+++ b/internal/bootstrap/patch/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/internal/bootstrap/patch/v3_24_0"
 	"github.com/OpenListTeam/OpenList/v4/internal/bootstrap/patch/v3_32_0"
 	"github.com/OpenListTeam/OpenList/v4/internal/bootstrap/patch/v3_41_0"
+	"github.com/OpenListTeam/OpenList/v4/internal/bootstrap/patch/v3_all"
 )
 
 type VersionPatches struct {
@@ -30,6 +31,12 @@ var UpgradePatches = []VersionPatches{
 		Version: "v3.41.0",
 		Patches: []func(){
 			v3_41_0.GrantAdminPermissions,
+		},
+	},
+	{
+		Version: "v3.0.0",
+		Patches: []func(){
+			v3_all.RenameAlistV3Driver,
 		},
 	},
 }

--- a/internal/bootstrap/patch/v3_all/rename.go
+++ b/internal/bootstrap/patch/v3_all/rename.go
@@ -9,23 +9,25 @@ import (
 func RenameAlistV3Driver() {
 	storages, _, err := db.GetStorages(1, -1)
 	if err != nil {
-		utils.Log.Errorf("failed to get storages: %s", err.Error())
+		utils.Log.Errorf("[RenameAlistV3Driver] failed to get storages: %s", err.Error())
 		return
 	}
 
 	updatedCount := 0
 	for _, s := range storages {
 		if s.Driver == "AList V3" {
-			utils.Log.Warnf("Rename storage [%d]%s from Alist V3 to OpenList", s.ID, s.MountPath)
+			utils.Log.Warnf("[RenameAlistV3Driver] rename storage [%d]%s from Alist V3 to OpenList", s.ID, s.MountPath)
 			s.Driver = "OpenList"
 			err = db.UpdateStorage(&s)
 			if err != nil {
-				utils.Log.Errorf("failed to update storage [%d]%s: %s", s.ID, s.MountPath, err.Error())
+				utils.Log.Errorf("[RenameAlistV3Driver] failed to update storage [%d]%s: %s", s.ID, s.MountPath, err.Error())
 			} else {
 				updatedCount++
 			}
 		}
 	}
 
-	utils.Log.Warnf("RenameAlistV3Driver: updated %d storages from Alist V3 to OpenList", updatedCount)
+	if updatedCount > 0 {
+		utils.Log.Infof("[RenameAlistV3Driver] updated %d storages from Alist V3 to OpenList", updatedCount)
+	}
 }

--- a/internal/bootstrap/patch/v3_all/rename.go
+++ b/internal/bootstrap/patch/v3_all/rename.go
@@ -1,0 +1,31 @@
+package v3_all
+
+import (
+	"github.com/OpenListTeam/OpenList/v4/internal/db"
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
+)
+
+// Rename Alist V3 driver to OpenList
+func RenameAlistV3Driver() {
+	storages, _, err := db.GetStorages(1, -1)
+	if err != nil {
+		utils.Log.Errorf("failed to get storages: %s", err.Error())
+		return
+	}
+
+	updatedCount := 0
+	for _, s := range storages {
+		if s.Driver == "AList V3" {
+			utils.Log.Warnf("Rename storage [%d]%s from Alist V3 to OpenList", s.ID, s.MountPath)
+			s.Driver = "OpenList"
+			err = db.UpdateStorage(&s)
+			if err != nil {
+				utils.Log.Errorf("failed to update storage [%d]%s: %s", s.ID, s.MountPath, err.Error())
+			} else {
+				updatedCount++
+			}
+		}
+	}
+
+	utils.Log.Warnf("RenameAlistV3Driver: updated %d storages from Alist V3 to OpenList", updatedCount)
+}


### PR DESCRIPTION

修复以下问题：

```
[31mERRO[0m[2025-07-31 00:08:22] failed get enabled storages: no driver named: AList V3
```

Close: https://github.com/OpenListTeam/OpenList/issues/908
Close: https://github.com/OpenListTeam/OpenList/issues/156
Close: https://github.com/OpenListTeam/OpenList/issues/122


测试日志：

```                     
[33mWARN[0m[2025-07-31 00:12:59] not enable search                            
[33mWARN[0m[2025-07-31 00:12:59] Rename storage [1]/test from Alist V3 to OpenList 
[33mWARN[0m[2025-07-31 00:12:59] RenameAlistV3Driver: updated 1 storages from Alist V3 to OpenList 
[36mINFO[0m[2025-07-31 00:12:59] init offline download tool ThunderBrowser success: ok 
[36mINFO[0m[2025-07-31 00:12:59] init offline download tool ThunderX success: ok 
[33mWARN[0m[2025-07-31 00:12:59] init offline download tool Transmission failed: failed get transmission version: can't get session values: 'session-get' rpc method failed: failed to execute HTTP request: Post "http://localhost:9091/transmission/rpc": dial tcp [::1]:9091: connectex: No connection could be made because the target machine actively refused it. 
[36mINFO[0m[2025-07-31 00:12:59] init offline download tool 115 Cloud success: ok 
[36mINFO[0m[2025-07-31 00:12:59] init offline download tool 115 Open success: ok 
[36mINFO[0m[2025-07-31 00:12:59] init offline download tool SimpleHttp success: ok 
[33mWARN[0m[2025-07-31 00:12:59] init offline download tool qBittorrent failed: Post "http://localhost:8080/api/v2/auth/login": dial tcp [::1]:8080: connectex: No connection could be made because the target machine actively refused it. 
[33mWARN[0m[2025-07-31 00:12:59] init offline download tool aria2 failed: failed get aria2 version: Post "http://localhost:6800/jsonrpc": dial tcp [::1]:6800: connectex: No connection could be made because the target machine actively refused it. 
[36mINFO[0m[2025-07-31 00:12:59] init offline download tool PikPak success: ok 
[36mINFO[0m[2025-07-31 00:12:59] init offline download tool Thunder success: ok 
[36mINFO[0m[2025-07-31 00:12:59] start HTTP server @ 0.0.0.0:5244             
[36mINFO[0m[2025-07-31 00:12:59] success load storage: [/teste], driver: [OpenList], order: [0] 
```

已知问题：

- [x] Dev 版本每次启动都执行迁移操作，这个应该不是问题，因为不会更新 `config.json` 中的 `last_launched_version` 字段，版本还是 v3，如果已经变成了 v4，但未执行迁移操作，可以将这个手动改回去 `"last_launched_version": "v3.44.0"`。
