### PR TITLE
docs(readme): remove duplicate alipan.com link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Thank you for your support and understanding of the OpenList project.
   - [x] [Thunder](https://pan.xunlei.com)
   - [x] [Lanzou](https://www.lanzou.com)
   - [x] [ILanzou](https://www.ilanzou.com)
-  - [x] [Aliyundrive share](https://www.alipan.com)
   - [x] [Google photo](https://photos.google.com)
   - [x] [Mega.nz](https://mega.nz)
   - [x] [Baidu photo](https://photo.baidu.com)

--- a/README_cn.md
+++ b/README_cn.md
@@ -74,7 +74,6 @@ OpenList 是一个由 OpenList 团队独立维护的开源项目，遵循 AGPL-3
   - [x] [迅雷网盘](https://pan.xunlei.com)
   - [x] [蓝奏云](https://www.lanzou.com)
   - [x] [蓝奏云优享版](https://www.ilanzou.com)
-  - [x] [阿里云盘分享](https://www.alipan.com)
   - [x] [Google 相册](https://photos.google.com)
   - [x] [Mega.nz](https://mega.nz)
   - [x] [百度相册](https://photo.baidu.com)

--- a/README_ja.md
+++ b/README_ja.md
@@ -74,7 +74,6 @@ OpenListプロジェクトへのご支援とご理解をありがとうござい
   - [x] [Thunder](https://pan.xunlei.com)
   - [x] [Lanzou](https://www.lanzou.com)
   - [x] [ILanzou](https://www.ilanzou.com)
-  - [x] [Aliyundrive share](https://www.alipan.com)
   - [x] [Google photo](https://photos.google.com)
   - [x] [Mega.nz](https://mega.nz)
   - [x] [Baidu photo](https://photo.baidu.com)

--- a/README_nl.md
+++ b/README_nl.md
@@ -74,7 +74,6 @@ Dank u voor uw ondersteuning en begrip
   - [x] [Thunder](https://pan.xunlei.com)
   - [x] [Lanzou](https://www.lanzou.com)
   - [x] [ILanzou](https://www.ilanzou.com)
-  - [x] [Aliyundrive share](https://www.alipan.com)
   - [x] [Google photo](https://photos.google.com)
   - [x] [Mega.nz](https://mega.nz)
   - [x] [Baidu photo](https://photo.baidu.com)


### PR DESCRIPTION
## Changes  
Remove duplicate alipan.com link from README
  
## Reason  
- Clean up duplicate links in documentation  
  
## Impact  
- Documentation only, no functional changes  
- No impact on business logic  
  
## Testing  
- [x] Confirmed removed link was duplicate  
- [x] Confirmed remaining link works properly