### PR TITLE
fix(pkg/aria2): use pointer receivers for Call methods

### DIFF
--- a/pkg/aria2/rpc/call.go
+++ b/pkg/aria2/rpc/call.go
@@ -120,7 +120,7 @@ func (h *httpCaller) setNotifier(ctx context.Context, u url.URL, notifier Notifi
 	return
 }
 
-func (h httpCaller) Call(method string, params, reply interface{}) (err error) {
+func (h *httpCaller) Call(method string, params, reply interface{}) (err error) {
 	payload, err := EncodeClientRequest(method, params)
 	if err != nil {
 		return
@@ -236,7 +236,7 @@ func (w *websocketCaller) Close() (err error) {
 	return
 }
 
-func (w websocketCaller) Call(method string, params, reply interface{}) (err error) {
+func (w *websocketCaller) Call(method string, params, reply interface{}) (err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), w.timeout)
 	defer cancel()
 	select {


### PR DESCRIPTION
## Description / 描述

Changed the Call methods in httpCaller and websocketCaller to use pointer receivers instead of value receivers. This ensures that any modifications to the receiver's state within the method are preserved and aligns with Go best practices for methods that may modify receiver state.

## Motivation and Context

## How Has This Been Tested?

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.

- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).

- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).

- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
