### PR TITLE
refactor!(userAgent): merge most userAgent into base

### DIFF
--- a/drivers/189/util.go
+++ b/drivers/189/util.go
@@ -107,7 +107,7 @@ import (
 //	res, err = d.client.R().
 //		SetHeaders(map[string]string{
 //			"lt":         lt,
-//			"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
+//			"User-Agent": base.UserAgentNT,
 //			"Referer":    "https://open.e.189.cn/",
 //			"accept":     "application/json;charset=UTF-8",
 //		}).SetFormData(map[string]string{

--- a/drivers/aliyundrive_open/util.go
+++ b/drivers/aliyundrive_open/util.go
@@ -38,7 +38,6 @@ func (d *AliyundriveOpen) _refreshToken(ctx context.Context) (string, string, er
 			return "", "", err
 		}
 		_, err = base.RestyClient.R().
-			SetHeader("User-Agent", "Mozilla/5.0 (Macintosh; Apple macOS 15_5) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/138.0.0.0 Openlist/425.6.30").
 			SetResult(&resp).
 			SetQueryParams(map[string]string{
 				"refresh_ui": d.RefreshToken,

--- a/drivers/baidu_netdisk/util.go
+++ b/drivers/baidu_netdisk/util.go
@@ -42,7 +42,6 @@ func (d *BaiduNetdisk) _refreshToken() error {
 			ErrorMessage string `json:"text"`
 		}
 		_, err := base.RestyClient.R().
-			SetHeader("User-Agent", "Mozilla/5.0 (Macintosh; Apple macOS 15_5) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/138.0.0.0 Openlist/425.6.30").
 			SetResult(&resp).
 			SetQueryParams(map[string]string{
 				"refresh_ui": d.RefreshToken,

--- a/drivers/base/client.go
+++ b/drivers/base/client.go
@@ -15,8 +15,11 @@ var (
 	RestyClient      *resty.Client
 	HttpClient       *http.Client
 )
-var UserAgent = "Mozilla/5.0 (Macintosh; Apple macOS 15_5) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/138.0.0.0"
+
 var DefaultTimeout = time.Second * 30
+
+const UserAgent = "Mozilla/5.0 (Macintosh; Apple macOS 26_1_0) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/142.0.0.0 OpenList/425.6.30"
+const UserAgentNT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/142.0.0.0 OpenList/425.6.30"
 
 func InitClient() {
 	NoRedirectClient = resty.New().SetRedirectPolicy(

--- a/drivers/doubao/util.go
+++ b/drivers/doubao/util.go
@@ -62,7 +62,7 @@ const (
 	VideoDataType    = "video"
 	DefaultChunkSize = int64(5 * 1024 * 1024) // 5MB
 	MaxRetryAttempts = 3                      // 最大重试次数
-	UserAgent        = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36"
+	UserAgent        = base.UserAgentNT
 	Region           = "cn-north-1"
 	UploadTimeout    = 3 * time.Minute
 )

--- a/drivers/doubao_share/util.go
+++ b/drivers/doubao_share/util.go
@@ -43,7 +43,7 @@ const (
 	FileDataType  = "file"
 	ImgDataType   = "image"
 	VideoDataType = "video"
-	UserAgent     = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36"
+	UserAgent     = base.UserAgentNT
 )
 
 func (d *DoubaoShare) request(path string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {

--- a/drivers/dropbox/util.go
+++ b/drivers/dropbox/util.go
@@ -24,7 +24,6 @@ func (d *Dropbox) refreshToken() error {
 			ErrorMessage string `json:"text"`
 		}
 		_, err := base.RestyClient.R().
-			SetHeader("User-Agent", "Mozilla/5.0 (Macintosh; Apple macOS 15_5) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/138.0.0.0 Openlist/425.6.30").
 			SetResult(&resp).
 			SetQueryParams(map[string]string{
 				"refresh_ui": d.RefreshToken,
@@ -176,12 +175,12 @@ func (d *Dropbox) finishUploadSession(ctx context.Context, toPath string, offset
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Authorization", "Bearer "+d.AccessToken)
 	if d.RootNamespaceId != "" {
-	apiPathRootJson, err := d.buildPathRootHeader()
-	if err != nil {
-	    return err
+		apiPathRootJson, err := d.buildPathRootHeader()
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Dropbox-API-Path-Root", apiPathRootJson)
 	}
-	req.Header.Set("Dropbox-API-Path-Root", apiPathRootJson)
-}
 
 	uploadFinishArgs := UploadFinishArgs{
 		Commit: struct {
@@ -227,12 +226,12 @@ func (d *Dropbox) startUploadSession(ctx context.Context) (string, error) {
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Authorization", "Bearer "+d.AccessToken)
 	if d.RootNamespaceId != "" {
-	apiPathRootJson, err := d.buildPathRootHeader()
-	if err != nil {
-	    return "", err
+		apiPathRootJson, err := d.buildPathRootHeader()
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Dropbox-API-Path-Root", apiPathRootJson)
 	}
-	req.Header.Set("Dropbox-API-Path-Root", apiPathRootJson)
-}
 	req.Header.Set("Dropbox-API-Arg", "{\"close\":false}")
 
 	res, err := base.HttpClient.Do(req)
@@ -249,9 +248,8 @@ func (d *Dropbox) startUploadSession(ctx context.Context) (string, error) {
 }
 
 func (d *Dropbox) buildPathRootHeader() (string, error) {
-    return utils.Json.MarshalToString(map[string]interface{}{
-        ".tag": "root",
-        "root": d.RootNamespaceId,
-    })
+	return utils.Json.MarshalToString(map[string]interface{}{
+		".tag": "root",
+		"root": d.RootNamespaceId,
+	})
 }
-

--- a/drivers/google_drive/util.go
+++ b/drivers/google_drive/util.go
@@ -58,7 +58,6 @@ func (d *GoogleDrive) refreshToken() error {
 			ErrorMessage string `json:"text"`
 		}
 		_, err := base.RestyClient.R().
-			SetHeader("User-Agent", "Mozilla/5.0 (Macintosh; Apple macOS 15_5) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/138.0.0.0 Openlist/425.6.30").
 			SetResult(&resp).
 			SetQueryParams(map[string]string{
 				"refresh_ui": d.RefreshToken,

--- a/drivers/ilanzou/driver.go
+++ b/drivers/ilanzou/driver.go
@@ -152,8 +152,7 @@ func (d *ILanZou) Link(ctx context.Context, file model.Obj, args model.LinkArgs)
 	req := base.NoRedirectClient.R()
 
 	req.SetHeaders(map[string]string{
-		"Referer":    d.conf.site + "/",
-		"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0",
+		"Referer": d.conf.site + "/",
 	})
 	if d.Addition.Ip != "" {
 		req.SetHeader("X-Forwarded-For", d.Addition.Ip)

--- a/drivers/ilanzou/util.go
+++ b/drivers/ilanzou/util.go
@@ -71,9 +71,8 @@ func (d *ILanZou) request(pathname, method string, callback base.ReqCallback, pr
 	req.SetHeaders(map[string]string{
 		"Origin":          d.conf.site,
 		"Referer":         d.conf.site + "/",
-		"User-Agent":      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36 Edg/125.0.0.0",
-		"Accept-Encoding": "gzip, deflate, br, zstd",
-		"Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6,mt;q=0.5",
+		"Accept-Encoding": "gzip",
+		"Accept-Language": "zh-CN,zh;q=0.9,en-US,en;q=0.8",
 	})
 
 	if d.Addition.Ip != "" {

--- a/drivers/lanzou/driver.go
+++ b/drivers/lanzou/driver.go
@@ -31,7 +31,7 @@ func (d *LanZou) GetAddition() driver.Additional {
 
 func (d *LanZou) Init(ctx context.Context) (err error) {
 	if d.UserAgent == "" {
-		d.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.39 (KHTML, like Gecko) Chrome/89.0.4389.111 Safari/537.39"
+		d.UserAgent = base.UserAgentNT
 	}
 	switch d.Type {
 	case "account":

--- a/drivers/lanzou/meta.go
+++ b/drivers/lanzou/meta.go
@@ -17,7 +17,7 @@ type Addition struct {
 	SharePassword  string `json:"share_password"`
 	BaseUrl        string `json:"baseUrl" required:"true" default:"https://pc.woozooo.com" help:"basic URL for file operation"`
 	ShareUrl       string `json:"shareUrl" required:"true" default:"https://pan.lanzoui.com" help:"used to get the sharing page"`
-	UserAgent      string `json:"user_agent" required:"true" default:"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.39 (KHTML, like Gecko) Chrome/89.0.4389.111 Safari/537.39"`
+	UserAgent      string `json:"user_agent" required:"true" default:"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.39 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.39"`
 	RepairFileInfo bool   `json:"repair_file_info" help:"To use webdav, you need to enable it"`
 }
 

--- a/drivers/mediafire/meta.go
+++ b/drivers/mediafire/meta.go
@@ -15,6 +15,7 @@ Final opts by @Suyunjing @j2rong4cn @KirCute @Da3zKi7
 */
 
 import (
+	"github.com/OpenListTeam/OpenList/v4/drivers/base"
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
 )
@@ -49,13 +50,11 @@ var config = driver.Config{
 func init() {
 	op.RegisterDriver(func() driver.Driver {
 		return &Mediafire{
-			appBase:         "https://app.mediafire.com",
-			apiBase:         "https://www.mediafire.com/api/1.5",
-			hostBase:        "https://www.mediafire.com",
-			maxRetries:      3,
-			secChUa:         "\"Not)A;Brand\";v=\"8\", \"Chromium\";v=\"139\", \"Google Chrome\";v=\"139\"",
-			secChUaPlatform: "Windows",
-			userAgent:       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+			appBase:    "https://app.mediafire.com",
+			apiBase:    "https://www.mediafire.com/api/1.5",
+			hostBase:   "https://www.mediafire.com",
+			maxRetries: 3,
+			userAgent:  base.UserAgent,
 		}
 	})
 }

--- a/drivers/onedrive/util.go
+++ b/drivers/onedrive/util.go
@@ -82,7 +82,6 @@ func (d *Onedrive) _refreshToken() error {
 			ErrorMessage string `json:"text"`
 		}
 		_, err := base.RestyClient.R().
-			SetHeader("User-Agent", "Mozilla/5.0 (Macintosh; Apple macOS 15_5) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/138.0.0.0 Openlist/425.6.30").
 			SetResult(&resp).
 			SetQueryParams(map[string]string{
 				"refresh_ui": d.RefreshToken,

--- a/drivers/quark_open/util.go
+++ b/drivers/quark_open/util.go
@@ -441,7 +441,6 @@ func (d *QuarkOpen) _refreshToken() (string, string, error) {
 		u := d.APIAddress
 		var resp RefreshTokenOnlineAPIResp
 		_, err := base.RestyClient.R().
-			SetHeader("User-Agent", "Mozilla/5.0 (Macintosh; Apple macOS 15_5) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/138.0.0.0 Openlist/425.6.30").
 			SetResult(&resp).
 			SetQueryParams(map[string]string{
 				"refresh_ui": d.RefreshToken,

--- a/drivers/yandex_disk/util.go
+++ b/drivers/yandex_disk/util.go
@@ -23,7 +23,6 @@ func (d *YandexDisk) refreshToken() error {
 			ErrorMessage string `json:"text"`
 		}
 		_, err := base.RestyClient.R().
-			SetHeader("User-Agent", "Mozilla/5.0 (Macintosh; Apple macOS 15_5) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/138.0.0.0 Openlist/425.6.30").
 			SetResult(&resp).
 			SetQueryParams(map[string]string{
 				"refresh_ui": d.RefreshToken,


### PR DESCRIPTION
## 描述

1. change var to const
2. remove duplicated ua definetion after original Resty R
3. upgrade Chrome and OS versions

保留了一些疑似特定UA的地方。

```
./drivers/115/util.go:  return fmt.Sprintf("Mozilla/5.0 115Browser/%s", appVer)
./drivers/123_share/util.go:            "user-agent":    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) openlist-client",
./drivers/123/util.go:          "user-agent":    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) openlist-client",
./drivers/189/util.go://                        "User-Agent":     "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:74.0) Gecko/20100101 Firefox/76.0",
./drivers/chaoxing/meta.go:                             ua:         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) quark-cloud-drive/2.5.20 Chrome/100.0.4896.160 Electron/18.3.5.4-b478491100 Safari/537.36 Channel/pckk_other_ch",
./drivers/lanzou/meta.go:       UserAgent      string `json:"user_agent" required:"true" default:"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.39 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.39"`
./drivers/lenovonas_share/util.go:              "user-agent":  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) openlist-client",
./drivers/netease_music/util.go:                req.Header.Set("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36")
./drivers/pikpak_share/driver.go:               d.UserAgent = "MainWindow Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) PikPak/2.6.11.4955 Chrome/100.0.4896.160 Electron/18.3.15 Safari/537.36"
./drivers/pikpak_share/driver.go:               d.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36"
./drivers/pikpak/driver.go:             d.UserAgent = "MainWindow Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) PikPak/2.6.11.4955 Chrome/100.0.4896.160 Electron/18.3.15 Safari/537.36"
./drivers/pikpak/driver.go:             d.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36"
./drivers/quark_uc_tv/util.go:  UserAgent    = "Mozilla/5.0 (Linux; U; Android 13; zh-cn; M2004J7AC Build/UKQ1.231108.001) AppleWebKit/533.1 (KHTML, like Gecko) Mobile Safari/533.1"
./drivers/quark_uc/meta.go:                             ua:      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) quark-cloud-drive/2.5.20 Chrome/100.0.4896.160 Electron/18.3.5.4-b478491100 Safari/537.36 Channel/pckk_other_ch",
./drivers/quark_uc/meta.go:                             ua:      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) uc-cloud-drive/2.5.20 Chrome/100.0.4896.160 Electron/18.3.5.4-b478491100 Safari/537.36 Channel/pckk_other_ch",
```

## 背景

## ⚠️⚠️⚠️测试⚠️⚠️⚠️

⚠️⚠️⚠️
因为没有那么多账号所以完全无法测试，如果存在一些原先是破解的情况，那么此提交会很危险！
但我保留了部分可能是特定UA的没有合并到client base文件中。
⚠️⚠️⚠️

## 检查清单

- [x] 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] 我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] 我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] 我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
