### PR TITLE
feat(server): add error page and status code

### DIFF
--- a/server/common/common.go
+++ b/server/common/common.go
@@ -2,6 +2,9 @@ package common
 
 import (
 	"context"
+	"fmt"
+	"html"
+	"net/http"
 	"strings"
 
 	"github.com/OpenListTeam/OpenList/v4/cmd/flags"
@@ -36,6 +39,41 @@ func ErrorResp(c *gin.Context, err error, code int, l ...bool) {
 	//	Data:    nil,
 	//})
 	//c.Abort()
+}
+
+// ErrorPage is used to return error page HTML.
+// It also returns standard HTTP status code.
+// @param l: if true, log error
+func ErrorPage(c *gin.Context, err error, code int, l ...bool) {
+
+	if len(l) > 0 && l[0] {
+		if flags.Debug || flags.Dev {
+			log.Errorf("%+v", err)
+		} else {
+			log.Errorf("%v", err)
+		}
+	}
+
+	codes := fmt.Sprintf("%d %s", code, http.StatusText(code))
+
+	html := fmt.Sprintf(`<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="color-scheme" content="dark light" />
+		<meta name="robots" content="noindex" />
+		<title>%s</title>
+	</head>
+	<body>
+		<h1>%s</h1>
+		<hr>
+		<p>%s</p>
+	</body>
+</html>`,
+		codes, codes, html.EscapeString(hidePrivacy(err.Error())))
+	c.Data(code, "text/html; charset=utf-8", []byte(html))
+	c.Abort()
 }
 
 func ErrorWithDataResp(c *gin.Context, err error, code int, data interface{}, l ...bool) {

--- a/server/handles/archive.go
+++ b/server/handles/archive.go
@@ -298,7 +298,7 @@ func ArchiveDown(c *gin.Context) {
 	filename := stdpath.Base(innerPath)
 	storage, err := fs.GetStorage(archiveRawPath, &fs.GetStoragesArgs{})
 	if err != nil {
-		common.ErrorResp(c, err, 500)
+		common.ErrorPage(c, err, 500)
 		return
 	}
 	if common.ShouldProxy(storage, filename) {
@@ -318,7 +318,7 @@ func ArchiveDown(c *gin.Context) {
 			InnerPath: innerPath,
 		})
 		if err != nil {
-			common.ErrorResp(c, err, 500)
+			common.ErrorPage(c, err, 500)
 			return
 		}
 		redirect(c, link)
@@ -332,7 +332,7 @@ func ArchiveProxy(c *gin.Context) {
 	filename := stdpath.Base(innerPath)
 	storage, err := fs.GetStorage(archiveRawPath, &fs.GetStoragesArgs{})
 	if err != nil {
-		common.ErrorResp(c, err, 500)
+		common.ErrorPage(c, err, 500)
 		return
 	}
 	if canProxy(storage, filename) {
@@ -348,7 +348,7 @@ func ArchiveProxy(c *gin.Context) {
 			InnerPath: innerPath,
 		})
 		if err != nil {
-			common.ErrorResp(c, err, 500)
+			common.ErrorPage(c, err, 500)
 			return
 		}
 		proxy(c, link, file, storage.GetStorage().ProxyRange)
@@ -373,7 +373,7 @@ func ArchiveInternalExtract(c *gin.Context) {
 		InnerPath: innerPath,
 	})
 	if err != nil {
-		common.ErrorResp(c, err, 500)
+		common.ErrorPage(c, err, 500)
 		return
 	}
 	defer func() {

--- a/server/handles/down.go
+++ b/server/handles/down.go
@@ -26,7 +26,7 @@ func Down(c *gin.Context) {
 	filename := stdpath.Base(rawPath)
 	storage, err := fs.GetStorage(rawPath, &fs.GetStoragesArgs{})
 	if err != nil {
-		common.ErrorResp(c, err, 500)
+		common.ErrorPage(c, err, 500)
 		return
 	}
 	if common.ShouldProxy(storage, filename) {
@@ -40,7 +40,7 @@ func Down(c *gin.Context) {
 			Redirect: true,
 		})
 		if err != nil {
-			common.ErrorResp(c, err, 500)
+			common.ErrorPage(c, err, 500)
 			return
 		}
 		redirect(c, link)
@@ -52,7 +52,7 @@ func Proxy(c *gin.Context) {
 	filename := stdpath.Base(rawPath)
 	storage, err := fs.GetStorage(rawPath, &fs.GetStoragesArgs{})
 	if err != nil {
-		common.ErrorResp(c, err, 500)
+		common.ErrorPage(c, err, 500)
 		return
 	}
 	if canProxy(storage, filename) {
@@ -67,7 +67,7 @@ func Proxy(c *gin.Context) {
 			Type:   c.Query("type"),
 		})
 		if err != nil {
-			common.ErrorResp(c, err, 500)
+			common.ErrorPage(c, err, 500)
 			return
 		}
 		proxy(c, link, file, storage.GetStorage().ProxyRange)
@@ -89,7 +89,7 @@ func redirect(c *gin.Context, link *model.Link) {
 		}
 		link.URL, err = utils.InjectQuery(link.URL, query)
 		if err != nil {
-			common.ErrorResp(c, err, 500)
+			common.ErrorPage(c, err, 500)
 			return
 		}
 	}
@@ -106,7 +106,7 @@ func proxy(c *gin.Context, link *model.Link, file model.Obj, proxyRange bool) {
 		}
 		link.URL, err = utils.InjectQuery(link.URL, query)
 		if err != nil {
-			common.ErrorResp(c, err, 500)
+			common.ErrorPage(c, err, 500)
 			return
 		}
 	}
@@ -149,9 +149,9 @@ func proxy(c *gin.Context, link *model.Link, file model.Obj, proxyRange bool) {
 		log.Errorf("%s %s local proxy error: %+v", c.Request.Method, c.Request.URL.Path, err)
 	} else {
 		if statusCode, ok := errors.Unwrap(err).(net.ErrorHttpStatusCode); ok {
-			common.ErrorResp(c, err, int(statusCode), true)
+			common.ErrorPage(c, err, int(statusCode), true)
 		} else {
-			common.ErrorResp(c, err, 500, true)
+			common.ErrorPage(c, err, 500, true)
 		}
 	}
 }

--- a/server/middlewares/down.go
+++ b/server/middlewares/down.go
@@ -22,7 +22,7 @@ func Down(verifyFunc func(string, string) error) func(c *gin.Context) {
 		meta, err := op.GetNearestMeta(rawPath)
 		if err != nil {
 			if !errors.Is(errors.Cause(err), errs.MetaNotFound) {
-				common.ErrorResp(c, err, 500, true)
+				common.ErrorPage(c, err, 500, true)
 				return
 			}
 		}
@@ -32,7 +32,7 @@ func Down(verifyFunc func(string, string) error) func(c *gin.Context) {
 			s := c.Query("sign")
 			err = verifyFunc(rawPath, strings.TrimSuffix(s, "/"))
 			if err != nil {
-				common.ErrorResp(c, err, 401)
+				common.ErrorPage(c, err, 401)
 				c.Abort()
 				return
 			}


### PR DESCRIPTION
Close: #1086

Only modify the behavior of `/d/*path`, `/p/*path`, `/ad/*path`, `/ap/*path`, `/ae/*path`. 

**Not affect `/api`.**

The API will always respond with a 200 status code, with the actual status code wrapped in a JSON object, like the previous response.

Some error status responses are still under discussion. Returning a `500` status code for all errors may not be the most optimal approach.