### PR TITLE
fix(ftp): create a new connection for each download

### DIFF
--- a/drivers/ftp/util.go
+++ b/drivers/ftp/util.go
@@ -2,14 +2,10 @@ package ftp
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
-	"os"
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/pkg/singleflight"
-	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"github.com/jlaffaye/ftp"
 )
 
@@ -44,29 +40,4 @@ func (d *FTP) _login(ctx context.Context) (*ftp.ServerConn, error) {
 		return nil, err
 	}
 	return conn, nil
-}
-
-type FileReader struct {
-	*ftp.Response
-	io.Reader
-	ctx context.Context
-}
-
-func (r *FileReader) Read(buf []byte) (int, error) {
-	n := 0
-	for n < len(buf) {
-		w, err := r.Reader.Read(buf[n:])
-		if utils.IsCanceled(r.ctx) {
-			return n, r.ctx.Err()
-		}
-		n += w
-		if errors.Is(err, os.ErrDeadlineExceeded) {
-			r.Response.SetDeadline(time.Now().Add(time.Second))
-			continue
-		}
-		if err != nil || w == 0 {
-			return n, err
-		}
-	}
-	return n, nil
 }


### PR DESCRIPTION
Previously, the FTP `Link` function was designed to reuse a single control connection
for multiple download range requests. This approach could lead to connection conflicts
and unpredictable behavior, as the FTP protocol is stateful and not designed for
concurrent `RETR` commands on a single control connection.

This commit changes the behavior to create a new control connection for each
download range request. This ensures that each concurrent download task operates
on a dedicated, isolated connection, improving the stability and reliability of
multi-threaded FTP downloads.