### PR TITLE
fix(lanzou): support acw_sc__v2 and secondary validation for download link

### DIFF
--- a/drivers/lanzou/util.go
+++ b/drivers/lanzou/util.go
@@ -461,22 +461,31 @@ func (d *LanZou) getFilesByShareUrl(shareID, pwd string, sharePageData string) (
 	}
 
 	if err != nil {
-		return nil, err
-	}
+        return nil, err
+    }
 
-	file.Url = res.Header().Get("location")
+    file.Url = res.Header().Get("location")
 
-	// 触发验证
-	if res.StatusCode() != 302 {
-		bodyBytes, _ := io.ReadAll(res.RawBody())
-		res.RawBody().Close()
-		rPageData := string(bodyBytes)
-		param, err = htmlJsonToMap(rPageData)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return &file, nil
+    // 触发验证
+    if res.StatusCode() != 302 {
+        bodyBytes, _ := io.ReadAll(res.RawBody())
+        res.RawBody().Close()
+        rPageData := string(bodyBytes)
+        param, err = htmlJsonToMap(rPageData)
+        if err != nil {
+            return nil, err
+        }
+        param["el"] = "2"
+        time.Sleep(time.Second * 2)
+
+        // 通过验证获取直连
+        data, err := d.post(fmt.Sprint(baseUrl, "/ajax.php"), func(req *resty.Request) { req.SetFormData(param) }, nil)
+        if err != nil {
+            return nil, err
+        }
+        file.Url = utils.Json.Get(data, "url").ToString()
+    }
+    return &file, nil
 }
 
 // 通过分享链接获取文件夹

--- a/drivers/lanzou/util.go
+++ b/drivers/lanzou/util.go
@@ -430,9 +430,36 @@ func (d *LanZou) getFilesByShareUrl(shareID, pwd string, sharePageData string) (
 	file.Time = timeFindReg.FindString(sharePageData)
 
 	// 重定向获取真实链接
-	res, err := base.NoRedirectClient.R().SetHeaders(map[string]string{
-		"accept-language": "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6",
-	}).Get(downloadUrl)
+	var res *resty.Response
+	var vs string
+	for i := 0; i < 3; i++ {
+		res, err = base.NoRedirectClient.R().SetHeaders(map[string]string{
+			"accept-language": "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6",
+			"Referer":         baseUrl,
+		}).SetDoNotParseResponse(true).
+			SetCookie(&http.Cookie{
+				Name:  "acw_sc__v2",
+				Value: vs,
+			}).Get(downloadUrl)
+		if err != nil {
+			return nil, err
+		}
+		if res.StatusCode() == 302 {
+			break
+		}
+		bodyBytes, _ := io.ReadAll(res.RawBody())
+		res.RawBody().Close()
+		bodyStr := string(bodyBytes)
+		if strings.Contains(bodyStr, "acw_sc__v2") {
+			if vs, err = CalcAcwScV2(bodyStr); err != nil {
+				log.Errorf("lanzou: err => acw_sc__v2 validation error  ,data => %s\n", bodyStr)
+				return nil, err
+			}
+			continue
+		}
+		break
+	}
+
 	if err != nil {
 		return nil, err
 	}
@@ -440,21 +467,14 @@ func (d *LanZou) getFilesByShareUrl(shareID, pwd string, sharePageData string) (
 	file.Url = res.Header().Get("location")
 
 	// 触发验证
-	rPageData := res.String()
 	if res.StatusCode() != 302 {
+		bodyBytes, _ := io.ReadAll(res.RawBody())
+		res.RawBody().Close()
+		rPageData := string(bodyBytes)
 		param, err = htmlJsonToMap(rPageData)
 		if err != nil {
 			return nil, err
 		}
-		param["el"] = "2"
-		time.Sleep(time.Second * 2)
-
-		// 通过验证获取直连
-		data, err := d.post(fmt.Sprint(baseUrl, "/ajax.php"), func(req *resty.Request) { req.SetFormData(param) }, nil)
-		if err != nil {
-			return nil, err
-		}
-		file.Url = utils.Json.Get(data, "url").ToString()
 	}
 	return &file, nil
 }

--- a/drivers/lanzou/util.go
+++ b/drivers/lanzou/util.go
@@ -478,7 +478,7 @@ func (d *LanZou) getFilesByShareUrl(shareID, pwd string, sharePageData string) (
         param["el"] = "2"
         time.Sleep(time.Second * 2)
 
-        // 通过验证获取直连
+        // 通过验证获取直链
         data, err := d.post(fmt.Sprint(baseUrl, "/ajax.php"), func(req *resty.Request) { req.SetFormData(param) }, nil)
         if err != nil {
             return nil, err


### PR DESCRIPTION
<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
-->

## Description / 描述

<!-- Describe your changes in detail -->
<!-- 详细描述您的更改 -->
在 `drivers/lanzou/util.go` 的 `getFilesByShareUrl` 函数中，增加了对获取最终下载链接时 `acw_sc__v2` 验证的处理。

当请求下载页面以获取302重定向时，如果服务器返回的是包含 `acw_sc__v2` JavaScript 验证的页面而不是重定向，代码现在会：
1.  解析响应体，计算出 `acw_sc__v2` 的值。
2.  将计算出的值作为 Cookie，重新发起请求。
3.  此过程在一个循环中进行，最多重试3次，以确保能成功获取到真实的下载链接。

## Motivation and Context / 背景

<!-- Why is this change required? What problem does it solve? -->
<!-- 为什么需要此更改？它解决了什么问题？ -->
蓝奏云更新了其安全策略，在获取最终下载链接的步骤中也加入了 `acw_sc__v2` 验证。这导致在没有相应处理的情况下，无法获取到真实的下载地址，从而导致解析失败。

此更改修复了该问题，使程序能够正确处理这种验证，保证蓝奏云分享链接解析功能的稳定性。
- alist输出
<img width="616" height="162" alt="image" src="https://github.com/user-attachments/assets/b4ec9873-3589-44d3-b34b-8446521fe00e" />

- 蓝奏云真实请求
<img width="531" height="193" alt="image" src="https://github.com/user-attachments/assets/f169c1b4-80f5-4329-9e7f-08f85ff26c56" />


<!-- If it fixes an open issue, please link to the issue here. -->
<!-- 如果修复了一个打开的issue，请在此处链接到该issue -->

Closes #XXXX

<!-- or -->
<!-- 或者 -->

Relates to #XXXX

## How Has This Been Tested? / 测试

<!-- Please describe in detail how you tested your changes. -->
<!-- 请详细描述您如何测试更改 -->
通过对触发了 `acw_sc__v2` 验证的蓝奏云文件分享链接进行实际测试，验证了修改后的代码可以成功绕过验证并获取到正确的最终下载地址。

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX