### PR TITLE
feat(cloudreve_v4): add ks3 support

### DIFF
--- a/drivers/cloudreve_v4/driver.go
+++ b/drivers/cloudreve_v4/driver.go
@@ -299,7 +299,9 @@ func (d *CloudreveV4) Put(ctx context.Context, dstDir model.Obj, file model.File
 		case "onedrive":
 			err = d.upOneDrive(ctx, file, u, up)
 		case "s3":
-			err = d.upS3(ctx, file, u, up)
+			err = d.upS3(ctx, file, u, up, "s3")
+		case "ks3":
+			err = d.upS3(ctx, file, u, up, "ks3")
 		default:
 			return errs.NotImplement
 		}


### PR DESCRIPTION
<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
-->

## Description / 描述

增加对 ks3 存储策略上传的支持。

## Motivation and Context / 背景

远端将 `Content-Type` 预签名为 `application/octet-stream`，所以需要跟着修改，否则会报错 `SignatureDoesNotMatch`。

https://github.com/cloudreve/cloudreve/blob/32632db36fffead17264c89dcc1c2eda77bda61a/pkg/filemanager/driver/ks3/ks3.go#L437

## How Has This Been Tested? / 测试

<img width="1530" height="584" alt="image" src="https://github.com/user-attachments/assets/0bc9ed50-7f25-42a2-9ffb-44eed010915f" />


## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) 
  - [x] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) https://github.com/OpenListTeam/OpenList-Docs/pull/271
