### PR TITLE
fix(drivers): free space underflow if used larger than total space

### DIFF
--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -260,10 +260,7 @@ func (d *Pan123) GetDetails(ctx context.Context) (*model.StorageDetails, error) 
 	}
 	total := userInfo.Data.SpacePermanent + userInfo.Data.SpaceTemp
 	return &model.StorageDetails{
-		DiskUsage: model.DiskUsage{
-			TotalSpace: total,
-			FreeSpace:  total - userInfo.Data.SpaceUsed,
-		},
+		DiskUsage: *model.NewDiskUsageFromUsedAndTotal(userInfo.Data.SpaceUsed, total),
 	}, nil
 }
 

--- a/drivers/aliyundrive/driver.go
+++ b/drivers/aliyundrive/driver.go
@@ -337,10 +337,7 @@ func (d *AliDrive) GetDetails(ctx context.Context) (*model.StorageDetails, error
 	used := utils.Json.Get(res, "drive_used_size").ToUint64()
 	total := utils.Json.Get(res, "drive_total_size").ToUint64()
 	return &model.StorageDetails{
-		DiskUsage: model.DiskUsage{
-			TotalSpace: total,
-			FreeSpace:  total - used,
-		},
+		DiskUsage: *model.NewDiskUsageFromUsedAndTotal(used, total),
 	}, nil
 }
 

--- a/drivers/baidu_netdisk/util.go
+++ b/drivers/baidu_netdisk/util.go
@@ -390,10 +390,7 @@ func (d *BaiduNetdisk) quota(ctx context.Context) (*model.DiskUsage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &model.DiskUsage{
-		TotalSpace: resp.Total,
-		FreeSpace:  resp.Total - resp.Used,
-	}, nil
+	return model.NewDiskUsageFromUsedAndTotal(resp.Used, resp.Total), nil
 }
 
 // func encodeURIComponent(str string) string {

--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -349,10 +349,7 @@ func (d *CloudreveV4) GetDetails(ctx context.Context) (*model.StorageDetails, er
 		return nil, err
 	}
 	return &model.StorageDetails{
-		DiskUsage: model.DiskUsage{
-			TotalSpace: r.Total,
-			FreeSpace:  r.Total - r.Used,
-		},
+		DiskUsage: *model.NewDiskUsageFromUsedAndTotal(r.Used, r.Total),
 	}, nil
 }
 

--- a/drivers/google_drive/driver.go
+++ b/drivers/google_drive/driver.go
@@ -189,10 +189,7 @@ func (d *GoogleDrive) GetDetails(ctx context.Context) (*model.StorageDetails, er
 		return nil, err
 	}
 	return &model.StorageDetails{
-		DiskUsage: model.DiskUsage{
-			TotalSpace: total,
-			FreeSpace:  total - used,
-		},
+		DiskUsage: *model.NewDiskUsageFromUsedAndTotal(used, total),
 	}, nil
 }
 

--- a/drivers/ilanzou/driver.go
+++ b/drivers/ilanzou/driver.go
@@ -412,10 +412,7 @@ func (d *ILanZou) GetDetails(ctx context.Context) (*model.StorageDetails, error)
 	total := utils.Json.Get(res, "map", "totalSize").ToUint64() * 1024
 	used := utils.Json.Get(res, "map", "usedSize").ToUint64() * 1024
 	return &model.StorageDetails{
-		DiskUsage: model.DiskUsage{
-			TotalSpace: total,
-			FreeSpace:  total - used,
-		},
+		DiskUsage: *model.NewDiskUsageFromUsedAndTotal(used, total),
 	}, nil
 }
 

--- a/internal/model/storage.go
+++ b/internal/model/storage.go
@@ -61,6 +61,13 @@ type DiskUsage struct {
 	FreeSpace  uint64 `json:"free_space"`
 }
 
+func NewDiskUsageFromUsedAndTotal(used, total uint64) *DiskUsage {
+	return &DiskUsage{
+		TotalSpace: max(used, total),
+		FreeSpace: total - min(used, total),
+	}
+}
+
 type StorageDetails struct {
 	DiskUsage
 }


### PR DESCRIPTION
## Description / 描述

Fix some drivers free space underflow if used larger than total space

## Motivation and Context / 背景

<img width="286" height="52" alt="screenshot" src="https://github.com/user-attachments/assets/5550be49-b25f-44d7-846a-a2b3aa4eaaef" />

## How Has This Been Tested? / 测试

Not tested, simple fix

## Checklist / 检查清单

- [X] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [X] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
