### PR TITLE
feat(onedrive): add ref support

### DIFF
--- a/drivers/onedrive/driver.go
+++ b/drivers/onedrive/driver.go
@@ -38,8 +38,6 @@ func (d *Onedrive) Init(ctx context.Context) error {
 		d.ChunkSize = 5
 	}
 	if d.ref != nil {
-		d.AccessToken = d.ref.AccessToken
-		d.RefreshToken = d.ref.RefreshToken
 		return nil
 	}
 	return d.refreshToken()

--- a/drivers/onedrive/util.go
+++ b/drivers/onedrive/util.go
@@ -73,16 +73,6 @@ func (d *Onedrive) refreshToken() error {
 }
 
 func (d *Onedrive) _refreshToken() error {
-	if d.ref != nil {
-		err := d.ref._refreshToken()
-		if err != nil {
-			return err
-		}
-		d.AccessToken = d.ref.AccessToken
-		d.RefreshToken = d.ref.RefreshToken
-		return nil
-	}
-
 	// 使用在线API刷新Token，无需ClientID和ClientSecret
 	if d.UseOnlineAPI && len(d.APIAddress) > 0 {
 		u := d.APIAddress
@@ -144,14 +134,11 @@ func (d *Onedrive) _refreshToken() error {
 }
 
 func (d *Onedrive) Request(url string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
-	req := base.RestyClient.R()
-
-	token := d.AccessToken
 	if d.ref != nil {
-		token = d.ref.AccessToken
+		return d.ref.Request(url, method, callback, resp)
 	}
-
-	req.SetHeader("Authorization", "Bearer "+token)
+	req := base.RestyClient.R()
+	req.SetHeader("Authorization", "Bearer "+d.AccessToken)
 	if callback != nil {
 		callback(req)
 	}


### PR DESCRIPTION
## Description

Add reference support for OneDrive.

## Motivation and Context

This feature is useful when you want to share multiple paths on OneDrive without having to log in repeatedly.

## How Has This Been Tested?

Tested on my cluster; may require additional testing.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
