### PR TITLE
feat(cloudreve_v4): enhance token management

### DIFF
--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -20,7 +20,9 @@ import (
 type CloudreveV4 struct {
 	model.Storage
 	Addition
-	ref *CloudreveV4
+	ref            *CloudreveV4
+	AccessExpires  string
+	RefreshExpires string
 }
 
 func (d *CloudreveV4) Config() driver.Config {
@@ -44,11 +46,14 @@ func (d *CloudreveV4) Init(ctx context.Context) error {
 	if d.ref != nil {
 		return nil
 	}
-	if d.AccessToken == "" && d.RefreshToken != "" {
+	if d.canLogin() {
+		return d.login()
+	}
+	if d.RefreshToken != "" {
 		return d.refreshToken()
 	}
-	if d.Username != "" {
-		return d.login()
+	if d.AccessToken == "" {
+		return errors.New("no way to authenticate. At least AccessToken is required")
 	}
 	return nil
 }

--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -55,7 +55,8 @@ func (d *CloudreveV4) Init(ctx context.Context) error {
 	if d.AccessToken == "" {
 		return errors.New("no way to authenticate. At least AccessToken is required")
 	}
-	return nil
+	// ensure AccessToken is valid
+	return d.parseJWT(d.AccessToken, &AccessJWT{})
 }
 
 func (d *CloudreveV4) InitReference(storage driver.Driver) error {

--- a/drivers/cloudreve_v4/types.go
+++ b/drivers/cloudreve_v4/types.go
@@ -66,6 +66,22 @@ type CaptchaResp struct {
 	Ticket string `json:"ticket"`
 }
 
+type AccessJWT struct {
+	TokenType string `json:"token_type"`
+	Sub       string `json:"sub"`
+	Exp       int64  `json:"exp"`
+	Nbf       int64  `json:"nbf"`
+}
+
+type RefreshJWT struct {
+	TokenType   string `json:"token_type"`
+	Sub         string `json:"sub"`
+	Exp         int    `json:"exp"`
+	Nbf         int    `json:"nbf"`
+	StateHash   string `json:"state_hash"`
+	RootTokenID string `json:"root_token_id"`
+}
+
 type Token struct {
 	AccessToken    string `json:"access_token"`
 	RefreshToken   string `json:"refresh_token"`

--- a/drivers/cloudreve_v4/types.go
+++ b/drivers/cloudreve_v4/types.go
@@ -67,10 +67,10 @@ type CaptchaResp struct {
 }
 
 type Token struct {
-	AccessToken    string    `json:"access_token"`
-	RefreshToken   string    `json:"refresh_token"`
-	AccessExpires  time.Time `json:"access_expires"`
-	RefreshExpires time.Time `json:"refresh_expires"`
+	AccessToken    string `json:"access_token"`
+	RefreshToken   string `json:"refresh_token"`
+	AccessExpires  string `json:"access_expires"`
+	RefreshExpires string `json:"refresh_expires"`
 }
 
 type TokenResponse struct {

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -28,6 +28,15 @@ import (
 
 // do others that not defined in Driver interface
 
+const (
+	CodeLoginRequired     = http.StatusUnauthorized
+	CodeCredentialInvalid = 40020 // Failed to issue token
+)
+
+var (
+	ErrorIssueToken = errors.New("failed to issue token")
+)
+
 func (d *CloudreveV4) getUA() string {
 	if d.CustomUA != "" {
 		return d.CustomUA
@@ -39,6 +48,23 @@ func (d *CloudreveV4) request(method string, path string, callback base.ReqCallb
 	if d.ref != nil {
 		return d.ref.request(method, path, callback, out)
 	}
+
+	// ensure token
+	if d.isTokenExpired() {
+		err := d.refreshToken()
+		if err != nil {
+			return err
+		}
+	}
+
+	return d._request(method, path, callback, out)
+}
+
+func (d *CloudreveV4) _request(method string, path string, callback base.ReqCallback, out any) error {
+	if d.ref != nil {
+		return d.ref._request(method, path, callback, out)
+	}
+
 	u := d.Address + "/api/v4" + path
 	req := base.RestyClient.R()
 	req.SetHeaders(map[string]string{
@@ -65,13 +91,15 @@ func (d *CloudreveV4) request(method string, path string, callback base.ReqCallb
 	}
 
 	if r.Code != 0 {
-		if r.Code == 401 && d.RefreshToken != "" && path != "/session/token/refresh" {
-			// try to refresh token
-			err = d.refreshToken()
+		if r.Code == CodeLoginRequired && d.canLogin() && path != "/session/token/refresh" {
+			err = d.login()
 			if err != nil {
 				return err
 			}
 			return d.request(method, path, callback, out)
+		}
+		if r.Code == CodeCredentialInvalid {
+			return ErrorIssueToken
 		}
 		return fmt.Errorf("%d: %s", r.Code, r.Msg)
 	}
@@ -91,14 +119,18 @@ func (d *CloudreveV4) request(method string, path string, callback base.ReqCallb
 	return nil
 }
 
+func (d *CloudreveV4) canLogin() bool {
+	return d.Username != "" && d.Password != ""
+}
+
 func (d *CloudreveV4) login() error {
 	var siteConfig SiteLoginConfigResp
-	err := d.request(http.MethodGet, "/site/config/login", nil, &siteConfig)
+	err := d._request(http.MethodGet, "/site/config/login", nil, &siteConfig)
 	if err != nil {
 		return err
 	}
 	var prepareLogin PrepareLoginResp
-	err = d.request(http.MethodGet, "/session/prepare?email="+d.Addition.Username, nil, &prepareLogin)
+	err = d._request(http.MethodGet, "/session/prepare?email="+d.Addition.Username, nil, &prepareLogin)
 	if err != nil {
 		return err
 	}
@@ -128,7 +160,7 @@ func (d *CloudreveV4) doLogin(needCaptcha bool) error {
 	}
 	if needCaptcha {
 		var config BasicConfigResp
-		err = d.request(http.MethodGet, "/site/config/basic", nil, &config)
+		err = d._request(http.MethodGet, "/site/config/basic", nil, &config)
 		if err != nil {
 			return err
 		}
@@ -136,7 +168,7 @@ func (d *CloudreveV4) doLogin(needCaptcha bool) error {
 			return fmt.Errorf("captcha type %s not support", config.CaptchaType)
 		}
 		var captcha CaptchaResp
-		err = d.request(http.MethodGet, "/site/captcha", nil, &captcha)
+		err = d._request(http.MethodGet, "/site/captcha", nil, &captcha)
 		if err != nil {
 			return err
 		}
@@ -162,20 +194,22 @@ func (d *CloudreveV4) doLogin(needCaptcha bool) error {
 		loginBody["captcha"] = captchaCode
 	}
 	var token TokenResponse
-	err = d.request(http.MethodPost, "/session/token", func(req *resty.Request) {
+	err = d._request(http.MethodPost, "/session/token", func(req *resty.Request) {
 		req.SetBody(loginBody)
 	}, &token)
 	if err != nil {
 		return err
 	}
 	d.AccessToken, d.RefreshToken = token.Token.AccessToken, token.Token.RefreshToken
+	d.AccessExpires, d.RefreshExpires = token.Token.AccessExpires, token.Token.RefreshExpires
 	op.MustSaveDriverStorage(d)
 	return nil
 }
 
 func (d *CloudreveV4) refreshToken() error {
+	// if no refresh token, try to login if possible
 	if d.RefreshToken == "" {
-		if d.Username != "" {
+		if d.canLogin() {
 			err := d.login()
 			if err != nil {
 				return fmt.Errorf("cannot login to get refresh token, error: %s", err)
@@ -183,18 +217,137 @@ func (d *CloudreveV4) refreshToken() error {
 		}
 		return nil
 	}
+
+	// parse jwt to check if refresh token is valid
+	var jwt struct {
+		TokenType   string `json:"token_type"`
+		Sub         string `json:"sub"`
+		Exp         int    `json:"exp"`
+		Nbf         int    `json:"nbf"`
+		StateHash   string `json:"state_hash"`
+		RootTokenID string `json:"root_token_id"`
+	}
+	err := d.parseJWT(d.RefreshToken, &jwt)
+	if err != nil {
+		// if refresh token is invalid, try to login if possible
+		if d.canLogin() {
+			return d.login()
+		}
+		d.GetStorage().SetStatus(fmt.Sprintf("Invalid RefreshToken: %s", err.Error()))
+		op.MustSaveDriverStorage(d)
+		return fmt.Errorf("invalid refresh token: %w", err)
+	}
+
+	// do refresh token
 	var token Token
-	err := d.request(http.MethodPost, "/session/token/refresh", func(req *resty.Request) {
+	err = d._request(http.MethodPost, "/session/token/refresh", func(req *resty.Request) {
 		req.SetBody(base.Json{
 			"refresh_token": d.RefreshToken,
 		})
 	}, &token)
 	if err != nil {
+		if errors.Is(err, ErrorIssueToken) {
+			if d.canLogin() {
+				// try to login again
+				return d.login()
+			}
+			d.GetStorage().SetStatus("This session is no longer valid")
+			op.MustSaveDriverStorage(d)
+			return ErrorIssueToken
+		}
 		return err
 	}
 	d.AccessToken, d.RefreshToken = token.AccessToken, token.RefreshToken
+	d.AccessExpires, d.RefreshExpires = token.AccessExpires, token.RefreshExpires
 	op.MustSaveDriverStorage(d)
 	return nil
+}
+
+func (d *CloudreveV4) parseJWT(token string, jwt any) error {
+	split := strings.Split(token, ".")
+	if len(split) != 3 {
+		return fmt.Errorf("invalid token length: %d. Ensure the token is a valid JWT", len(split))
+	}
+	data, err := base64.RawURLEncoding.DecodeString(split[1])
+	if err != nil {
+		return fmt.Errorf("invalid token encoding: %w. Ensure the token is a valid JWT", err)
+	}
+	err = json.Unmarshal(data, &jwt)
+	if err != nil {
+		return fmt.Errorf("invalid token content: %w. Ensure the token is a valid JWT", err)
+	}
+	return nil
+}
+
+// check if token is expired
+// https://github.com/cloudreve/frontend/blob/ddfacc1c31c49be03beb71de4cc114c8811038d6/src/session/index.ts#L177-L200
+func (d *CloudreveV4) isTokenExpired() bool {
+	if d.RefreshToken == "" {
+		// login again if username and password is set
+		if d.canLogin() {
+			return true
+		}
+		// no refresh token, cannot refresh
+		return false
+	}
+	if d.AccessToken == "" {
+		return true
+	}
+	var (
+		err     error
+		expires time.Time
+	)
+	// check if token is expired
+	if d.AccessExpires != "" {
+		// use expires field if possible to prevent timezone issue
+		// only available after login or refresh token
+		// 2025-08-28T02:43:07.645109985+08:00
+		expires, err = time.Parse(time.RFC3339Nano, d.AccessExpires)
+		if err != nil {
+			return false
+		}
+	} else {
+		// fallback to parse jwt
+		// if failed, disable the storage
+		var jwt struct {
+			TokenType string `json:"token_type"`
+			Sub       string `json:"sub"`
+			Exp       int64  `json:"exp"`
+			Nbf       int64  `json:"nbf"`
+		}
+		err = d.parseJWT(d.AccessToken, &jwt)
+		if err != nil {
+			d.GetStorage().SetStatus(fmt.Sprintf("Invalid AccessToken: %s", err.Error()))
+			op.MustSaveDriverStorage(d)
+			return false
+		}
+		// may be have timezone issue
+		expires = time.Unix(jwt.Exp, 0)
+	}
+	// add a 10 minutes safe margin
+	ddl := time.Now().Add(10 * time.Minute)
+	if expires.Before(ddl) {
+		// current access token expired, check if refresh token is expired
+		// warning: cannot parse refresh token from jwt, because the exp field is not standard
+		if d.RefreshExpires != "" {
+			refreshExpires, err := time.Parse(time.RFC3339Nano, d.RefreshExpires)
+			if err != nil {
+				return false
+			}
+			if refreshExpires.Before(time.Now()) {
+				// This session is no longer valid
+				if d.canLogin() {
+					// try to login again
+					return true
+				}
+				d.GetStorage().SetStatus("This session is no longer valid")
+				op.MustSaveDriverStorage(d)
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }
 
 func (d *CloudreveV4) upLocal(ctx context.Context, file model.FileStreamer, u FileUploadResp, up driver.UpdateProgress) error {

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -259,15 +259,15 @@ func (d *CloudreveV4) refreshToken() error {
 func (d *CloudreveV4) parseJWT(token string, jwt any) error {
 	split := strings.Split(token, ".")
 	if len(split) != 3 {
-		return fmt.Errorf("invalid token length: %d. Ensure the token is a valid JWT", len(split))
+		return fmt.Errorf("invalid token length: %d, ensure the token is a valid JWT", len(split))
 	}
 	data, err := base64.RawURLEncoding.DecodeString(split[1])
 	if err != nil {
-		return fmt.Errorf("invalid token encoding: %w. Ensure the token is a valid JWT", err)
+		return fmt.Errorf("invalid token encoding: %w, ensure the token is a valid JWT", err)
 	}
 	err = json.Unmarshal(data, &jwt)
 	if err != nil {
-		return fmt.Errorf("invalid token content: %w. Ensure the token is a valid JWT", err)
+		return fmt.Errorf("invalid token content: %w, ensure the token is a valid JWT", err)
 	}
 	return nil
 }

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -73,7 +73,7 @@ func (d *CloudreveV4) request(method string, path string, callback base.ReqCallb
 			}
 			return d.request(method, path, callback, out)
 		}
-		return errors.New(r.Msg)
+		return fmt.Errorf("%d: %s", r.Code, r.Msg)
 	}
 
 	if out != nil && r.Data != nil {

--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -219,14 +219,7 @@ func (d *CloudreveV4) refreshToken() error {
 	}
 
 	// parse jwt to check if refresh token is valid
-	var jwt struct {
-		TokenType   string `json:"token_type"`
-		Sub         string `json:"sub"`
-		Exp         int    `json:"exp"`
-		Nbf         int    `json:"nbf"`
-		StateHash   string `json:"state_hash"`
-		RootTokenID string `json:"root_token_id"`
-	}
+	var jwt RefreshJWT
 	err := d.parseJWT(d.RefreshToken, &jwt)
 	if err != nil {
 		// if refresh token is invalid, try to login if possible
@@ -309,12 +302,7 @@ func (d *CloudreveV4) isTokenExpired() bool {
 	} else {
 		// fallback to parse jwt
 		// if failed, disable the storage
-		var jwt struct {
-			TokenType string `json:"token_type"`
-			Sub       string `json:"sub"`
-			Exp       int64  `json:"exp"`
-			Nbf       int64  `json:"nbf"`
-		}
+		var jwt AccessJWT
 		err = d.parseJWT(d.AccessToken, &jwt)
 		if err != nil {
 			d.GetStorage().SetStatus(fmt.Sprintf("Invalid AccessToken: %s", err.Error()))


### PR DESCRIPTION
<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
-->

## Description / 描述

对 Cloudreve V4 驱动的令牌管理进行了增强，具体包括：

- 在 `CloudreveV4` 结构体中新增了 `AccessExpires` 和 `RefreshExpires` 字段，用于记录访问令牌和刷新令牌的过期时间。
- 优化了初始化和认证流程，增加了令牌过期检查和刷新逻辑，确保在令牌过期前自动刷新或重新登录。
- `Token` 结构体的过期时间字段类型由 `time.Time` 改为 `string`，以便更好地处理时间格式和时区问题。
- 新增了 `isTokenExpired` 方法，支持判断令牌是否过期，并在过期前自动处理刷新或重新登录。
- 对请求流程进行了调整，确保每次请求前都检查令牌有效性，并在必要时刷新令牌或重新登录。
- 增加了错误处理和状态提示，提升了异常情况下的用户体验。

整体提升了 Cloudreve V4 驱动的令牌有效性管理和自动恢复能力。

## Motivation and Context / 背景

容易报错 `failed get objs: failed to list objs: Failed to issue token pair`

<img width="1490" height="312" alt="ac1118bf8fa67c8c3d2f3a0eefb86df0" src="https://github.com/user-attachments/assets/a2f2cced-07ab-43df-b900-a13267f89828" />

## How Has This Been Tested? / 测试

1. 每次 Init 自动刷新 Token

<img width="2266" height="1455" alt="image" src="https://github.com/user-attachments/assets/f0fdd85d-21e4-4310-8bea-ae064e55ecfe" />

2. 如果登录失败，错误信息输出到 Status，同时下线该驱动，避免一直登录错误 CC 源站导致 IP 被封

F5 测试，仅请求一次

3. 增加 JWT 校验，避免用户没复制完整

<img width="1061" height="775" alt="image" src="https://github.com/user-attachments/assets/bc7c49ab-05e6-45c5-837a-989cafdc8dfe" />

4. 处理填写为空的情况

<img width="1254" height="783" alt="image" src="https://github.com/user-attachments/assets/f6eb5d31-d3c8-41b8-992a-e7222d5f2290" />


## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
