### PR TITLE
fix(ftp-server): cannot get obj in uploading state inconsistency window

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/t3rm1n4l/go-mega v0.0.0-20241213151442-a19cff0ec7b5
+	github.com/tchap/go-patricia/v2 v2.3.3
 	github.com/u2takey/ffmpeg-go v0.5.0
 	github.com/upyun/go-sdk/v3 v3.0.4
 	github.com/winfsp/cgofuse v1.6.0
@@ -254,7 +255,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.etcd.io/bbolt v1.4.0 // indirect
 	golang.org/x/arch v0.18.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
+	golang.org/x/sync v0.16.0
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/term v0.33.0 // indirect
 	golang.org/x/text v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -624,6 +624,8 @@ github.com/t3rm1n4l/go-mega v0.0.0-20241213151442-a19cff0ec7b5 h1:Sa+sR8aaAMFwxh
 github.com/t3rm1n4l/go-mega v0.0.0-20241213151442-a19cff0ec7b5/go.mod h1:UdZiFUFu6e2WjjtjxivwXWcwc1N/8zgbkBR9QNucUOY=
 github.com/taruti/bytepool v0.0.0-20160310082835-5e3a9ea56543 h1:6Y51mutOvRGRx6KqyMNo//xk8B8o6zW9/RVmy1VamOs=
 github.com/taruti/bytepool v0.0.0-20160310082835-5e3a9ea56543/go.mod h1:jpwqYA8KUVEvSUJHkCXsnBRJCSKP1BMa81QZ6kvRpow=
+github.com/tchap/go-patricia/v2 v2.3.3 h1:xfNEsODumaEcCcY3gI0hYPZ/PcpVv5ju6RMAhgwZDDc=
+github.com/tchap/go-patricia/v2 v2.3.3/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/tklauser/go-sysconf v0.3.15 h1:VE89k0criAymJ/Os65CSn1IXaol+1wrsFHEB8Ol49K4=
 github.com/tklauser/go-sysconf v0.3.15/go.mod h1:Dmjwr6tYFIseJw7a3dRLJfsHAMXZ3nEnL/aZY+0IuI4=
 github.com/tklauser/numcpus v0.10.0 h1:18njr6LDBk1zuna922MgdjQuJFjrdppsZG60sHGfjso=

