### PR TITLE
fix(cmd): output to console

### DIFF
--- a/cmd/admin.go
+++ b/cmd/admin.go
@@ -4,6 +4,8 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/OpenListTeam/OpenList/v4/internal/conf"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
 	"github.com/OpenListTeam/OpenList/v4/internal/setting"
@@ -24,10 +26,11 @@ var AdminCmd = &cobra.Command{
 		if err != nil {
 			utils.Log.Errorf("failed get admin user: %+v", err)
 		} else {
-			utils.Log.Infof("Admin user's username: %s", admin.Username)
-			utils.Log.Infof("The password can only be output at the first startup, and then stored as a hash value, which cannot be reversed")
-			utils.Log.Infof("You can reset the password with a random string by running [openlist admin random]")
-			utils.Log.Infof("You can also set a new password by running [openlist admin set NEW_PASSWORD]")
+			utils.Log.Infof("get admin user from CLI")
+			fmt.Println("Admin user's username:", admin.Username)
+			fmt.Println("The password can only be output at the first startup, and then stored as a hash value, which cannot be reversed")
+			fmt.Println("You can reset the password with a random string by running [openlist admin random]")
+			fmt.Println("You can also set a new password by running [openlist admin set NEW_PASSWORD]")
 		}
 	},
 }
@@ -36,6 +39,7 @@ var RandomPasswordCmd = &cobra.Command{
 	Use:   "random",
 	Short: "Reset admin user's password to a random string",
 	Run: func(cmd *cobra.Command, args []string) {
+		utils.Log.Infof("reset admin user's password to a random string from CLI")
 		newPwd := random.String(8)
 		setAdminPassword(newPwd)
 	},
@@ -44,12 +48,12 @@ var RandomPasswordCmd = &cobra.Command{
 var SetPasswordCmd = &cobra.Command{
 	Use:   "set",
 	Short: "Set admin user's password",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			utils.Log.Errorf("Please enter the new password")
-			return
+			return fmt.Errorf("Please enter the new password")
 		}
 		setAdminPassword(args[0])
+		return nil
 	},
 }
 
@@ -60,7 +64,8 @@ var ShowTokenCmd = &cobra.Command{
 		Init()
 		defer Release()
 		token := setting.GetStr(conf.Token)
-		utils.Log.Infof("Admin token: %s", token)
+		utils.Log.Infof("show admin token from CLI")
+		fmt.Println("Admin token:", token)
 	},
 }
 
@@ -77,9 +82,10 @@ func setAdminPassword(pwd string) {
 		utils.Log.Errorf("failed update admin user: %+v", err)
 		return
 	}
-	utils.Log.Infof("admin user has been updated:")
-	utils.Log.Infof("username: %s", admin.Username)
-	utils.Log.Infof("password: %s", pwd)
+	utils.Log.Infof("admin user has been update from CLI")
+	fmt.Println("admin user has been updated:")
+	fmt.Println("username:", admin.Username)
+	fmt.Println("password:", pwd)
 	DelAdminCacheOnline()
 }
 

