### PR TITLE
fix(bootstrap): add newline after initial admin password output

### DIFF
--- a/internal/bootstrap/data/user.go
+++ b/internal/bootstrap/data/user.go
@@ -41,7 +41,7 @@ func initUser() {
 			} else {
 				// DO NOT output the password to log file. Only output to console.
 				// utils.Log.Infof("Successfully created the admin user and the initial password is: %s", adminPassword)
-				fmt.Printf("Successfully created the admin user and the initial password is: %s", adminPassword)
+				fmt.Printf("Successfully created the admin user and the initial password is: %s\n", adminPassword)
 			}
 		} else {
 			utils.Log.Fatalf("[init user] Failed to get admin user: %v", err)


### PR DESCRIPTION
Fix:

```              
Successfully created the admin user and the initial password is: 5NvFV6yjstart HTTP server @ 0.0.0.0:5244
```