--- a/server/ftp.go
+++ b/server/ftp.go
@@ -32,6 +32,7 @@ type FtpMainDriver struct {
 }
 
 func NewMainDriver() (*FtpMainDriver, error) {
+	ftp.InitStage()
 	transferType := ftpserver.TransferTypeASCII
 	if conf.Conf.FTP.DefaultTransferBinary {
 		transferType = ftpserver.TransferTypeBinary

--- a/server/ftp/fsread.go
+++ b/server/ftp/fsread.go
@@ -130,6 +130,9 @@ func Stat(ctx context.Context, path string) (os.FileInfo, error) {
 	if !common.CanAccess(user, meta, reqPath, ctx.Value(conf.MetaPassKey).(string)) {
 		return nil, errs.PermissionDenied
 	}
+	if ret, err := StatStage(reqPath); !errors.Is(err, errs.ObjectNotFound) {
+		return ret, err
+	}
 	obj, err := fs.Get(ctx, reqPath, &fs.GetArgs{})
 	if err != nil {
 		return nil, err

--- a/server/ftp/fsread.go
+++ b/server/ftp/fsread.go
@@ -157,6 +157,8 @@ func List(ctx context.Context, path string) ([]os.FileInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	uploading := ListStage(reqPath)
+	objs = append(objs, uploading...)
 	ret := make([]os.FileInfo, len(objs))
 	for i, obj := range objs {
 		ret[i] = &OsFileInfoAdapter{obj: obj}

--- a/server/ftp/fsup.go
+++ b/server/ftp/fsup.go
@@ -63,10 +63,10 @@ func (f *FileUploadProxy) Read(p []byte) (n int, err error) {
 func (f *FileUploadProxy) Write(p []byte) (n int, err error) {
 	n, err = f.buffer.Write(p)
 	if err != nil {
-		return
+		return n, err
 	}
 	err = stream.ClientUploadLimit.WaitN(f.ctx, n)
-	return
+	return n, err
 }
 
 func (f *FileUploadProxy) Seek(offset int64, whence int) (int64, error) {
@@ -90,7 +90,7 @@ func (f *FileUploadProxy) Close() error {
 	if _, err := f.buffer.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
-	borrow, err := MakeStage(f.buffer, size, f.path)
+	borrow, err := MakeStage(f.ctx, f.buffer, size, f.path)
 	if err != nil {
 		return fmt.Errorf("failed make stage for [%s]: %+v", f.path, err)
 	}
@@ -188,10 +188,10 @@ func (f *FileUploadWithLengthProxy) write(p []byte) (n int, err error) {
 func (f *FileUploadWithLengthProxy) Write(p []byte) (n int, err error) {
 	n, err = f.write(p)
 	if err != nil {
-		return
+		return n, err
 	}
 	err = stream.ClientUploadLimit.WaitN(f.ctx, n)
-	return
+	return n, err
 }
 
 func (f *FileUploadWithLengthProxy) Seek(offset int64, whence int) (int64, error) {

--- a/server/ftp/upload_stage.go
+++ b/server/ftp/upload_stage.go
@@ -1,0 +1,159 @@
+package ftp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/internal/stream"
+	"github.com/tchap/go-patricia/v2/patricia"
+)
+
+var (
+	stage      *patricia.Trie
+	stageMutex sync.Mutex
+)
+
+func init() {
+	stage = patricia.NewTrie(patricia.MaxPrefixPerNode(16))
+	stageMutex = sync.Mutex{}
+}
+
+type uploadingFile struct {
+	file     *os.File
+	size     int64
+	modTime  time.Time
+	refCount int
+}
+
+func MakeStage(buffer *os.File, size int64, path string) (io.Closer, error) {
+	stageMutex.Lock()
+	defer stageMutex.Unlock()
+	prefix := patricia.Prefix(path)
+	f := uploadingFile{
+		file:     buffer,
+		size:     size,
+		modTime:  time.Now(),
+		refCount: 1,
+	}
+	if !stage.Insert(prefix, f) {
+		return nil, errors.New("upload path conflict")
+	}
+	return dropCloser{prefix}, nil
+}
+
+func Borrow(ctx context.Context, path string) (*BorrowedFile, error) {
+	stageMutex.Lock()
+	defer stageMutex.Unlock()
+	prefix := patricia.Prefix(path)
+	v := stage.Get(prefix)
+	if v == nil {
+		return nil, errs.ObjectNotFound
+	}
+	s := v.(*uploadingFile)
+	borrowed, err := os.OpenFile(s.file.Name(), os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed borrow [%s]: %+v", s.file.Name(), err)
+	}
+	s.refCount++
+	return &BorrowedFile{
+		file: borrowed,
+		path: prefix,
+		ctx:  ctx,
+	}, nil
+}
+
+func drop(path patricia.Prefix) {
+	stageMutex.Lock()
+	defer stageMutex.Unlock()
+	v := stage.Get(path)
+	if v == nil {
+		return
+	}
+	s := v.(*uploadingFile)
+	s.refCount--
+	if s.refCount == 0 {
+		_ = s.file.Close()
+		_ = os.RemoveAll(s.file.Name())
+		stage.Delete(path)
+	}
+}
+
+func ListStage(path string) []model.Obj {
+	stageMutex.Lock()
+	defer stageMutex.Unlock()
+	path = path + "/"
+	prefix := patricia.Prefix(path)
+	ret := make([]model.Obj, 0)
+	_ = stage.VisitSubtree(prefix, func(prefix patricia.Prefix, item patricia.Item) error {
+		visit := string(prefix)
+		visitSub := strings.TrimPrefix(visit, path)
+		name, _, nonDirect := strings.Cut(visitSub, "/")
+		if nonDirect {
+			return nil
+		}
+		f := item.(*uploadingFile)
+		ret = append(ret, &model.Object{
+			Path:     visit,
+			Name:     name,
+			Size:     f.size,
+			Modified: f.modTime,
+			IsFolder: false,
+		})
+		return nil
+	})
+	return ret
+}
+
+type dropCloser struct {
+	path patricia.Prefix
+}
+
+func (dc dropCloser) Close() error {
+	drop(dc.path)
+	return nil
+}
+
+type BorrowedFile struct {
+	file *os.File
+	path patricia.Prefix
+	ctx  context.Context
+}
+
+func (f *BorrowedFile) Read(p []byte) (n int, err error) {
+	n, err = f.file.Read(p)
+	if err != nil {
+		return
+	}
+	err = stream.ClientDownloadLimit.WaitN(f.ctx, n)
+	return
+}
+
+func (f *BorrowedFile) ReadAt(p []byte, off int64) (n int, err error) {
+	n, err = f.file.ReadAt(p, off)
+	if err != nil {
+		return
+	}
+	err = stream.ClientDownloadLimit.WaitN(f.ctx, n)
+	return
+}
+
+func (f *BorrowedFile) Seek(offset int64, whence int) (int64, error) {
+	return f.file.Seek(offset, whence)
+}
+
+func (f *BorrowedFile) Write(_ []byte) (n int, err error) {
+	return 0, errs.NotSupport
+}
+
+func (f *BorrowedFile) Close() error {
+	drop(f.path)
+	return f.file.Close()
+}

--- a/server/ftp/upload_stage.go
+++ b/server/ftp/upload_stage.go
@@ -91,12 +91,12 @@ func drop(path patricia.Prefix) {
 	}
 }
 
-func ListStage(path string) []model.Obj {
+func ListStage(path string) map[string]model.Obj {
 	stageMutex.Lock()
 	defer stageMutex.Unlock()
 	path = path + "/"
 	prefix := patricia.Prefix(path)
-	ret := make([]model.Obj, 0)
+	ret := make(map[string]model.Obj)
 	_ = stage.VisitSubtree(prefix, func(prefix patricia.Prefix, item patricia.Item) error {
 		visit := string(prefix)
 		visitSub := strings.TrimPrefix(visit, path)
@@ -105,13 +105,13 @@ func ListStage(path string) []model.Obj {
 			return nil
 		}
 		f := item.(*uploadingFile)
-		ret = append(ret, &model.Object{
+		ret[name] = &model.Object{
 			Path:     visit,
 			Name:     name,
 			Size:     f.size,
 			Modified: f.modTime,
 			IsFolder: false,
-		})
+		}
 		return nil
 	})
 	return ret

--- a/server/sftp.go
+++ b/server/sftp.go
@@ -23,6 +23,7 @@ type SftpDriver struct {
 }
 
 func NewSftpDriver() (*SftpDriver, error) {
+	ftp.InitStage()
 	sftp.InitHostKey()
 	return &SftpDriver{
 		proxyHeader: http.Header{
@@ -50,7 +51,7 @@ func (d *SftpDriver) GetConfig() *sftpd.Config {
 		ServerConfig: serverConfig,
 		HostPort:     conf.Conf.SFTP.Listen,
 		ErrorLogFunc: utils.Log.Error,
-		//DebugLogFunc: utils.Log.Debugf,
+		// DebugLogFunc: utils.Log.Debugf,
 	}
 	return d.config
 }


### PR DESCRIPTION
## Description / 描述

原生 FTP 协议不支持在上传开始之前提交文件大小，上传过程中，文件会先完整传到服务端，得到大小后再从服务端上传到驱动。

服务端上传到驱动的过程是异步进行的，开始之前会先直接向客户端返回“上传成功”，在服务端传输到驱动的过程中，如果客户端访问刚刚上传的文件，会得到`ObjectNotFound`，一些客户端会因此判断上传失败或进行重传。

我通过在服务端上传过程中，用本地的临时文件响应客户端的请求，使用引用计数的方式来保证无论是服务端上传先结束还是客户端请求先结束，最终临时文件都可以被删除。

## Motivation and Context / 背景

Closes #1288

## How Has This Been Tested? / 测试

测试了使用 BCompare 和 FreeFileSync 进行同步，FTP 均成功，SFTP 均不成功，SFTP 不成功的原因推测是二者使用了未实现（因为无法实现）的接口，理论上无法修复。

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
