### PR TITLE
feat(baidu_netdisk): Add shard upload timeout setting

### DIFF
--- a/drivers/baidu_netdisk/driver.go
+++ b/drivers/baidu_netdisk/driver.go
@@ -58,8 +58,13 @@ func (d *BaiduNetdisk) GetAddition() driver.Additional {
 }
 
 func (d *BaiduNetdisk) Init(ctx context.Context) error {
+	timeout := DEFAULT_UPLOAD_SLICE_TIMEOUT
+	if d.UploadSliceTimeout > 0 {
+		timeout = time.Second * time.Duration(d.UploadSliceTimeout)
+	}
+
 	d.upClient = base.NewRestyClient().
-		SetTimeout(UPLOAD_TIMEOUT).
+		SetTimeout(timeout).
 		SetRetryCount(UPLOAD_RETRY_COUNT).
 		SetRetryWaitTime(UPLOAD_RETRY_WAIT_TIME).
 		SetRetryMaxWaitTime(UPLOAD_RETRY_MAX_WAIT_TIME)

--- a/drivers/baidu_netdisk/meta.go
+++ b/drivers/baidu_netdisk/meta.go
@@ -19,6 +19,7 @@ type Addition struct {
 	AccessToken           string
 	RefreshToken          string `json:"refresh_token" required:"true"`
 	UploadThread          string `json:"upload_thread" default:"3" help:"1<=thread<=32"`
+	UploadSliceTimeout    int    `json:"upload_timeout" type:"number" default:"60" help:"per-slice upload timeout in seconds"`
 	UploadAPI             string `json:"upload_api" default:"https://d.pcs.baidu.com"`
 	UseDynamicUploadAPI   bool   `json:"use_dynamic_upload_api" default:"true" help:"dynamically get upload api domain, when enabled, the 'Upload API' setting will be used as a fallback if failed to get"`
 	CustomUploadPartSize  int64  `json:"custom_upload_part_size" type:"number" default:"0" help:"0 for auto"`
@@ -27,12 +28,12 @@ type Addition struct {
 }
 
 const (
-	UPLOAD_FALLBACK_API        = "https://d.pcs.baidu.com" // 备用上传地址
-	UPLOAD_URL_EXPIRE_TIME     = time.Minute * 60          // 上传地址有效期(分钟)
-	UPLOAD_TIMEOUT             = time.Minute * 30          // 上传请求超时时间
-	UPLOAD_RETRY_COUNT         = 3
-	UPLOAD_RETRY_WAIT_TIME     = time.Second * 1
-	UPLOAD_RETRY_MAX_WAIT_TIME = time.Second * 5
+	UPLOAD_FALLBACK_API          = "https://d.pcs.baidu.com" // 备用上传地址
+	UPLOAD_URL_EXPIRE_TIME       = time.Minute * 60          // 上传地址有效期(分钟)
+	DEFAULT_UPLOAD_SLICE_TIMEOUT = time.Second * 60          // 上传分片请求默认超时时间
+	UPLOAD_RETRY_COUNT           = 3
+	UPLOAD_RETRY_WAIT_TIME       = time.Second * 1
+	UPLOAD_RETRY_MAX_WAIT_TIME   = time.Second * 5
 )
 
 var config = driver.Config{


### PR DESCRIPTION
## Description / 描述

增加了自定义分片上传的超时时间

## Motivation and Context / 背景

在最近版本的修复中，分片上传的超时时间被设置为较久

加上百度的抽风问题，上传速度特别特别慢的情况下，有时候不如让它直接失败重试效率更高

无论是否启动动态上传域名，都无法避免个别任务会出现上传速度特别慢的情况，在失败重试后又正常


## How Has This Been Tested? / 测试


## Checklist / 检查清单


- [X] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [X] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [X] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) OpenListTeam/OpenList-Frontend#283
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
