### PR TITLE
feat(alias): support pass through provider

### DIFF
--- a/drivers/alias/meta.go
+++ b/drivers/alias/meta.go
@@ -15,6 +15,7 @@ type Addition struct {
 	DownloadConcurrency int    `json:"download_concurrency" default:"0" required:"false" type:"number" help:"Need to enable proxy"`
 	DownloadPartSize    int    `json:"download_part_size" default:"0" type:"number" required:"false" help:"Need to enable proxy. Unit: KB"`
 	Writable            bool   `json:"writable" type:"bool" default:"false"`
+	ProviderPassThrough bool   `json:"provider_pass_through" type:"bool" default:"false"`
 }
 
 var config = driver.Config{

--- a/internal/model/obj.go
+++ b/internal/model/obj.go
@@ -80,6 +80,10 @@ type SetPath interface {
 	SetPath(path string)
 }
 
+type ObjWithProvider interface {
+	GetProvider() string
+}
+
 func SortFiles(objs []Obj, orderBy, orderDirection string) {
 	if orderBy == "" {
 		return
@@ -166,6 +170,16 @@ func GetUrl(obj Obj) (url string, ok bool) {
 	return url, false
 }
 
+func GetProvider(obj Obj) (string, bool) {
+	if obj, ok := obj.(ObjWithProvider); ok {
+		return obj.GetProvider(), true
+	}
+	if unwrap, ok := obj.(ObjUnwrap); ok {
+		return GetProvider(unwrap.Unwrap())
+	}
+	return "unknown", false
+}
+
 func GetRawObject(obj Obj) *Object {
 	switch v := obj.(type) {
 	case *ObjThumbURL:
@@ -173,6 +187,8 @@ func GetRawObject(obj Obj) *Object {
 	case *ObjThumb:
 		return &v.Object
 	case *ObjectURL:
+		return &v.Object
+	case *ObjectProvider:
 		return &v.Object
 	case *Object:
 		return v

--- a/internal/model/object.go
+++ b/internal/model/object.go
@@ -99,3 +99,16 @@ type ObjThumbURL struct {
 	Thumbnail
 	Url
 }
+
+type Provider struct {
+	Provider string
+}
+
+func (p Provider) GetProvider() string {
+	return p.Provider
+}
+
+type ObjectProvider struct {
+	Object
+	Provider
+}

--- a/server/handles/fsread.go
+++ b/server/handles/fsread.go
@@ -301,8 +301,8 @@ func FsGet(c *gin.Context, req *FsGetReq, user *model.User) {
 	var rawURL string
 
 	storage, err := fs.GetStorage(reqPath, &fs.GetStoragesArgs{})
-	provider := "unknown"
-	if err == nil {
+	provider, ok := model.GetProvider(obj)
+	if !ok && err == nil {
 		provider = storage.Config().Name
 	}
 	if !obj.IsDir() {


### PR DESCRIPTION
## Description / 描述

`aliyundrive_open`等驱动预览视频的方法与其它驱动不同，前端决定是否添加驱动独有预览方式的依据是`/fs/get`响应中的`provider`字段。

本 PR 给`alias`驱动添加了一个选项，开启该选项后，如果文件真实路径不冲突，则会返回文件的真实`provider`，以此实现预览被`alias`代理的`aliyundrive_open`驱动内的视频预览。

## Motivation and Context / 背景

## How Has This Been Tested? / 测试

测试了后端驱动为`aliyundriver_open`的情况

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
