### PR TITLE
fix(local): cannot mkdir on specific platforms

### DIFF
--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -51,7 +51,7 @@ func (d *Local) Config() driver.Config {
 
 func (d *Local) Init(ctx context.Context) error {
 	if d.MkdirPerm == "" {
-		d.mkdirPerm = 0777
+		d.mkdirPerm = 0o777
 	} else {
 		v, err := strconv.ParseUint(d.MkdirPerm, 8, 32)
 		if err != nil {
@@ -150,6 +150,7 @@ func (d *Local) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 	}
 	return files, nil
 }
+
 func (d *Local) FileInfoToObj(ctx context.Context, f fs.FileInfo, reqPath string, fullPath string) model.Obj {
 	thumb := ""
 	if d.Thumbnail {
@@ -198,7 +199,7 @@ func (d *Local) Get(ctx context.Context, path string) (model.Obj, error) {
 	path = filepath.Join(d.GetRootPath(), path)
 	f, err := os.Stat(path)
 	if err != nil {
-		if strings.Contains(err.Error(), "cannot find the file") {
+		if os.IsNotExist(err) {
 			return nil, errs.ObjectNotFound
 		}
 		return nil, err
@@ -375,7 +376,7 @@ func (d *Local) Remove(ctx context.Context, obj model.Obj) error {
 		}
 	} else {
 		if !utils.Exists(d.RecycleBinPath) {
-			err = os.MkdirAll(d.RecycleBinPath, 0755)
+			err = os.MkdirAll(d.RecycleBinPath, 0o755)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description / 描述

创建文件夹时使用字符串匹配判断错误类型是否为 NotExist，导致某些平台因无法正确判断而无法创建文件夹。

## Motivation and Context / 背景


## How Has This Been Tested? / 测试


## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
