### PR TITLE
fix(driver): fix file copy failure to 123pan due to incorrect etag

### DIFF
--- a/drivers/baidu_netdisk/types.go
+++ b/drivers/baidu_netdisk/types.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
-	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 )
 
 var (
@@ -76,9 +75,7 @@ func fileToObj(f File) *model.ObjThumb {
 			Modified: time.Unix(f.ServerMtime, 0),
 			Ctime:    time.Unix(f.ServerCtime, 0),
 			IsFolder: f.Isdir == 1,
-
-			// 直接获取的MD5是错误的
-			HashInfo: utils.NewHashInfo(utils.MD5, DecryptMd5(f.Md5)),
+			// 百度API返回的MD5不可信，不使用HashInfo
 		},
 		Thumbnail: model.Thumbnail{Thumbnail: f.Thumbs.Url3},
 	}


### PR DESCRIPTION
https://github.com/OpenListTeam/OpenList/issues/1739#issue-3683848663
## 描述
<img width="1351" height="200" alt="image" src="https://github.com/user-attachments/assets/a19a03d6-4491-47c1-9c3d-a1b6f7a734b1" />

此 PR 修复了从百度网盘跨存储复制大文件时，某些驱动在最后合并阶段（complete）失败的问题。

源存储元数据提供的 Etag/MD5 与文件实际数据流的标准 MD5 不一致。由于 123 云盘 API 在合并分片时指纹不匹配会导致服务器直接报错“文件上传失败”。

**主要更改：**
删除Hashinfo
## 测试

1. 使用百度网盘中一个 140MB 的文件成功复现问题（源 MD5 `7968...` 与真实值 `f167...` 不符）。
2. 验证新代码计算出正确 MD5 并被 123 云盘服务端接受。
<img width="3015" height="346" alt="image" src="https://github.com/user-attachments/assets/1f7a416c-b36d-4bdb-b4fd-b95a0bfea265" />


## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
- [ ] I have added appropriate labels to this PR.
- [x] I have requested review from relevant code authors.
- [ ] I have updated the repository accordingly.