### PR TITLE
chore(archive): fix struct literal uses unkeyed fields

### DIFF
--- a/internal/archive/rardecode/rardecode.go
+++ b/internal/archive/rardecode/rardecode.go
@@ -22,7 +22,7 @@ func (RarDecoder) AcceptedExtensions() []string {
 
 func (RarDecoder) AcceptedMultipartExtensions() map[string]tool.MultipartExtension {
 	return map[string]tool.MultipartExtension{
-		".part1.rar": {regexp.MustCompile("^.*\\.part(\\d+)\\.rar$"), 2},
+		".part1.rar": {PartFileFormat: regexp.MustCompile(`^.*\.part(\d+)\.rar$`), SecondPartIndex: 2},
 	}
 }
 

--- a/internal/archive/sevenzip/sevenzip.go
+++ b/internal/archive/sevenzip/sevenzip.go
@@ -19,7 +19,7 @@ func (SevenZip) AcceptedExtensions() []string {
 
 func (SevenZip) AcceptedMultipartExtensions() map[string]tool.MultipartExtension {
 	return map[string]tool.MultipartExtension{
-		".7z.001": {regexp.MustCompile("^.*\\.7z\\.(\\d+)$"), 2},
+		".7z.001": {PartFileFormat: regexp.MustCompile(`^.*\.7z\.(\d+)$`), SecondPartIndex: 2},
 	}
 }
 

--- a/internal/archive/zip/zip.go
+++ b/internal/archive/zip/zip.go
@@ -22,8 +22,8 @@ func (z *Zip) AcceptedExtensions() []string {
 
 func (z *Zip) AcceptedMultipartExtensions() map[string]tool.MultipartExtension {
 	return map[string]tool.MultipartExtension{
-		".zip":     {regexp.MustCompile("^.*\\.z(\\d+)$"), 1},
-		".zip.001": {regexp.MustCompile("^.*\\.zip\\.(\\d+)$"), 2},
+		".zip":     {PartFileFormat: regexp.MustCompile(`^.*\.z(\d+)$`), SecondPartIndex: 1},
+		".zip.001": {PartFileFormat: regexp.MustCompile(`^.*\.zip\.(\d+)$`), SecondPartIndex: 2},
 	}
 }
 
@@ -135,6 +135,6 @@ var _ tool.Tool = (*Zip)(nil)
 
 func init() {
 	tool.RegisterTool(&Zip{
-		traditionalSecondPartRegExp: regexp.MustCompile("^.*\\.z0*1$"),
+		traditionalSecondPartRegExp: regexp.MustCompile(`^.*\.z0*1$`),
 	})
 }


### PR DESCRIPTION
## Description / 描述

fix struct literal uses unkeyed fields

## Motivation and Context

## How Has This Been Tested?

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.

- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).

- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).

- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
