### PR TITLE
Fix incorrect path error during upload on Dropbox

### DIFF
--- a/drivers/dropbox/meta.go
+++ b/drivers/dropbox/meta.go
@@ -13,7 +13,7 @@ type Addition struct {
 	ClientSecret    string `json:"client_secret" required:"false" help:"Keep it empty if you don't have one"`
 	AccessToken     string
 	RefreshToken    string `json:"refresh_token" required:"true"`
-	RootNamespaceId string
+	RootNamespaceId string `json:"RootNamespaceId" required:"false"`
 }
 
 var config = driver.Config{

--- a/drivers/dropbox/util.go
+++ b/drivers/dropbox/util.go
@@ -175,6 +175,16 @@ func (d *Dropbox) finishUploadSession(ctx context.Context, toPath string, offset
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Authorization", "Bearer "+d.AccessToken)
+	if d.RootNamespaceId != "" {
+	apiPathRootJson, err := utils.Json.MarshalToString(map[string]interface{}{
+	    ".tag": "root",
+	    "root": d.RootNamespaceId,
+	})
+	if err != nil {
+	    return err
+	}
+	req.Header.Set("Dropbox-API-Path-Root", apiPathRootJson)
+}
 
 	uploadFinishArgs := UploadFinishArgs{
 		Commit: struct {
@@ -219,6 +229,16 @@ func (d *Dropbox) startUploadSession(ctx context.Context) (string, error) {
 	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Authorization", "Bearer "+d.AccessToken)
+	if d.RootNamespaceId != "" {
+	apiPathRootJson, err := utils.Json.MarshalToString(map[string]interface{}{
+	    ".tag": "root",
+	    "root": d.RootNamespaceId,
+	})
+	if err != nil {
+	    return "", err
+	}
+	req.Header.Set("Dropbox-API-Path-Root", apiPathRootJson)
+}
 	req.Header.Set("Dropbox-API-Arg", "{\"close\":false}")
 
 	res, err := base.HttpClient.Do(req)


### PR DESCRIPTION
"Fix the bug mentioned in this issue — caused by a missing header that prevents Dropbox from correctly identifying the path." Reference: https://github.com/OpenListTeam/OpenList/issues/909