### PR TITLE
feat(local): move deleted files to corresponding locations

### DIFF
--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -375,18 +375,26 @@ func (d *Local) Remove(ctx context.Context, obj model.Obj) error {
 			err = os.Remove(obj.GetPath())
 		}
 	} else {
-		if !utils.Exists(d.RecycleBinPath) {
-			err = os.MkdirAll(d.RecycleBinPath, 0o755)
+		objPath := obj.GetPath()
+		objName := obj.GetName()
+		var relPath string
+		relPath, err = filepath.Rel(d.GetRootPath(), filepath.Dir(objPath))
+		if err != nil {
+			return err
+		}
+		recycleBinPath := filepath.Join(d.RecycleBinPath, relPath)
+		if !utils.Exists(recycleBinPath) {
+			err = os.MkdirAll(recycleBinPath, 0o755)
 			if err != nil {
 				return err
 			}
 		}
 
-		dstPath := filepath.Join(d.RecycleBinPath, obj.GetName())
+		dstPath := filepath.Join(recycleBinPath, objName)
 		if utils.Exists(dstPath) {
-			dstPath = filepath.Join(d.RecycleBinPath, obj.GetName()+"_"+time.Now().Format("20060102150405"))
+			dstPath = filepath.Join(recycleBinPath, objName+"_"+time.Now().Format("20060102150405"))
 		}
-		err = os.Rename(obj.GetPath(), dstPath)
+		err = os.Rename(objPath, dstPath)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
-->

## Description / 描述

<!-- Describe your changes in detail -->
<!-- 详细描述您的更改 -->

When deleting a file from local storage, move the file to the corresponding recycle bin directory.

在删除本地存储的文件时，将该文件移动到回收站对应的目录中。

## Motivation and Context / 背景

<!-- Why is this change required? What problem does it solve? -->
<!-- 为什么需要此更改？它解决了什么问题？ -->

<!-- If it fixes an open issue, please link to the issue here. -->
<!-- 如果修复了一个打开的issue，请在此处链接到该issue -->

Both SMB and OpenList services are running on my NAS. After enabling the recycle bin in SMB, deleted files will be moved to the corresponding directory in the recycle bin. For example, if I want to delete /dir1/file1 and the recycle bin directory set by SMB is /.recycle, then the file will be moved to /.recycle/dir1/file1.

Currently, all deleted files in local storage are moved directly to the root directory of the recycle bin, which may cause confusion and difficulties in management. For example, if I only want to restore files from a specific directory, it is hard to separate them because all files are mixed together; or in a multi-user environment, it is difficult to identify the origin of files deleted by others. The SMB solution can solve these problems well.

我的NAS上同时运行了 SMB 和 OpenList 两个服务。SMB 在设置回收站后，会将被删除的文件移动到回收站对应的目录中。比如我要删除`/dir1/file1`，SMB 设置的回收站目录为 `/.recycle`，那么这个文件就会被移动到 `/.recycle/dir1/file1`。

目前本地存储所有被删除的文件都会直接移动到回收站的根目录，在管理时可能会造成混乱和困惑，比如我只想还原某个目录的文件，但是所有的文件都混在一起难以分离；或者在多人使用中难以辨别其他人删除的文件的来历等。而 SMB 的方案能够很好的解决这个问题。

## How Has This Been Tested? / 测试

<!-- Please describe in detail how you tested your changes. -->
<!-- 请详细描述您如何测试更改 -->

EN:
1. First, build OpenList locally and replace the service on the NAS. The recycle bin folder is configured as /.recycle/openlist.
2. Delete the test file /test/test.txt on the web interface. The file is moved to /.recycle/openlist/test/test.txt, which is as expected.
3. Delete the test directory /test. The directory is moved to /.recycle/openlist/test_20250915095931, which is as expected.

CN:
1. 先在本地构建 openlist，替换 NAS 上的服务，回收站文件夹被配置为 `/.recycle/openlist`
2. 在网页端删除测试文件 `/test/test.txt`，该文件被移动到 `/.recycle/openlist/test/test.txt`，符合预期
3. 删除测试目录 `/test`，该目录被移动到`/.recycle/openlist/test_20250915095931`，符合预期

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [x] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
