### PR TITLE
fix(alias): nil panic in `ResolveLinkCacheMode`

### DIFF
--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -50,10 +50,6 @@ func (d *Alias) Init(ctx context.Context) error {
 			continue
 		}
 		k, v := getPair(path)
-		_, _, err := op.GetStorageAndActualPath(v)
-		if err != nil {
-			return err
-		}
 		if _, ok := d.pathMap[k]; !ok {
 			d.rootOrder = append(d.rootOrder, k)
 		}


### PR DESCRIPTION
## Description / 描述

- 驱动初始化时检查路径合法性
- 修复驱动路径配置错误时，link 接口报错问题

## Motivation and Context / 背景

当前别名驱动未进行配置检查，因此实际运行过程中可能使用到一个不存在的驱动路径，且在 `ResolveLinkCacheMode` 函数中驱动获取时判断有问题，导致发生空指针异常。

Closes #1518 

## How Has This Been Tested? / 测试

在别名驱动中配置一个不存在的路径，然后访问该驱动，获取任意文件下载地址即可触发500报错。

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
