### PR TITLE
chore(pkg/aria2): simplify context cancellation handling in RPC calls

### DIFF
--- a/pkg/aria2/rpc/call.go
+++ b/pkg/aria2/rpc/call.go
@@ -69,14 +69,11 @@ func (h *httpCaller) setNotifier(ctx context.Context, u url.URL, notifier Notifi
 	go func() {
 		defer h.wg.Done()
 		defer conn.Close()
-		select {
-		case <-ctx.Done():
-			conn.SetWriteDeadline(time.Now().Add(time.Second))
-			if err := conn.WriteMessage(websocket.CloseMessage,
-				websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")); err != nil {
-				log.Printf("sending websocket close message: %v", err)
-			}
-			return
+		<-ctx.Done()
+		conn.SetWriteDeadline(time.Now().Add(time.Second))
+		if err := conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")); err != nil {
+			log.Printf("sending websocket close message: %v", err)
 		}
 	}()
 	h.wg.Add(1)
@@ -251,11 +248,9 @@ func (w websocketCaller) Call(method string, params, reply interface{}) (err err
 		return errors.New("sending channel blocking")
 	}
 
-	select {
-	case <-ctx.Done():
-		if err := ctx.Err(); err == context.DeadlineExceeded {
-			return err
-		}
+	<-ctx.Done()
+	if err := ctx.Err(); err == context.DeadlineExceeded {
+		return err
 	}
 	return
 }


### PR DESCRIPTION
## Description / 描述

Refactored the use of select statements to direct channel receives for context cancellation in setNotifier and Call methods. This streamlines the code and improves readability without changing functionality.

## Motivation and Context

## How Has This Been Tested?

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.

- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).

- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).

- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
