### PR TITLE
fix(alias): stabilize list root result

### DIFF
--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -23,6 +23,7 @@ import (
 type Alias struct {
 	model.Storage
 	Addition
+	rootOrder   []string
 	pathMap     map[string][]string
 	autoFlatten bool
 	oneKey      string
@@ -40,13 +41,18 @@ func (d *Alias) Init(ctx context.Context) error {
 	if d.Paths == "" {
 		return errors.New("paths is required")
 	}
+	paths := strings.Split(d.Paths, "\n")
+	d.rootOrder = make([]string, 0, len(paths))
 	d.pathMap = make(map[string][]string)
-	for _, path := range strings.Split(d.Paths, "\n") {
+	for _, path := range paths {
 		path = strings.TrimSpace(path)
 		if path == "" {
 			continue
 		}
 		k, v := getPair(path)
+		if _, ok := d.pathMap[k]; !ok {
+			d.rootOrder = append(d.rootOrder, k)
+		}
 		d.pathMap[k] = append(d.pathMap[k], v)
 	}
 	if len(d.pathMap) == 1 {
@@ -62,6 +68,7 @@ func (d *Alias) Init(ctx context.Context) error {
 }
 
 func (d *Alias) Drop(ctx context.Context) error {
+	d.rootOrder = nil
 	d.pathMap = nil
 	return nil
 }

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -19,7 +19,7 @@ import (
 func (d *Alias) listRoot(ctx context.Context, withDetails bool) []model.Obj {
 	var objs []model.Obj
 	var wg sync.WaitGroup
-	for k, v := range d.pathMap {
+	for _, k := range d.rootOrder {
 		obj := model.Object{
 			Name:     k,
 			IsFolder: true,
@@ -27,6 +27,7 @@ func (d *Alias) listRoot(ctx context.Context, withDetails bool) []model.Obj {
 		}
 		idx := len(objs)
 		objs = append(objs, &obj)
+		v := d.pathMap[k]
 		if !withDetails || len(v) != 1 {
 			continue
 		}


### PR DESCRIPTION
## Description / 描述

`alias`驱动在没有排序策略时，返回的根目录列表顺序是随机变化的，该 PR 使这个顺序稳定为填写顺序

## Motivation and Context / 背景

## How Has This Been Tested? / 测试

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
