### PR TITLE
feat(s3): implement Getter interface

### DIFF
--- a/drivers/s3/driver.go
+++ b/drivers/s3/driver.go
@@ -16,9 +16,12 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/pkg/cron"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"github.com/OpenListTeam/OpenList/v4/server/common"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -243,4 +246,81 @@ func (d *S3) GetDirectUploadInfo(ctx context.Context, _ string, dstDir model.Obj
 	}, nil
 }
 
+// implements driver.Getter interface
+func (d *S3) Get(ctx context.Context, path string) (model.Obj, error) {
+	if utils.PathEqual(path, "/") {
+		return &model.Object{
+			Name:     "Root",
+			IsFolder: true,
+			Path:     "/",
+		}, nil
+	}
+
+	// try to get object as a file using HeadObject
+	key := getKey(path, false)
+	headInput := &s3.HeadObjectInput{
+		Bucket: &d.Bucket,
+		Key:    &key,
+	}
+	headOutput, err := d.client.HeadObjectWithContext(ctx, headInput)
+	if err == nil {
+		// Object exists as a file
+		fileName := stdpath.Base(path)
+		return &model.Object{
+			Name:     fileName,
+			Size:     *headOutput.ContentLength,
+			Modified: *headOutput.LastModified,
+			Path:     path,
+		}, nil
+	}
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) && awsErr.Code() != "NotFound" {
+		return nil, errors.WithMessage(err, "failed to head object")
+	}
+
+	// If HeadObject fails with 404, check if it's a directory
+	prefix := getKey(path, true)
+	var contents []*s3.Object
+	var commonPrefixes []*s3.CommonPrefix
+	switch d.ListObjectVersion {
+	case "v1":
+		listInput := &s3.ListObjectsInput{
+			Bucket:  &d.Bucket,
+			Prefix:  &prefix,
+			MaxKeys: aws.Int64(1), // Only need to check if at least one object exists
+		}
+		listResult, err := d.client.ListObjectsWithContext(ctx, listInput)
+		if err != nil {
+			return nil, errors.WithMessage(err, "failed to list objects with prefix")
+		}
+		contents = listResult.Contents
+		commonPrefixes = listResult.CommonPrefixes
+	case "v2":
+		listInput := &s3.ListObjectsV2Input{
+			Bucket:  &d.Bucket,
+			Prefix:  &prefix,
+			MaxKeys: aws.Int64(1),
+		}
+		listResult, err := d.client.ListObjectsV2WithContext(ctx, listInput)
+		if err != nil {
+			return nil, errors.WithMessage(err, "failed to list objects v2 with prefix")
+		}
+		contents = listResult.Contents
+		commonPrefixes = listResult.CommonPrefixes
+	default:
+		return nil, fmt.Errorf("unsupported ListObjectVersion: %s", d.ListObjectVersion)
+	}
+	if len(contents) > 0 || len(commonPrefixes) > 0 {
+		dirName := stdpath.Base(path + "/")
+		return &model.Object{
+			Name:     dirName,
+			Modified: d.Modified,
+			IsFolder: true,
+			Path:     path,
+		}, nil
+	}
+	return nil, errs.ObjectNotFound
+}
+
 var _ driver.Driver = (*S3)(nil)
+var _ driver.Getter = (*S3)(nil)

--- a/drivers/s3/driver.go
+++ b/drivers/s3/driver.go
@@ -248,14 +248,6 @@ func (d *S3) GetDirectUploadInfo(ctx context.Context, _ string, dstDir model.Obj
 
 // implements driver.Getter interface
 func (d *S3) Get(ctx context.Context, path string) (model.Obj, error) {
-	if utils.PathEqual(path, "/") {
-		return &model.Object{
-			Name:     "Root",
-			IsFolder: true,
-			Path:     "/",
-		}, nil
-	}
-
 	// try to get object as a file using HeadObject
 	key := getKey(stdpath.Join(d.GetRootPath(), path), false)
 	headInput := &s3.HeadObjectInput{

--- a/drivers/s3/driver.go
+++ b/drivers/s3/driver.go
@@ -257,7 +257,7 @@ func (d *S3) Get(ctx context.Context, path string) (model.Obj, error) {
 	}
 
 	// try to get object as a file using HeadObject
-	key := getKey(path, false)
+	key := getKey(stdpath.Join(d.GetRootPath(), path), false)
 	headInput := &s3.HeadObjectInput{
 		Bucket: &d.Bucket,
 		Key:    &key,


### PR DESCRIPTION
<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
-->

## Description / 描述

<!-- Describe your changes in detail -->
<!-- 详细描述您的更改 -->
The S3 driver has been updated to implement the Getter interface. This addition introduces the Get method, which allows the retrieval of both files and directories from S3. The method works by first attempting to fetch the object as a file using HeadObject. If the object is not found (HTTP 404), it checks if the path corresponds to a directory by listing objects with the given prefix. The Get method handles two different object listing strategies, “v1” and “v2”, based on the configuration of the ListObjectVersion. 


## Motivation and Context / 背景

<!-- Why is this change required? What problem does it solve? -->
<!-- 为什么需要此更改？它解决了什么问题？ -->

<!-- If it fixes an open issue, please link to the issue here. -->
<!-- 如果修复了一个打开的issue，请在此处链接到该issue -->


<!-- or -->
<!-- 或者 -->


- Improve performance for directly accessing multi-level directories.
- Some S3 implementations do not allow listing objects without a prefix at the first level (i.e., for paths like bucket://), which can cause issues with the original List method. This can prevent access to paths like bucket://xxx/xxx (althrough with prefix). By using Get, which directly retrieves objects based on the path, this problem can be avoided.

## How Has This Been Tested? / 测试

<!-- Please describe in detail how you tested your changes. -->
<!-- 请详细描述您如何测试更改 -->

I added logging inside the newly implemented Get method, then created an S3 storage instance to verify that:
- the Get method was indeed invoked, and
- it returned the correct results for both files and multi-level directories.

This confirmed that the new logic behaves as expected.


## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [x] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
