### PR TITLE
feat(fs): support get fileobj by path

### DIFF
--- a/drivers/115_open/driver.go
+++ b/drivers/115_open/driver.go
@@ -131,7 +131,7 @@ func (d *Open115) Link(ctx context.Context, file model.Obj, args model.LinkArgs)
 	}, nil
 }
 
-func (d *Open115) GetObjInfo(ctx context.Context, path string) (model.Obj, error) {
+func (d *Open115) Get(ctx context.Context, path string) (model.Obj, error) {
 	if err := d.WaitLimit(ctx); err != nil {
 		return nil, err
 	}

--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -73,14 +73,15 @@ func (d *Alias) Drop(ctx context.Context) error {
 	return nil
 }
 
+func (d *Alias) GetRoot(ctx context.Context) (model.Obj, error) {
+	return &model.Object{
+		Name:     "Root",
+		IsFolder: true,
+		Path:     "/",
+	}, nil
+}
+
 func (d *Alias) Get(ctx context.Context, path string) (model.Obj, error) {
-	if utils.PathEqual(path, "/") {
-		return &model.Object{
-			Name:     "Root",
-			IsFolder: true,
-			Path:     "/",
-		}, nil
-	}
 	root, sub := d.getRootAndPath(path)
 	dsts, ok := d.pathMap[root]
 	if !ok {

--- a/drivers/aliyundrive_open/driver.go
+++ b/drivers/aliyundrive_open/driver.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	stdpath "path"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
@@ -52,6 +54,34 @@ func (d *AliyundriveOpen) Init(ctx context.Context) error {
 	userid := utils.Json.Get(res, "user_id").ToString()
 	d.limiter.free()
 	d.limiter = getLimiterForUser(userid) // Allocate a corresponding limiter for each user.
+
+	d.buildRootPath(ctx)
+	return nil
+}
+
+func (d *AliyundriveOpen) buildRootPath(ctx context.Context) error {
+	d.RootPath = "/"
+	if d.RootFolderID == "root" {
+		return nil
+	}
+	currentFileId := d.RootFolderID
+	var pathSegments []string
+	for currentFileId != "root" {
+		var resp File
+		_, err := d.request(ctx, limiterOther, "/adrive/v1.0/openFile/get", http.MethodPost, func(req *resty.Request) {
+			req.SetBody(base.Json{
+				"drive_id": d.DriveId,
+				"file_id":  currentFileId,
+			}).SetResult(&resp)
+		})
+		if err != nil {
+			return err
+		}
+		pathSegments = append(pathSegments, resp.Name)
+		currentFileId = resp.ParentFileId
+	}
+	slices.Reverse(pathSegments)
+	d.RootPath = stdpath.Join(d.RootPath, stdpath.Join(pathSegments...))
 	return nil
 }
 
@@ -84,8 +114,11 @@ func (d *AliyundriveOpen) GetRoot(ctx context.Context) (model.Obj, error) {
 }
 
 func (d *AliyundriveOpen) Get(ctx context.Context, path string) (model.Obj, error) {
+	if d.RootPath != "/" {
+		path = stdpath.Join(d.RootPath, path)
+	}
 	var resp File
-	_, err := d.request(ctx, limiterLink, "/adrive/v1.0/openFile/get_by_path", http.MethodPost, func(req *resty.Request) {
+	_, err := d.request(ctx, limiterOther, "/adrive/v1.0/openFile/get_by_path", http.MethodPost, func(req *resty.Request) {
 		req.SetBody(base.Json{
 			"drive_id":  d.DriveId,
 			"file_path": path,

--- a/drivers/aliyundrive_open/driver.go
+++ b/drivers/aliyundrive_open/driver.go
@@ -83,6 +83,22 @@ func (d *AliyundriveOpen) GetRoot(ctx context.Context) (model.Obj, error) {
 	}, nil
 }
 
+func (d *AliyundriveOpen) Get(ctx context.Context, path string) (model.Obj, error) {
+	var resp File
+	_, err := d.request(ctx, limiterLink, "/adrive/v1.0/openFile/get_by_path", http.MethodPost, func(req *resty.Request) {
+		req.SetBody(base.Json{
+			"drive_id":  d.DriveId,
+			"file_path": path,
+		}).SetResult(&resp)
+	})
+	if err != nil {
+		return nil, err
+	}
+	obj := fileToObj(resp)
+	obj.Path = path
+	return obj, nil
+}
+
 func (d *AliyundriveOpen) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
 	files, err := d.getFiles(ctx, dir.GetID())
 	if err != nil {

--- a/drivers/aliyundrive_open/meta.go
+++ b/drivers/aliyundrive_open/meta.go
@@ -21,6 +21,7 @@ type Addition struct {
 	InternalUpload     bool   `json:"internal_upload" help:"If you are using Aliyun ECS is located in Beijing, you can turn it on to boost the upload speed"`
 	LIVPDownloadFormat string `json:"livp_download_format" type:"select" options:"jpeg,mov" default:"jpeg"`
 	AccessToken        string
+	RootPath           string
 }
 
 var config = driver.Config{

--- a/drivers/chunk/driver.go
+++ b/drivers/chunk/driver.go
@@ -52,14 +52,15 @@ func (d *Chunk) Drop(ctx context.Context) error {
 	return nil
 }
 
+func (d *Chunk) GetRoot(ctx context.Context) (model.Obj, error) {
+	return &model.Object{
+		Name:     "Root",
+		IsFolder: true,
+		Path:     "/",
+	}, nil
+}
+
 func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {
-	if utils.PathEqual(path, "/") {
-		return &model.Object{
-			Name:     "Root",
-			IsFolder: true,
-			Path:     "/",
-		}, nil
-	}
 	remoteStorage, remoteActualPath, err := op.GetStorageAndActualPath(d.RemotePath)
 	if err != nil {
 		return nil, err

--- a/drivers/crypt/driver.go
+++ b/drivers/crypt/driver.go
@@ -186,14 +186,15 @@ func (d *Crypt) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 	return result, nil
 }
 
+func (d *Crypt) GetRoot(ctx context.Context) (model.Obj, error) {
+	return &model.Object{
+		Name:     "Root",
+		IsFolder: true,
+		Path:     "/",
+	}, nil
+}
+
 func (d *Crypt) Get(ctx context.Context, path string) (model.Obj, error) {
-	if utils.PathEqual(path, "/") {
-		return &model.Object{
-			Name:     "Root",
-			IsFolder: true,
-			Path:     "/",
-		}, nil
-	}
 	remoteFullPath := ""
 	var remoteObj model.Obj
 	var err, err2 error

--- a/drivers/netease_music/driver.go
+++ b/drivers/netease_music/driver.go
@@ -42,14 +42,14 @@ func (d *NeteaseMusic) Drop(ctx context.Context) error {
 	return nil
 }
 
-func (d *NeteaseMusic) Get(ctx context.Context, path string) (model.Obj, error) {
-	if path == "/" {
-		return &model.Object{
-			IsFolder: true,
-			Path:     path,
-		}, nil
-	}
+func (d *NeteaseMusic) GetRoot(ctx context.Context) (model.Obj, error) {
+	return &model.Object{
+		IsFolder: true,
+		Path:     "/",
+	}, nil
+}
 
+func (d *NeteaseMusic) Get(ctx context.Context, path string) (model.Obj, error) {
 	fragments := strings.Split(path, "/")
 	if len(fragments) > 1 {
 		fileName := fragments[1]

--- a/drivers/strm/driver.go
+++ b/drivers/strm/driver.go
@@ -89,14 +89,15 @@ func (d *Strm) Drop(ctx context.Context) error {
 	return nil
 }
 
+func (d *Strm) GetRoot(ctx context.Context) (model.Obj, error) {
+	return &model.Object{
+		Name:     "Root",
+		IsFolder: true,
+		Path:     "/",
+	}, nil
+}
+
 func (d *Strm) Get(ctx context.Context, path string) (model.Obj, error) {
-	if utils.PathEqual(path, "/") {
-		return &model.Object{
-			Name:     "Root",
-			IsFolder: true,
-			Path:     "/",
-		}, nil
-	}
 	root, sub := d.getRootAndPath(path)
 	dsts, ok := d.pathMap[root]
 	if !ok {

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -47,11 +47,6 @@ type Getter interface {
 	Get(ctx context.Context, path string) (model.Obj, error)
 }
 
-type GetObjInfo interface {
-	// GetObjInfo get file info by path
-	GetObjInfo(ctx context.Context, path string) (model.Obj, error)
-}
-
 //type Writer interface {
 //	Mkdir
 //	Move

--- a/internal/op/fs.go
+++ b/internal/op/fs.go
@@ -5,7 +5,6 @@ import (
 	stderrors "errors"
 	stdpath "path"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
@@ -261,32 +260,11 @@ func Link(ctx context.Context, storage driver.Driver, path string, args model.Li
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
 		return nil, nil, errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
-	var (
-		file model.Obj
-		err  error
-	)
-	// use cache directly
-	dir, name := stdpath.Split(stdpath.Join(storage.GetStorage().MountPath, path))
-	if cacheFiles, ok := listCache.Get(strings.TrimSuffix(dir, "/")); ok {
-		for _, f := range cacheFiles {
-			if f.GetName() == name {
-				file = model.UnwrapObj(f)
-				break
-			}
-		}
-	} else {
-		if g, ok := storage.(driver.GetObjInfo); ok {
-			file, err = g.GetObjInfo(ctx, path)
-		} else {
-			file, err = GetUnwrap(ctx, storage, path)
-		}
+	file, err := GetUnwrap(ctx, storage, path)
+	if err != nil {
+		return nil, nil, errors.WithMessage(err, "failed to get file")
 	}
-	if file == nil {
-		if err != nil {
-			return nil, nil, errors.WithMessage(err, "failed to get file")
-		}
-		return nil, nil, errors.WithStack(errs.ObjectNotFound)
-	}
+
 	if file.IsDir() {
 		return nil, nil, errors.WithStack(errs.NotFile)
 	}


### PR DESCRIPTION
给阿里云盘open添加通过路径获取文件或目录信息，加快爆米花，emby等APP的起播速度。

fileobj获取顺序是Get实现路径获取，List向上级缓存查找，再向网盘获取。
以前只有非网盘驱动实现，忽略缓存影响不大，但目前有115open,阿里云盘open也实现，所以提前listcache查找。