--- a/cmd/cancel2FA.go
+++ b/cmd/cancel2FA.go
@@ -4,6 +4,8 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"github.com/spf13/cobra"
@@ -24,7 +26,8 @@ var Cancel2FACmd = &cobra.Command{
 			if err != nil {
 				utils.Log.Errorf("failed to cancel 2FA: %+v", err)
 			} else {
-				utils.Log.Info("2FA canceled")
+				utils.Log.Infof("2FA is canceled from CLI")
+				fmt.Println("2FA canceled")
 				DelAdminCacheOnline()
 			}
 		}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -65,6 +65,7 @@ the address is defined in config file`,
 		var httpSrv, httpsSrv, unixSrv *http.Server
 		if conf.Conf.Scheme.HttpPort != -1 {
 			httpBase := fmt.Sprintf("%s:%d", conf.Conf.Scheme.Address, conf.Conf.Scheme.HttpPort)
+			fmt.Printf("start HTTP server @ %s\n", httpBase)
 			utils.Log.Infof("start HTTP server @ %s", httpBase)
 			httpSrv = &http.Server{Addr: httpBase, Handler: httpHandler}
 			go func() {
@@ -76,6 +77,7 @@ the address is defined in config file`,
 		}
 		if conf.Conf.Scheme.HttpsPort != -1 {
 			httpsBase := fmt.Sprintf("%s:%d", conf.Conf.Scheme.Address, conf.Conf.Scheme.HttpsPort)
+			fmt.Printf("start HTTPS server @ %s\n", httpsBase)
 			utils.Log.Infof("start HTTPS server @ %s", httpsBase)
 			httpsSrv = &http.Server{Addr: httpsBase, Handler: r}
 			go func() {
@@ -86,6 +88,7 @@ the address is defined in config file`,
 			}()
 		}
 		if conf.Conf.Scheme.UnixFile != "" {
+			fmt.Printf("start unix server @ %s\n", conf.Conf.Scheme.UnixFile)
 			utils.Log.Infof("start unix server @ %s", conf.Conf.Scheme.UnixFile)
 			unixSrv = &http.Server{Handler: httpHandler}
 			go func() {
@@ -114,6 +117,7 @@ the address is defined in config file`,
 			s3r.Use(gin.LoggerWithWriter(log.StandardLogger().Out), gin.RecoveryWithWriter(log.StandardLogger().Out))
 			server.InitS3(s3r)
 			s3Base := fmt.Sprintf("%s:%d", conf.Conf.Scheme.Address, conf.Conf.S3.Port)
+			fmt.Printf("start S3 server @ %s\n", s3Base)
 			utils.Log.Infof("start S3 server @ %s", s3Base)
 			go func() {
 				var err error
@@ -138,6 +142,7 @@ the address is defined in config file`,
 			if err != nil {
 				utils.Log.Fatalf("failed to start ftp driver: %s", err.Error())
 			} else {
+				fmt.Printf("start ftp server on %s\n", conf.Conf.FTP.Listen)
 				utils.Log.Infof("start ftp server on %s", conf.Conf.FTP.Listen)
 				go func() {
 					ftpServer = ftpserver.NewFtpServer(ftpDriver)
@@ -156,6 +161,7 @@ the address is defined in config file`,
 			if err != nil {
 				utils.Log.Fatalf("failed to start sftp driver: %s", err.Error())
 			} else {
+				fmt.Printf("start sftp server on %s", conf.Conf.SFTP.Listen)
 				utils.Log.Infof("start sftp server on %s", conf.Conf.SFTP.Listen)
 				go func() {
 					sftpServer = sftpd.NewSftpServer(sftpDriver)

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -4,11 +4,11 @@ Copyright © 2023 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/db"
-	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -24,26 +24,26 @@ var storageCmd = &cobra.Command{
 var disableStorageCmd = &cobra.Command{
 	Use:   "disable",
 	Short: "Disable a storage",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			utils.Log.Errorf("mount path is required")
-			return
+			return fmt.Errorf("mount path is required")
 		}
 		mountPath := args[0]
 		Init()
 		defer Release()
 		storage, err := db.GetStorageByMountPath(mountPath)
 		if err != nil {
-			utils.Log.Errorf("failed to query storage: %+v", err)
+			return fmt.Errorf("failed to query storage: %+v", err)
 		} else {
 			storage.Disabled = true
 			err = db.UpdateStorage(storage)
 			if err != nil {
-				utils.Log.Errorf("failed to update storage: %+v", err)
+				return fmt.Errorf("failed to update storage: %+v", err)
 			} else {
-				utils.Log.Infof("Storage with mount path [%s] have been disabled", mountPath)
+				fmt.Printf("Storage with mount path [%s] have been disabled\n", mountPath)
 			}
 		}
+		return nil
 	},
 }
 
@@ -88,14 +88,14 @@ var storageTableHeight int
 var listStorageCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all storages",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		Init()
 		defer Release()
 		storages, _, err := db.GetStorages(1, -1)
 		if err != nil {
-			utils.Log.Errorf("failed to query storages: %+v", err)
+			return fmt.Errorf("failed to query storages: %+v", err)
 		} else {
-			utils.Log.Infof("Found %d storages", len(storages))
+			fmt.Printf("Found %d storages\n", len(storages))
 			columns := []table.Column{
 				{Title: "ID", Width: 4},
 				{Title: "Driver", Width: 16},
@@ -138,10 +138,11 @@ var listStorageCmd = &cobra.Command{
 
 			m := model{t}
 			if _, err := tea.NewProgram(m).Run(); err != nil {
-				utils.Log.Errorf("failed to run program: %+v", err)
+				fmt.Printf("failed to run program: %+v\n", err)
 				os.Exit(1)
 			}
 		}
+		return nil
 	},
 }
 

--- a/internal/bootstrap/data/user.go
+++ b/internal/bootstrap/data/user.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"fmt"
-	"time"
 	"os"
 
 	"github.com/OpenListTeam/OpenList/v4/cmd/flags"
@@ -40,18 +39,19 @@ func initUser() {
 			if err := op.CreateUser(admin); err != nil {
 				panic(err)
 			} else {
-				utils.Log.Infof("Successfully created the admin user and the initial password is: %s", adminPassword)
-				fmt.Printf("\033[36mINFO\033[39m[%s] Successfully created the admin user and the initial password is: %s\n", time.Now().Format("2006-01-02 15:04:05"), adminPassword)
+				// DO NOT output the password to log file. Only output to console.
+				// utils.Log.Infof("Successfully created the admin user and the initial password is: %s", adminPassword)
+				fmt.Printf("Successfully created the admin user and the initial password is: %s", adminPassword)
 			}
 		} else {
 			utils.Log.Fatalf("[init user] Failed to get admin user: %v", err)
 		}
 	}
-	guest, err := op.GetGuest()
+	_, err = op.GetGuest()
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			salt := random.String(16)
-			guest = &model.User{
+			guest := &model.User{
 				Username:   "guest",
 				PwdHash:    model.TwoHashPwd("guest", salt),
 				Salt:       salt,


### PR DESCRIPTION

#816 #833 引入了 #833 这个问题，虽然  #833 将首次启动时的密码输出到了终端，但还是会输出到日志文件，另外也没有处理 `openlist admin random` 的输出。

---

个人认为，将密码直接写入**日志文件**为比较高危的操作，应当仅通过标准输出输出到控制台中。如果后面有需求将日志输出到前端的设置页面（或者是用户的管理工具支持此操作），然后又使用 HTTP 协议可以中间人监听，这样密码等隐私信息就存在泄露风险。

另外，发现存在一个 `storage` 的运行参数，可以不启动服务直接查看挂载列表，也就是说 OpenList **存在两套 UI**——WebUI 和 TUI（虽然很少见）。之前可能是图方便，CLI 直接用的 logrus 输出，所以 #816 #833 重构日志过滤之后好多东西就打印不出来了。因此应当正确区分处理 CLI 和服务的输出，最好是分开处理。

![](https://github.com/user-attachments/assets/59e818de-9f71-4e42-9b72-db6da34c1665)

（图为修复后截取，修复前无 `Found 2 storages`）

---

本 PR 对于基于 `cobra` 的 CLI 部分即 `cmd/**/*.go` 改用 fmt.Print 输出，然后在日志文件中仅记录“从CLI执行了XX操作”的信息，这样就不会将密码等隐私信息直接写入日志文件，同时管理员也可以从日志中审计操作。

对于错误信息，如 `logrus` 的 Error、Fatal，会同时输出到日志和终端，可以暂不调整。