### PR TITLE
feat(drivers): add cnb_releases

### DIFF
--- a/drivers/all.go
+++ b/drivers/all.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/chaoxing"
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/cloudreve"
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/cloudreve_v4"
+	_ "github.com/OpenListTeam/OpenList/v4/drivers/cnb_releases"
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/crypt"
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/doubao"
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/doubao_share"

--- a/drivers/cnb_releases/driver.go
+++ b/drivers/cnb_releases/driver.go
@@ -162,9 +162,17 @@ func (d *CnbReleases) Move(ctx context.Context, srcObj, dstDir model.Obj) (model
 	return nil, errs.NotImplement
 }
 
-func (d *CnbReleases) Rename(ctx context.Context, srcObj model.Obj, newName string) (model.Obj, error) {
-	// TODO rename obj, optional
-	return nil, errs.NotImplement
+func (d *CnbReleases) Rename(ctx context.Context, srcObj model.Obj, newName string) error {
+	if srcObj.IsDir() && !d.UseTagName {
+		return d.Request(http.MethodPatch, "/{repo}/-/releases/{release_id}", func(req *resty.Request) {
+			req.SetPathParam("repo", d.Repo)
+			req.SetPathParam("release_id", srcObj.GetID())
+			req.SetFormData(map[string]string{
+				"name": newName,
+			})
+		}, nil)
+	}
+	return errs.NotImplement
 }
 
 func (d *CnbReleases) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {

--- a/drivers/cnb_releases/driver.go
+++ b/drivers/cnb_releases/driver.go
@@ -1,0 +1,143 @@
+package cnb_releases
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
+	"github.com/go-resty/resty/v2"
+)
+
+type CnbReleases struct {
+	model.Storage
+	Addition
+}
+
+func (d *CnbReleases) Config() driver.Config {
+	return config
+}
+
+func (d *CnbReleases) GetAddition() driver.Additional {
+	return &d.Addition
+}
+
+func (d *CnbReleases) Init(ctx context.Context) error {
+	// TODO login / refresh token
+	//op.MustSaveDriverStorage(d)
+	return nil
+}
+
+func (d *CnbReleases) Drop(ctx context.Context) error {
+	return nil
+}
+
+func (d *CnbReleases) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
+	if dir.GetPath() == "/" {
+		// get all tags for root dir
+		var resp TagList
+		err := d.Request(http.MethodGet, "/{repo}/-/git/tags", func(req *resty.Request) {
+			req.SetPathParam("repo", d.Repo)
+		}, &resp)
+		if err != nil {
+			return nil, err
+		}
+
+		return utils.SliceConvert(resp, func(src Tag) (model.Obj, error) {
+			return &model.Object{
+				ID:       src.Target,
+				Name:     src.Name,
+				Modified: src.Commit.Commit.Committer.Date,
+				IsFolder: src.TargetType == "tag",
+			}, nil
+		})
+	} else {
+		// get release info by tag name
+		var resp Release
+		err := d.Request(http.MethodGet, "/{repo}/-/releases/tags/{tag}", func(req *resty.Request) {
+			req.SetPathParam("repo", d.Repo)
+			req.SetPathParam("tag", dir.GetName())
+		}, &resp)
+		if err != nil {
+			return nil, err
+		}
+		// return assets plane
+		return utils.SliceConvert(resp.Assets, func(src ReleaseAsset) (model.Obj, error) {
+			return &model.Object{
+				ID:       src.ID,
+				Path:     src.Path, // for Link only
+				Name:     src.Name,
+				Size:     src.Size,
+				Ctime:    src.CreatedAt,
+				Modified: src.UpdatedAt,
+				IsFolder: false,
+			}, nil
+		})
+	}
+}
+
+func (d *CnbReleases) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
+	return &model.Link{
+		URL: "https://cnb.cool" + file.GetPath(),
+	}, nil
+}
+
+func (d *CnbReleases) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) (model.Obj, error) {
+	// TODO create folder, optional
+	return nil, errs.NotImplement
+}
+
+func (d *CnbReleases) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	// TODO move obj, optional
+	return nil, errs.NotImplement
+}
+
+func (d *CnbReleases) Rename(ctx context.Context, srcObj model.Obj, newName string) (model.Obj, error) {
+	// TODO rename obj, optional
+	return nil, errs.NotImplement
+}
+
+func (d *CnbReleases) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	// TODO copy obj, optional
+	return nil, errs.NotImplement
+}
+
+func (d *CnbReleases) Remove(ctx context.Context, obj model.Obj) error {
+	// TODO remove obj, optional
+	return errs.NotImplement
+}
+
+func (d *CnbReleases) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
+	// TODO upload file, optional
+	return nil, errs.NotImplement
+}
+
+func (d *CnbReleases) GetArchiveMeta(ctx context.Context, obj model.Obj, args model.ArchiveArgs) (model.ArchiveMeta, error) {
+	// TODO get archive file meta-info, return errs.NotImplement to use an internal archive tool, optional
+	return nil, errs.NotImplement
+}
+
+func (d *CnbReleases) ListArchive(ctx context.Context, obj model.Obj, args model.ArchiveInnerArgs) ([]model.Obj, error) {
+	// TODO list args.InnerPath in the archive obj, return errs.NotImplement to use an internal archive tool, optional
+	return nil, errs.NotImplement
+}
+
+func (d *CnbReleases) Extract(ctx context.Context, obj model.Obj, args model.ArchiveInnerArgs) (*model.Link, error) {
+	// TODO return link of file args.InnerPath in the archive obj, return errs.NotImplement to use an internal archive tool, optional
+	return nil, errs.NotImplement
+}
+
+func (d *CnbReleases) ArchiveDecompress(ctx context.Context, srcObj, dstDir model.Obj, args model.ArchiveDecompressArgs) ([]model.Obj, error) {
+	// TODO extract args.InnerPath path in the archive srcObj to the dstDir location, optional
+	// a folder with the same name as the archive file needs to be created to store the extracted results if args.PutIntoNewDir
+	// return errs.NotImplement to use an internal archive tool
+	return nil, errs.NotImplement
+}
+
+//func (d *Template) Other(ctx context.Context, args model.OtherArgs) (interface{}, error) {
+//	return nil, errs.NotSupport
+//}
+
+var _ driver.Driver = (*CnbReleases)(nil)

