### PR TITLE
fix(onedrive): direct upload small file error

### DIFF
--- a/drivers/onedrive/driver.go
+++ b/drivers/onedrive/driver.go
@@ -244,11 +244,11 @@ func (d *Onedrive) GetDirectUploadTools() []string {
 }
 
 // GetDirectUploadInfo returns the direct upload info for OneDrive
-func (d *Onedrive) GetDirectUploadInfo(ctx context.Context, _ string, dstDir model.Obj, fileName string, _ int64) (any, error) {
+func (d *Onedrive) GetDirectUploadInfo(ctx context.Context, _ string, dstDir model.Obj, fileName string, fileSize int64) (any, error) {
 	if !d.EnableDirectUpload {
 		return nil, errs.NotImplement
 	}
-	return d.getDirectUploadInfo(ctx, path.Join(dstDir.GetPath(), fileName))
+	return d.getDirectUploadInfo(ctx, path.Join(dstDir.GetPath(), fileName), fileSize)
 }
 
 var _ driver.Driver = (*Onedrive)(nil)


### PR DESCRIPTION
https://github.com/OpenListTeam/OpenList-Frontend/pull/279

## Description / 描述

- Simply remove the `file.size > chunkSize` check in the Frontend.

## Motivation and Context / 背景

Relates to #249  

When uploading files (`size <= ChunkSize`), server side uses `upBig` logic (for chunked upload) to request for the upload url, therefore the PUT request needs a header `Content-Range`.

But in frontend `uploadSingle` don't specify this header. Causing `Upload failed with status 400`.

```json
{"error":{"code":"invalidRequest","message":"The Content-Range header is missing or malformed."}}
```

## How Has This Been Tested? / 测试

0 < `smallFileLimit` (e.g. 4mb) < default `ChunkSize` (e.g. 5mb)

So there are 3 situations:

- `3.5mb`: Server uses `upSmall` logic, Client receives `ChunkSize = 0` and uses `uploadSingle`
- `4.5mb`: Server uses `upBig` logic, Client receives `ChunkSize > 0` and uses `uploadChunk` but `ChunkCount = 1` (1 PUT request)
- `5.5mb`: Server uses `upBig` logic, Client receives `ChunkSize > 0` and uses `uploadChunk` but `ChunkCount > 1` (multiple PUT requests)

```bash
fallocate -l 3.5M 3.5M.bin
fallocate -l 4.5M 4.5M.bin
fallocate -l 5.5M 5.5M.bin
```

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
