### PR TITLE
fix(strm): support generate strm with sign

### DIFF
--- a/drivers/strm/meta.go
+++ b/drivers/strm/meta.go
@@ -13,6 +13,7 @@ type Addition struct {
 	FilterFileTypes       string `json:"filterFileTypes" type:"text" default:"mp4,mkv,flv,avi,wmv,ts,rmvb,webm,mp3,flac,aac,wav,ogg,m4a,wma,alac" required:"false" help:"Supports suffix name of strm file"`
 	EncodePath            bool   `json:"encodePath" default:"true" required:"true" help:"encode the path in the strm file"`
 	WithoutUrl            bool   `json:"withoutUrl" default:"false" help:"strm file content without URL prefix"`
+	WithSign              bool   `json:"withSign" default:"false"`
 	SaveStrmToLocal       bool   `json:"SaveStrmToLocal" default:"false" help:"save strm file locally"`
 	SaveStrmLocalPath     string `json:"SaveStrmLocalPath" type:"text" help:"save strm file local path"`
 	KeepLocalDownloadFile bool   `json:"KeepLocalDownloadFile" default:"false" help:"keep local download files"`

--- a/drivers/strm/util.go
+++ b/drivers/strm/util.go
@@ -108,7 +108,7 @@ func (d *Strm) getLink(ctx context.Context, path string) string {
 	if d.EncodePath {
 		finalPath = utils.EncodePath(path, true)
 	}
-	if d.EnableSign {
+	if d.WithSign {
 		signPath := sign.Sign(path)
 		finalPath = fmt.Sprintf("%s?sign=%s", finalPath, signPath)
 	}


### PR DESCRIPTION
## Description / 描述

支持生成的 strm 携带签名。

其实本来就是支持的，但是判断条件和驱动的下载链接是否应当携带签名用的是一个，应该是原作者没有正确理解`EnableSign`这个配置项的含义导致的，这个 PR 将两个配置项分开了。

## Motivation and Context / 背景

## How Has This Been Tested? / 测试

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
