### PR TITLE
fix(webdav): Handle HEAD requests for directories with appropriate headers

### DIFF
--- a/server/webdav/webdav.go
+++ b/server/webdav/webdav.go
@@ -233,6 +233,11 @@ func (h *Handler) handleGetHeadPost(w http.ResponseWriter, r *http.Request) (sta
 		return http.StatusNotFound, err
 	}
 	if fi.IsDir() {
+		if r.Method == http.MethodHead {
+			w.Header().Set("Content-Type", "httpd/unix-directory")
+			w.Header().Set("Content-Length", "0")
+			return http.StatusOK, nil
+		}
 		return http.StatusMethodNotAllowed, nil
 	}
 	// Let ServeContent determine the Content-Type header.


### PR DESCRIPTION
Implement handling of HEAD requests for directories by setting the correct Content-Type and Content-Length headers.