### PR TITLE
feat(pikpak): support disk usage

### DIFF
--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -260,7 +260,7 @@ func (d *Pan123) GetDetails(ctx context.Context) (*model.StorageDetails, error) 
 	}
 	total := userInfo.Data.SpacePermanent + userInfo.Data.SpaceTemp
 	return &model.StorageDetails{
-		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(userInfo.Data.SpaceUsed, total),
+		DiskUsage: driver.DiskUsageFromUsedAndTotal(userInfo.Data.SpaceUsed, total),
 	}, nil
 }
 

--- a/drivers/123/driver.go
+++ b/drivers/123/driver.go
@@ -260,7 +260,7 @@ func (d *Pan123) GetDetails(ctx context.Context) (*model.StorageDetails, error) 
 	}
 	total := userInfo.Data.SpacePermanent + userInfo.Data.SpaceTemp
 	return &model.StorageDetails{
-		DiskUsage: *model.NewDiskUsageFromUsedAndTotal(userInfo.Data.SpaceUsed, total),
+		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(userInfo.Data.SpaceUsed, total),
 	}, nil
 }
 

--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -146,22 +146,27 @@ func (d *Alias) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 		})
 		if err == nil {
 			tmp, err = utils.SliceConvert(tmp, func(obj model.Obj) (model.Obj, error) {
-				thumb, ok := model.GetThumb(obj)
 				objRes := model.Object{
 					Name:     obj.GetName(),
 					Size:     obj.GetSize(),
 					Modified: obj.ModTime(),
 					IsFolder: obj.IsDir(),
 				}
-				if !ok {
-					return &objRes, nil
+				if thumb, ok := model.GetThumb(obj); ok {
+					return &model.ObjThumb{
+						Object: objRes,
+						Thumbnail: model.Thumbnail{
+							Thumbnail: thumb,
+						},
+					}, nil
 				}
-				return &model.ObjThumb{
-					Object: objRes,
-					Thumbnail: model.Thumbnail{
-						Thumbnail: thumb,
-					},
-				}, nil
+				if details, ok := model.GetStorageDetails(obj); ok {
+					return &model.ObjStorageDetails{
+						Obj:                    &objRes,
+						StorageDetailsWithName: *details,
+					}, nil
+				}
+				return &objRes, nil
 			})
 		}
 		if err == nil {

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -6,6 +6,7 @@ import (
 	stdpath "path"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/errs"
@@ -49,7 +50,9 @@ func (d *Alias) listRoot(ctx context.Context, withDetails bool) []model.Obj {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			details, e := op.GetStorageDetails(ctx, remoteDriver)
+			c, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			details, e := op.GetStorageDetails(c, remoteDriver)
 			if e != nil {
 				if !errors.Is(e, errs.NotImplement) {
 					log.Errorf("failed get %s storage details: %+v", remoteDriver.GetStorage().MountPath, e)

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -54,7 +54,7 @@ func (d *Alias) listRoot(ctx context.Context, withDetails bool) []model.Obj {
 			defer cancel()
 			details, e := op.GetStorageDetails(c, remoteDriver)
 			if e != nil {
-				if !errors.Is(e, errs.NotImplement) {
+				if !errors.Is(e, errs.NotImplement) && !errors.Is(e, errs.StorageNotInit) {
 					log.Errorf("failed get %s storage details: %+v", remoteDriver.GetStorage().MountPath, e)
 				}
 				return

--- a/drivers/aliyundrive/driver.go
+++ b/drivers/aliyundrive/driver.go
@@ -337,7 +337,7 @@ func (d *AliDrive) GetDetails(ctx context.Context) (*model.StorageDetails, error
 	used := utils.Json.Get(res, "drive_used_size").ToUint64()
 	total := utils.Json.Get(res, "drive_total_size").ToUint64()
 	return &model.StorageDetails{
-		DiskUsage: *model.NewDiskUsageFromUsedAndTotal(used, total),
+		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(used, total),
 	}, nil
 }
 

--- a/drivers/aliyundrive/driver.go
+++ b/drivers/aliyundrive/driver.go
@@ -337,7 +337,7 @@ func (d *AliDrive) GetDetails(ctx context.Context) (*model.StorageDetails, error
 	used := utils.Json.Get(res, "drive_used_size").ToUint64()
 	total := utils.Json.Get(res, "drive_total_size").ToUint64()
 	return &model.StorageDetails{
-		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(used, total),
+		DiskUsage: driver.DiskUsageFromUsedAndTotal(used, total),
 	}, nil
 }
 

--- a/drivers/baidu_netdisk/driver.go
+++ b/drivers/baidu_netdisk/driver.go
@@ -369,7 +369,7 @@ func (d *BaiduNetdisk) GetDetails(ctx context.Context) (*model.StorageDetails, e
 	if err != nil {
 		return nil, err
 	}
-	return &model.StorageDetails{DiskUsage: *du}, nil
+	return &model.StorageDetails{DiskUsage: du}, nil
 }
 
 var _ driver.Driver = (*BaiduNetdisk)(nil)

--- a/drivers/baidu_netdisk/util.go
+++ b/drivers/baidu_netdisk/util.go
@@ -391,7 +391,7 @@ func (d *BaiduNetdisk) quota(ctx context.Context) (model.DiskUsage, error) {
 	if err != nil {
 		return model.DiskUsage{}, err
 	}
-	return driver.NewDiskUsageFromUsedAndTotal(resp.Used, resp.Total), nil
+	return driver.DiskUsageFromUsedAndTotal(resp.Used, resp.Total), nil
 }
 
 // func encodeURIComponent(str string) string {

--- a/drivers/baidu_netdisk/util.go
+++ b/drivers/baidu_netdisk/util.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
+	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/errs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
@@ -382,15 +383,15 @@ func (d *BaiduNetdisk) getSliceSize(filesize int64) int64 {
 	return maxSliceSize
 }
 
-func (d *BaiduNetdisk) quota(ctx context.Context) (*model.DiskUsage, error) {
+func (d *BaiduNetdisk) quota(ctx context.Context) (model.DiskUsage, error) {
 	var resp QuotaResp
 	_, err := d.request("https://pan.baidu.com/api/quota", http.MethodGet, func(req *resty.Request) {
 		req.SetContext(ctx)
 	}, &resp)
 	if err != nil {
-		return nil, err
+		return model.DiskUsage{}, err
 	}
-	return model.NewDiskUsageFromUsedAndTotal(resp.Used, resp.Total), nil
+	return driver.NewDiskUsageFromUsedAndTotal(resp.Used, resp.Total), nil
 }
 
 // func encodeURIComponent(str string) string {

--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -349,7 +349,7 @@ func (d *CloudreveV4) GetDetails(ctx context.Context) (*model.StorageDetails, er
 		return nil, err
 	}
 	return &model.StorageDetails{
-		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(r.Used, r.Total),
+		DiskUsage: driver.DiskUsageFromUsedAndTotal(r.Used, r.Total),
 	}, nil
 }
 

--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -349,7 +349,7 @@ func (d *CloudreveV4) GetDetails(ctx context.Context) (*model.StorageDetails, er
 		return nil, err
 	}
 	return &model.StorageDetails{
-		DiskUsage: *model.NewDiskUsageFromUsedAndTotal(r.Used, r.Total),
+		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(r.Used, r.Total),
 	}, nil
 }
 

--- a/drivers/google_drive/driver.go
+++ b/drivers/google_drive/driver.go
@@ -189,7 +189,7 @@ func (d *GoogleDrive) GetDetails(ctx context.Context) (*model.StorageDetails, er
 		return nil, err
 	}
 	return &model.StorageDetails{
-		DiskUsage: *model.NewDiskUsageFromUsedAndTotal(used, total),
+		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(used, total),
 	}, nil
 }
 

--- a/drivers/google_drive/driver.go
+++ b/drivers/google_drive/driver.go
@@ -189,7 +189,7 @@ func (d *GoogleDrive) GetDetails(ctx context.Context) (*model.StorageDetails, er
 		return nil, err
 	}
 	return &model.StorageDetails{
-		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(used, total),
+		DiskUsage: driver.DiskUsageFromUsedAndTotal(used, total),
 	}, nil
 }
 

--- a/drivers/ilanzou/driver.go
+++ b/drivers/ilanzou/driver.go
@@ -412,7 +412,7 @@ func (d *ILanZou) GetDetails(ctx context.Context) (*model.StorageDetails, error)
 	total := utils.Json.Get(res, "map", "totalSize").ToUint64() * 1024
 	used := utils.Json.Get(res, "map", "usedSize").ToUint64() * 1024
 	return &model.StorageDetails{
-		DiskUsage: *model.NewDiskUsageFromUsedAndTotal(used, total),
+		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(used, total),
 	}, nil
 }
 

--- a/drivers/ilanzou/driver.go
+++ b/drivers/ilanzou/driver.go
@@ -412,7 +412,7 @@ func (d *ILanZou) GetDetails(ctx context.Context) (*model.StorageDetails, error)
 	total := utils.Json.Get(res, "map", "totalSize").ToUint64() * 1024
 	used := utils.Json.Get(res, "map", "usedSize").ToUint64() * 1024
 	return &model.StorageDetails{
-		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(used, total),
+		DiskUsage: driver.DiskUsageFromUsedAndTotal(used, total),
 	}, nil
 }
 

--- a/drivers/pikpak/driver.go
+++ b/drivers/pikpak/driver.go
@@ -36,7 +36,6 @@ func (d *PikPak) GetAddition() driver.Additional {
 }
 
 func (d *PikPak) Init(ctx context.Context) (err error) {
-
 	if d.Common == nil {
 		d.Common = &Common{
 			client:       base.NewRestyClient(),
@@ -247,7 +246,7 @@ func (d *PikPak) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 	}
 
 	params := resp.Resumable.Params
-	//endpoint := strings.Join(strings.Split(params.Endpoint, ".")[1:], ".")
+	// endpoint := strings.Join(strings.Split(params.Endpoint, ".")[1:], ".")
 	// web 端上传 返回的endpoint 为 `mypikpak.net` | android 端上传 返回的endpoint 为 `vip-lixian-07.mypikpak.net`·
 	if d.Addition.Platform == "android" {
 		params.Endpoint = "mypikpak.net"
@@ -258,6 +257,27 @@ func (d *PikPak) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 	}
 	// 分片上传
 	return d.UploadByMultipart(ctx, &params, stream.GetSize(), stream, up)
+}
+
+func (d *PikPak) GetDetails(ctx context.Context) (*model.StorageDetails, error) {
+	var about AboutResponse
+	_, err := d.request("https://api-drive.mypikpak.com/drive/v1/about", http.MethodGet, func(req *resty.Request) {
+		req.SetContext(ctx)
+	}, &about)
+	if err != nil {
+		return nil, err
+	}
+	total, err := strconv.ParseUint(about.Quota.Limit, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	used, err := strconv.ParseUint(about.Quota.Usage, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	return &model.StorageDetails{
+		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(used, total),
+	}, nil
 }
 
 // 离线下载文件
@@ -278,7 +298,6 @@ func (d *PikPak) OfflineDownload(ctx context.Context, fileUrl string, parentDir 
 		req.SetContext(ctx).
 			SetBody(requestBody)
 	}, &resp)
-
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +344,6 @@ func (d *PikPak) OfflineList(ctx context.Context, nextPageToken string, phase []
 		req.SetContext(ctx).
 			SetQueryParams(params)
 	}, &resp)
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to get offline list: %w", err)
 	}

--- a/drivers/pikpak/driver.go
+++ b/drivers/pikpak/driver.go
@@ -276,7 +276,7 @@ func (d *PikPak) GetDetails(ctx context.Context) (*model.StorageDetails, error) 
 		return nil, err
 	}
 	return &model.StorageDetails{
-		DiskUsage: driver.NewDiskUsageFromUsedAndTotal(used, total),
+		DiskUsage: driver.DiskUsageFromUsedAndTotal(used, total),
 	}, nil
 }
 

--- a/drivers/pikpak/types.go
+++ b/drivers/pikpak/types.go
@@ -78,7 +78,7 @@ type Media struct {
 
 type UploadTaskData struct {
 	UploadType string `json:"upload_type"`
-	//UPLOAD_TYPE_RESUMABLE
+	// UPLOAD_TYPE_RESUMABLE
 	Resumable *struct {
 		Kind     string   `json:"kind"`
 		Params   S3Params `json:"params"`
@@ -194,4 +194,16 @@ type CaptchaTokenResponse struct {
 	CaptchaToken string `json:"captcha_token"`
 	ExpiresIn    int64  `json:"expires_in"`
 	Url          string `json:"url"`
+}
+
+type AboutResponse struct {
+	Quota struct {
+		Limit         string `json:"limit"`
+		Usage         string `json:"usage"`
+		UsageInTrash  string `json:"usage_in_trash"`
+		IsUnlimited   bool   `json:"is_unlimited"`
+		Complimentary string `json:"complimentary"`
+	} `json:"quota"`
+	ExpiresAt string `json:"expires_at"`
+	UserType  int    `json:"user_type"`
 }

--- a/internal/driver/utils.go
+++ b/internal/driver/utils.go
@@ -62,7 +62,7 @@ type ReaderUpdatingProgress = stream.ReaderUpdatingProgress
 
 type SimpleReaderWithSize = stream.SimpleReaderWithSize
 
-func NewDiskUsageFromUsedAndTotal(used, total uint64) model.DiskUsage {
+func DiskUsageFromUsedAndTotal(used, total uint64) model.DiskUsage {
 	return model.DiskUsage{
 		TotalSpace: max(used, total),
 		FreeSpace:  total - min(used, total),

--- a/internal/driver/utils.go
+++ b/internal/driver/utils.go
@@ -20,7 +20,7 @@ func (p *Progress) Write(b []byte) (n int, err error) {
 	n = len(b)
 	p.Done += int64(n)
 	p.up(float64(p.Done) / float64(p.Total) * 100)
-	return
+	return n, err
 }
 
 func NewProgress(total int64, up UpdateProgress) *Progress {
@@ -61,3 +61,10 @@ type ReaderWithCtx = stream.ReaderWithCtx
 type ReaderUpdatingProgress = stream.ReaderUpdatingProgress
 
 type SimpleReaderWithSize = stream.SimpleReaderWithSize
+
+func NewDiskUsageFromUsedAndTotal(used, total uint64) model.DiskUsage {
+	return model.DiskUsage{
+		TotalSpace: max(used, total),
+		FreeSpace:  total - min(used, total),
+	}
+}

--- a/internal/errs/errors.go
+++ b/internal/errs/errors.go
@@ -12,13 +12,12 @@ var (
 	NotSupport   = errors.New("not support")
 	RelativePath = errors.New("using relative path is not allowed")
 
-	MoveBetweenTwoStorages = errors.New("can't move files between two storages, try to copy")
-	UploadNotSupported     = errors.New("upload not supported")
-
-	MetaNotFound     = errors.New("meta not found")
-	StorageNotFound  = errors.New("storage not found")
-	StreamIncomplete = errors.New("upload/download stream incomplete, possible network issue")
-	StreamPeekFail   = errors.New("StreamPeekFail")
+	UploadNotSupported = errors.New("upload not supported")
+	MetaNotFound       = errors.New("meta not found")
+	StorageNotFound    = errors.New("storage not found")
+	StorageNotInit     = errors.New("storage not init")
+	StreamIncomplete   = errors.New("upload/download stream incomplete, possible network issue")
+	StreamPeekFail     = errors.New("StreamPeekFail")
 
 	UnknownArchiveFormat      = errors.New("unknown archive format")
 	WrongArchivePassword      = errors.New("wrong archive password")

--- a/internal/model/storage.go
+++ b/internal/model/storage.go
@@ -32,7 +32,7 @@ type Proxy struct {
 	WebdavPolicy string `json:"webdav_policy"`
 	ProxyRange   bool   `json:"proxy_range"`
 	DownProxyURL string `json:"down_proxy_url"`
-	//Disable sign for DownProxyURL
+	// Disable sign for DownProxyURL
 	DisableProxySign bool `json:"disable_proxy_sign"`
 }
 
@@ -59,13 +59,6 @@ func (p Proxy) WebdavProxyURL() bool {
 type DiskUsage struct {
 	TotalSpace uint64 `json:"total_space"`
 	FreeSpace  uint64 `json:"free_space"`
-}
-
-func NewDiskUsageFromUsedAndTotal(used, total uint64) *DiskUsage {
-	return &DiskUsage{
-		TotalSpace: max(used, total),
-		FreeSpace: total - min(used, total),
-	}
 }
 
 type StorageDetails struct {

--- a/internal/op/archive.go
+++ b/internal/op/archive.go
@@ -27,7 +27,7 @@ var archiveMetaG singleflight.Group[*model.ArchiveMetaProvider]
 
 func GetArchiveMeta(ctx context.Context, storage driver.Driver, path string, args model.ArchiveMetaArgs) (*model.ArchiveMetaProvider, error) {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return nil, errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return nil, errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	path = utils.FixAndCleanPath(path)
 	key := Key(storage, path)
@@ -163,7 +163,7 @@ var archiveListG singleflight.Group[[]model.Obj]
 
 func ListArchive(ctx context.Context, storage driver.Driver, path string, args model.ArchiveListArgs) ([]model.Obj, error) {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return nil, errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return nil, errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	path = utils.FixAndCleanPath(path)
 	metaKey := Key(storage, path)
@@ -309,7 +309,7 @@ func splitPath(path string) []string {
 
 func ArchiveGet(ctx context.Context, storage driver.Driver, path string, args model.ArchiveListArgs) (model.Obj, model.Obj, error) {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return nil, nil, errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return nil, nil, errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	path = utils.FixAndCleanPath(path)
 	af, err := GetUnwrap(ctx, storage, path)
@@ -364,7 +364,7 @@ var extractG = singleflight.Group[*extractLink]{Remember: true}
 
 func DriverExtract(ctx context.Context, storage driver.Driver, path string, args model.ArchiveInnerArgs) (*model.Link, model.Obj, error) {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return nil, nil, errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return nil, nil, errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	key := stdpath.Join(Key(storage, path), args.InnerPath)
 	if link, ok := extractCache.Get(key); ok {
@@ -480,7 +480,7 @@ func InternalExtract(ctx context.Context, storage driver.Driver, path string, ar
 
 func ArchiveDecompress(ctx context.Context, storage driver.Driver, srcPath, dstDirPath string, args model.ArchiveDecompressArgs, lazyCache ...bool) error {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	srcPath = utils.FixAndCleanPath(srcPath)
 	dstDirPath = utils.FixAndCleanPath(dstDirPath)

--- a/internal/op/fs.go
+++ b/internal/op/fs.go
@@ -116,7 +116,7 @@ func Key(storage driver.Driver, path string) string {
 // List files in storage, not contains virtual file
 func List(ctx context.Context, storage driver.Driver, path string, args model.ListArgs) ([]model.Obj, error) {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return nil, errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return nil, errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	path = utils.FixAndCleanPath(path)
 	log.Debugf("op.List %s", path)
@@ -259,7 +259,7 @@ var errLinkMFileCache = stderrors.New("ErrLinkMFileCache")
 // Link get link, if is an url. should have an expiry time
 func Link(ctx context.Context, storage driver.Driver, path string, args model.LinkArgs) (*model.Link, model.Obj, error) {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return nil, nil, errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return nil, nil, errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	var (
 		file model.Obj
@@ -369,7 +369,7 @@ var mkdirG singleflight.Group[interface{}]
 
 func MakeDir(ctx context.Context, storage driver.Driver, path string, lazyCache ...bool) error {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	path = utils.FixAndCleanPath(path)
 	key := Key(storage, path)
@@ -424,7 +424,7 @@ func MakeDir(ctx context.Context, storage driver.Driver, path string, lazyCache 
 
 func Move(ctx context.Context, storage driver.Driver, srcPath, dstDirPath string, lazyCache ...bool) error {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	srcPath = utils.FixAndCleanPath(srcPath)
 	dstDirPath = utils.FixAndCleanPath(dstDirPath)
@@ -467,7 +467,7 @@ func Move(ctx context.Context, storage driver.Driver, srcPath, dstDirPath string
 
 func Rename(ctx context.Context, storage driver.Driver, srcPath, dstName string, lazyCache ...bool) error {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	srcPath = utils.FixAndCleanPath(srcPath)
 	srcRawObj, err := Get(ctx, storage, srcPath)
@@ -508,7 +508,7 @@ func Rename(ctx context.Context, storage driver.Driver, srcPath, dstName string,
 // Copy Just copy file[s] in a storage
 func Copy(ctx context.Context, storage driver.Driver, srcPath, dstDirPath string, lazyCache ...bool) error {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	srcPath = utils.FixAndCleanPath(srcPath)
 	dstDirPath = utils.FixAndCleanPath(dstDirPath)
@@ -545,7 +545,7 @@ func Copy(ctx context.Context, storage driver.Driver, srcPath, dstDirPath string
 
 func Remove(ctx context.Context, storage driver.Driver, path string) error {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	if utils.PathEqual(path, "/") {
 		return errors.New("delete root folder is not allowed, please goto the manage page to delete the storage instead")
@@ -586,7 +586,7 @@ func Put(ctx context.Context, storage driver.Driver, dstDirPath string, file mod
 		}
 	}()
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	// UrlTree PUT
 	if storage.GetStorage().Driver == "UrlTree" {
@@ -678,7 +678,7 @@ func Put(ctx context.Context, storage driver.Driver, dstDirPath string, file mod
 
 func PutURL(ctx context.Context, storage driver.Driver, dstDirPath, dstName, url string, lazyCache ...bool) error {
 	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
-		return errors.Errorf("storage not init: %s", storage.GetStorage().Status)
+		return errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
 	}
 	dstDirPath = utils.FixAndCleanPath(dstDirPath)
 	_, err := GetUnwrap(ctx, storage, stdpath.Join(dstDirPath, dstName))

--- a/server/handles/storage.go
+++ b/server/handles/storage.go
@@ -50,7 +50,7 @@ func makeStorageResp(c *gin.Context, storages []model.Storage) []*StorageResp {
 			defer cancel()
 			details, err := op.GetStorageDetails(ctx, d)
 			if err != nil {
-				if !errors.Is(err, errs.NotImplement) {
+				if !errors.Is(err, errs.NotImplement) && !errors.Is(err, errs.StorageNotInit) {
 					log.Errorf("failed get %s details: %+v", s.MountPath, err)
 				}
 				return


### PR DESCRIPTION
## Description / 描述

给`pikpak`添加剩余空间显示支持。

重构了`NewDiskUsageFromUsedAndTotal`所在的位置，修复了`alias`的一个小问题。

## Motivation and Context / 背景

## How Has This Been Tested? / 测试

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
