### PR TITLE
fix(server/static): handle error when index file fails to open

### DIFF
--- a/server/static/static.go
+++ b/server/static/static.go
@@ -80,16 +80,17 @@ func initIndex(siteConfig SiteConfig) {
 				utils.Log.Fatalf("index.html not exist, you may forget to put dist of frontend to public/dist")
 			}
 			utils.Log.Fatalf("failed to read index.html: %v", err)
+		}else{
+			defer func() {
+				_ = indexFile.Close()
+			}()
+			index, err := io.ReadAll(indexFile)
+			if err != nil {
+				utils.Log.Fatalf("failed to read dist/index.html")
+			}
+			conf.RawIndexHtml = string(index)
+			utils.Log.Debug("Successfully read index.html from static files system")
 		}
-		defer func() {
-			_ = indexFile.Close()
-		}()
-		index, err := io.ReadAll(indexFile)
-		if err != nil {
-			utils.Log.Fatalf("failed to read dist/index.html")
-		}
-		conf.RawIndexHtml = string(index)
-		utils.Log.Debug("Successfully read index.html from static files system")
 	}
 	utils.Log.Debug("Replacing placeholders in index.html...")
 	// Construct the correct manifest path based on basePath


### PR DESCRIPTION
## static.Open,  io.ReadAll a file with nil will cause a crash

Only io.ReadAll after file opening  successfully

## How Has This Been Tested?
```
set: 
conf.Conf.DistDir= ""

......

indexFile, err := static.Open("index.html")
if err != nil {
    if errors.Is(err, fs.ErrNotExist) {
        utils.Log.Fatalf("index.html not exist, you may forget to put dist of frontend to public/dist")
    }
    utils.Log.Fatalf("failed to read index.html: %v", err)
} 
defer func() {
_ = indexFile.Close()
}()

//!!! if error != nil is true, the index file will be nil, io.ReadAll will crash 
index, err := io.ReadAll(indexFile)

```
this panic will repreduc 


- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX