### PR TITLE
fix(fs): clear cache after directory rename to ensure consistency

### DIFF
--- a/internal/op/fs.go
+++ b/internal/op/fs.go
@@ -486,12 +486,18 @@ func Rename(ctx context.Context, storage driver.Driver, srcPath, dstName string,
 				updateCacheObj(storage, srcDirPath, srcRawObj, model.WrapObjName(newObj))
 			} else if !utils.IsBool(lazyCache...) {
 				DeleteCache(storage, srcDirPath)
+				if srcRawObj.IsDir() {
+					ClearCache(storage, srcPath)
+				}
 			}
 		}
 	case driver.Rename:
 		err = s.Rename(ctx, srcObj, dstName)
 		if err == nil && !utils.IsBool(lazyCache...) {
 			DeleteCache(storage, srcDirPath)
+			if srcRawObj.IsDir() {
+				ClearCache(storage, srcPath)
+			}
 		}
 	default:
 		return errs.NotImplement


### PR DESCRIPTION
## Description / 描述

 在对文件夹重命名后清除原文件夹下的缓存数据。

## Motivation and Context / 背景

修复缓存问题，复现步骤如下：

1. 原文件夹名称为 dir
2. 点击文件夹列出文件列表 list
3. 修改文件夹名称为 dir-bak
4. 新建文件夹，名称为 dir
5. 点击name，数据显示为原dir文件夹下的数据
6. 强制刷新，显示正常

## How Has This Been Tested? / 测试

1. 原文件夹状态

<img width="1513" height="148" alt="图片" src="https://github.com/user-attachments/assets/3cd5a00e-f5cc-4f1a-8ceb-bff91c9c9cf8" />
<img width="1534" height="204" alt="图片" src="https://github.com/user-attachments/assets/7252a74c-b6a0-455d-97a4-a80575d3c11e" />

2. 重命名文件夹并新建相同名称文件夹
<img width="1512" height="214" alt="图片" src="https://github.com/user-attachments/assets/a165c27b-5428-47e6-a4b6-b2c6e4870efe" />
3. 进入新建立的文件夹
<img width="1536" height="264" alt="图片" src="https://github.com/user-attachments/assets/18e3a908-38f3-41ba-90ba-4d5d20a9d0b6" />
4. 强制刷新
<img width="1545" height="194" alt="图片" src="https://github.com/user-attachments/assets/cfe9d05c-bb12-4e75-9719-427d200378cd" />


## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