--- a/drivers/cnb_releases/driver.go
+++ b/drivers/cnb_releases/driver.go
@@ -142,9 +142,19 @@ func (d *CnbReleases) Link(ctx context.Context, file model.Obj, args model.LinkA
 	}, nil
 }
 
-func (d *CnbReleases) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) (model.Obj, error) {
-	// TODO create folder, optional
-	return nil, errs.NotImplement
+func (d *CnbReleases) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {
+	if parentDir.GetPath() == "/" {
+		// create a new release
+		return d.Request(http.MethodPost, "/{repo}/-/releases", func(req *resty.Request) {
+			req.SetPathParam("repo", d.Repo)
+			req.SetBody(base.Json{
+				"name":             dirName,
+				"tag_name":         dirName,
+				"target_commitish": "main",
+			})
+		}, nil)
+	}
+	return errs.NotImplement
 }
 
 func (d *CnbReleases) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {

--- a/drivers/cnb_releases/driver.go
+++ b/drivers/cnb_releases/driver.go
@@ -77,9 +77,13 @@ func (d *CnbReleases) List(ctx context.Context, dir model.Obj, args model.ListAr
 		}
 
 		return utils.SliceConvert(resp, func(src Release) (model.Obj, error) {
+			name := src.Name
+			if d.UseTagName {
+				name = src.TagName
+			}
 			return &model.Object{
 				ID:       src.ID,
-				Name:     src.Name,
+				Name:     name,
 				Size:     d.sumAssetsSize(src.Assets),
 				Ctime:    src.CreatedAt,
 				Modified: src.UpdatedAt,

--- a/drivers/cnb_releases/driver.go
+++ b/drivers/cnb_releases/driver.go
@@ -102,10 +102,14 @@ func (d *CnbReleases) List(ctx context.Context, dir model.Obj, args model.ListAr
 		// }
 
 		// get release info by release id
+		releaseID := dir.GetID()
+		if releaseID == "" {
+			return nil, errs.ObjectNotFound
+		}
 		var resp Release
 		err := d.Request(http.MethodGet, "/{repo}/-/releases/{release_id}", func(req *resty.Request) {
 			req.SetPathParam("repo", d.Repo)
-			req.SetPathParam("release_id", dir.GetID())
+			req.SetPathParam("release_id", releaseID)
 		}, &resp)
 		if err != nil {
 			return nil, err

--- a/drivers/cnb_releases/driver.go
+++ b/drivers/cnb_releases/driver.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
@@ -234,7 +235,9 @@ func (d *CnbReleases) Put(ctx context.Context, dstDir model.Obj, file model.File
 	}()
 
 	// use net/http to upload file
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resp.UploadURL, pr)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Duration(resp.ExpiresInSec+1)*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctxWithTimeout, http.MethodPost, resp.UploadURL, pr)
 	if err != nil {
 		return err
 	}

--- a/drivers/cnb_releases/driver.go
+++ b/drivers/cnb_releases/driver.go
@@ -2,6 +2,7 @@ package cnb_releases
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
@@ -14,6 +15,7 @@ import (
 type CnbReleases struct {
 	model.Storage
 	Addition
+	ref *CnbReleases
 }
 
 func (d *CnbReleases) Config() driver.Config {
@@ -30,7 +32,17 @@ func (d *CnbReleases) Init(ctx context.Context) error {
 	return nil
 }
 
+func (d *CnbReleases) InitReference(storage driver.Driver) error {
+	refStorage, ok := storage.(*CnbReleases)
+	if ok {
+		d.ref = refStorage
+		return nil
+	}
+	return fmt.Errorf("ref: storage is not CnbReleases")
+}
+
 func (d *CnbReleases) Drop(ctx context.Context) error {
+	d.ref = nil
 	return nil
 }
 

--- a/drivers/cnb_releases/meta.go
+++ b/drivers/cnb_releases/meta.go
@@ -13,11 +13,9 @@ type Addition struct {
 }
 
 var config = driver.Config{
-	Name:              "CNB Releases",
-	LocalSort:         true,
-	DefaultRoot:       "/",
-	NoUpload:          true,
-	NoOverwriteUpload: true,
+	Name:        "CNB Releases",
+	LocalSort:   true,
+	DefaultRoot: "/",
 }
 
 func init() {

--- a/drivers/cnb_releases/meta.go
+++ b/drivers/cnb_releases/meta.go
@@ -7,9 +7,9 @@ import (
 
 type Addition struct {
 	driver.RootPath
-	Repo       string `json:"repo" type:"string" required:"false"`
-	Token      string `json:"token" type:"string" required:"false"`
-	UseTagName bool   `json:"use_tag_name" type:"bool" required:"false" help:"Use tag name instead of release name"`
+	Repo       string `json:"repo" type:"string" required:"true"`
+	Token      string `json:"token" type:"string" required:"true"`
+	UseTagName bool   `json:"use_tag_name" type:"bool" default:"false" help:"Use tag name instead of release name"`
 }
 
 var config = driver.Config{

--- a/drivers/cnb_releases/meta.go
+++ b/drivers/cnb_releases/meta.go
@@ -7,8 +7,9 @@ import (
 
 type Addition struct {
 	driver.RootPath
-	Repo  string `json:"repo" type:"string" required:"false"`
-	Token string `json:"token" type:"string" required:"false"`
+	Repo       string `json:"repo" type:"string" required:"false"`
+	Token      string `json:"token" type:"string" required:"false"`
+	UseTagName bool   `json:"use_tag_name" type:"bool" required:"false" help:"Use tag name instead of release name"`
 }
 
 var config = driver.Config{

--- a/drivers/cnb_releases/meta.go
+++ b/drivers/cnb_releases/meta.go
@@ -1,0 +1,26 @@
+package cnb_releases
+
+import (
+	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/op"
+)
+
+type Addition struct {
+	driver.RootPath
+	Repo  string `json:"repo" type:"string" required:"false"`
+	Token string `json:"token" type:"string" required:"false"`
+}
+
+var config = driver.Config{
+	Name:              "CNB Releases",
+	LocalSort:         true,
+	DefaultRoot:       "",
+	NoUpload:          true,
+	NoOverwriteUpload: true,
+}
+
+func init() {
+	op.RegisterDriver(func() driver.Driver {
+		return &CnbReleases{}
+	})
+}

--- a/drivers/cnb_releases/meta.go
+++ b/drivers/cnb_releases/meta.go
@@ -15,7 +15,7 @@ type Addition struct {
 var config = driver.Config{
 	Name:              "CNB Releases",
 	LocalSort:         true,
-	DefaultRoot:       "",
+	DefaultRoot:       "/",
 	NoUpload:          true,
 	NoOverwriteUpload: true,
 }

--- a/drivers/cnb_releases/types.go
+++ b/drivers/cnb_releases/types.go
@@ -1,0 +1,84 @@
+package cnb_releases
+
+import "time"
+
+type TagList []Tag
+type Tag struct {
+	Commit struct {
+		Author    UserInfo       `json:"author"`
+		Commit    CommitObject   `json:"commit"`
+		Committer UserInfo       `json:"committer"`
+		Parents   []CommitParent `json:"parents"`
+		Sha       string         `json:"sha"`
+	} `json:"commit"`
+	Name         string                `json:"name"`
+	Target       string                `json:"target"`
+	TargetType   string                `json:"target_type"`
+	Verification TagObjectVerification `json:"verification"`
+}
+
+type UserInfo struct {
+	Freeze   bool   `json:"freeze"`
+	Nickname string `json:"nickname"`
+	Username string `json:"username"`
+}
+
+type CommitObject struct {
+	Author       Signature                `json:"author"`
+	CommentCount int                      `json:"comment_count"`
+	Committer    Signature                `json:"committer"`
+	Message      string                   `json:"message"`
+	Tree         CommitObjectTree         `json:"tree"`
+	Verification CommitObjectVerification `json:"verification"`
+}
+
+type Signature struct {
+	Date  time.Time `json:"date"`
+	Email string    `json:"email"`
+	Name  string    `json:"name"`
+}
+
+type CommitObjectTree struct {
+	Sha string `json:"sha"`
+}
+
+type CommitObjectVerification struct {
+	Payload    string `json:"payload"`
+	Reason     string `json:"reason"`
+	Signature  string `json:"signature"`
+	Verified   bool   `json:"verified"`
+	VerifiedAt string `json:"verified_at"`
+}
+
+type CommitParent = CommitObjectTree
+
+type TagObjectVerification = CommitObjectVerification
+
+type ReleaseList []Release
+
+type Release struct {
+	Assets       []ReleaseAsset `json:"assets"`
+	Author       UserInfo       `json:"author"`
+	Body         string         `json:"body"`
+	CreatedAt    time.Time      `json:"created_at"`
+	Draft        bool           `json:"draft"`
+	ID           string         `json:"id"`
+	IsLatest     bool           `json:"is_latest"`
+	Name         string         `json:"name"`
+	Prerelease   bool           `json:"prerelease"`
+	PublishedAt  time.Time      `json:"published_at"`
+	TagCommitish string         `json:"tag_commitish"`
+	TagName      string         `json:"tag_name"`
+	UpdatedAt    time.Time      `json:"updated_at"`
+}
+
+type ReleaseAsset struct {
+	ContentType string    `json:"content_type"`
+	CreatedAt   time.Time `json:"created_at"`
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Path        string    `json:"path"`
+	Size        int64     `json:"size"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Uploader    UserInfo  `json:"uploader"`
+}

--- a/drivers/cnb_releases/types.go
+++ b/drivers/cnb_releases/types.go
@@ -1,6 +1,15 @@
 package cnb_releases
 
-import "time"
+import (
+	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+)
+
+type Object struct {
+	model.Object
+	ParentID string // parentID is used to store the parent directory ID for the object
+}
 
 type TagList []Tag
 type Tag struct {

--- a/drivers/cnb_releases/types.go
+++ b/drivers/cnb_releases/types.go
@@ -82,3 +82,9 @@ type ReleaseAsset struct {
 	UpdatedAt   time.Time `json:"updated_at"`
 	Uploader    UserInfo  `json:"uploader"`
 }
+
+type ReleaseAssetUploadURL struct {
+	UploadURL    string `json:"upload_url"`
+	ExpiresInSec int    `json:"expires_in_sec"`
+	VerifyURL    string `json:"verify_url"`
+}

--- a/drivers/cnb_releases/util.go
+++ b/drivers/cnb_releases/util.go
@@ -35,7 +35,7 @@ func (d *CnbReleases) Request(method string, path string, callback base.ReqCallb
 	if err != nil {
 		return err
 	}
-	if res.StatusCode() != http.StatusOK && res.StatusCode() != http.StatusCreated {
+	if res.StatusCode() != http.StatusOK && res.StatusCode() != http.StatusCreated && res.StatusCode() != http.StatusNoContent {
 		return fmt.Errorf("failed to request %s, status code: %d, message: %s", url, res.StatusCode(), res.String())
 	}
 

--- a/drivers/cnb_releases/util.go
+++ b/drivers/cnb_releases/util.go
@@ -11,6 +11,9 @@ import (
 // do others that not defined in Driver interface
 
 func (d *CnbReleases) Request(method string, path string, callback base.ReqCallback, resp any) error {
+	if d.ref != nil {
+		return d.ref.Request(method, path, callback, resp)
+	}
 	url := "https://api.cnb.cool" + path
 	req := base.RestyClient.R()
 	req.SetHeader("Accept", "application/json")

--- a/drivers/cnb_releases/util.go
+++ b/drivers/cnb_releases/util.go
@@ -3,6 +3,8 @@ package cnb_releases
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
 	log "github.com/sirupsen/logrus"
@@ -14,7 +16,12 @@ func (d *CnbReleases) Request(method string, path string, callback base.ReqCallb
 	if d.ref != nil {
 		return d.ref.Request(method, path, callback, resp)
 	}
-	url := "https://api.cnb.cool" + path
+	var url string
+	if strings.HasPrefix(path, "http") {
+		url = path
+	} else {
+		url = "https://api.cnb.cool" + path
+	}
 	req := base.RestyClient.R()
 	req.SetHeader("Accept", "application/json")
 	req.SetAuthScheme("Bearer")
@@ -28,7 +35,7 @@ func (d *CnbReleases) Request(method string, path string, callback base.ReqCallb
 	if err != nil {
 		return err
 	}
-	if res.StatusCode() != 200 {
+	if res.StatusCode() != http.StatusOK && res.StatusCode() != http.StatusCreated {
 		return fmt.Errorf("failed to request %s, status code: %d, message: %s", url, res.StatusCode(), res.String())
 	}
 

--- a/drivers/cnb_releases/util.go
+++ b/drivers/cnb_releases/util.go
@@ -41,3 +41,11 @@ func (d *CnbReleases) Request(method string, path string, callback base.ReqCallb
 
 	return nil
 }
+
+func (d *CnbReleases) sumAssetsSize(assets []ReleaseAsset) int64 {
+	var size int64
+	for _, asset := range assets {
+		size += asset.Size
+	}
+	return size
+}

--- a/drivers/cnb_releases/util.go
+++ b/drivers/cnb_releases/util.go
@@ -1,0 +1,40 @@
+package cnb_releases
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/OpenListTeam/OpenList/v4/drivers/base"
+	log "github.com/sirupsen/logrus"
+)
+
+// do others that not defined in Driver interface
+
+func (d *CnbReleases) Request(method string, path string, callback base.ReqCallback, resp any) error {
+	url := "https://api.cnb.cool" + path
+	req := base.RestyClient.R()
+	req.SetHeader("Accept", "application/json")
+	req.SetAuthScheme("Bearer")
+	req.SetAuthToken(d.Token)
+
+	if callback != nil {
+		callback(req)
+	}
+	res, err := req.Execute(method, url)
+	log.Debugln(res.String())
+	if err != nil {
+		return err
+	}
+	if res.StatusCode() != 200 {
+		return fmt.Errorf("failed to request %s, status code: %d, message: %s", url, res.StatusCode(), res.String())
+	}
+
+	if resp != nil {
+		err = json.Unmarshal(res.Body(), resp)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
增加 CNB Release 驱动

https://cnb.cool/

https://github.com/orgs/OpenListTeam/discussions/1025

TODO: 增加文档

## 参数：

### Repo

仓库。

仅支持填写一个仓库。如需复用 Token，请使用 Reference 功能。

### Token

访问令牌。支持 Reference 功能。

获取：登录后，进入 `个人设置` - [访问令牌](https://cnb.cool/profile/token) -> `添加访问令牌`。目前仅需 `repo-code:rw` 权限。

### UseTagName

使用 Tag 名字而不是 Release 名字。默认关闭。

## 已知问题（请勿反馈）：

1. 发行版不支持子目录
2. OpenAPI 上传返回 `expires_in_sec` 仅为 10 s，上传大文件会超时，超时后仍会继续上传然后返回 `token 无效`，因此增加了本地超时机制，达到上传接口返回的设定时间时自动停止上传，避免上传失败、浪费流量
3. 不支持 Move Copy Rename 操作
4. 仅支持在关闭 UseTagName 时，通过修改 Release 的 name 进行重命名
