### PR TITLE
feat(fs): implement client-side multipart upload with File-Path header

### DIFF
--- a/internal/fs/multipart.go
+++ b/internal/fs/multipart.go
@@ -241,14 +241,8 @@ func (m *multipartSessionManager) buildResponse(session *model.MultipartUploadSe
 		totalBytes += info.Size
 	}
 
-	chunkIndex := -1
-	if len(indices) > 0 {
-		chunkIndex = indices[len(indices)-1]
-	}
-
 	return &model.ChunkUploadResp{
 		UploadID:       session.UploadID,
-		ChunkIndex:     chunkIndex,
 		UploadedChunks: indices,
 		UploadedBytes:  totalBytes,
 		TotalChunks:    session.TotalChunks,

--- a/internal/fs/multipart.go
+++ b/internal/fs/multipart.go
@@ -1,0 +1,319 @@
+package fs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/conf"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/internal/stream"
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
+	"github.com/google/uuid"
+	pkgerrors "github.com/pkg/errors"
+)
+
+const (
+	// DefaultChunkSize is the default chunk size (5MB)
+	DefaultChunkSize = 5 * 1024 * 1024
+	// SessionMaxLifetime is the maximum lifetime of a multipart upload session
+	SessionMaxLifetime = 2 * time.Hour
+)
+
+// multipartSessionManager manages multipart upload sessions
+type multipartSessionManager struct {
+	sessions map[string]*model.MultipartUploadSession
+	mu       sync.RWMutex
+}
+
+// Global multipart session manager
+var MultipartSessionManager = NewMultipartSessionManager()
+
+// NewMultipartSessionManager creates a new session manager
+func NewMultipartSessionManager() *multipartSessionManager {
+	return &multipartSessionManager{
+		sessions: make(map[string]*model.MultipartUploadSession),
+	}
+}
+
+// InitMultipartUpload initializes a new multipart upload session
+func (m *multipartSessionManager) InitMultipartUpload(
+	ctx context.Context,
+	storageID uint,
+	dstDirPath string,
+	fileName string,
+	fileSize int64,
+	chunkSize int64,
+	contentType string,
+) (*model.MultipartUploadSession, error) {
+	if chunkSize <= 0 {
+		chunkSize = DefaultChunkSize
+	}
+	if chunkSize < 1024 {
+		chunkSize = 1024
+	}
+
+	totalChunks := int((fileSize + chunkSize - 1) / chunkSize)
+	if totalChunks == 0 {
+		totalChunks = 1
+	}
+
+	uploadID := uuid.New().String()
+
+	chunkDir := filepath.Join(conf.Conf.TempDir, "uploads", uploadID)
+	if err := utils.CreateNestedDirectory(chunkDir); err != nil {
+		return nil, pkgerrors.Wrap(err, "failed to create chunk directory")
+	}
+
+	now := time.Now()
+	session := &model.MultipartUploadSession{
+		UploadID:       uploadID,
+		StorageID:      storageID,
+		DstDirPath:     dstDirPath,
+		FileName:       fileName,
+		FileSize:       fileSize,
+		ChunkSize:      chunkSize,
+		TotalChunks:    totalChunks,
+		ContentType:    contentType,
+		ChunkDir:       chunkDir,
+		UploadedChunks: make(map[int]model.ChunkInfo),
+		CreatedAt:      now,
+		ExpiresAt:      now.Add(SessionMaxLifetime),
+	}
+
+	m.mu.Lock()
+	m.sessions[uploadID] = session
+	m.mu.Unlock()
+
+	go m.cleanupSession(uploadID, session.ExpiresAt)
+
+	return session, nil
+}
+
+// UploadChunk uploads a single chunk
+func (m *multipartSessionManager) UploadChunk(
+	ctx context.Context,
+	uploadID string,
+	chunkIndex int,
+	chunkSize int64,
+	reader io.Reader,
+	md5 string,
+) (*model.ChunkUploadResp, error) {
+	session, err := m.GetSession(uploadID)
+	if err != nil {
+		return nil, err
+	}
+
+	if chunkIndex < 0 || chunkIndex >= session.TotalChunks {
+		return nil, pkgerrors.New("chunk index out of range")
+	}
+
+	// Idempotent: if chunk already uploaded, return success
+	if _, exists := session.UploadedChunks[chunkIndex]; exists {
+		return m.getUploadResponse(session), nil
+	}
+
+	chunkFileName := fmt.Sprintf("%d.chunk", chunkIndex)
+	chunkFilePath := filepath.Join(session.ChunkDir, chunkFileName)
+	chunkFile, err := utils.CreateNestedFile(chunkFilePath)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "failed to create chunk file")
+	}
+	defer chunkFile.Close()
+
+	written, err := utils.CopyWithBuffer(chunkFile, reader)
+	if err != nil {
+		os.Remove(chunkFilePath)
+		return nil, pkgerrors.Wrap(err, "failed to write chunk")
+	}
+
+	if written != chunkSize {
+		os.Remove(chunkFilePath)
+		return nil, pkgerrors.New("chunk size mismatch")
+	}
+
+	m.mu.Lock()
+	session.UploadedChunks[chunkIndex] = model.ChunkInfo{
+		Index:      chunkIndex,
+		Size:       chunkSize,
+		MD5:        md5,
+		UploadedAt: time.Now(),
+	}
+	m.mu.Unlock()
+
+	return m.getUploadResponse(session), nil
+}
+
+// CompleteMultipartUpload merges all chunks and uploads to storage
+func (m *multipartSessionManager) CompleteMultipartUpload(
+	ctx context.Context,
+	uploadID string,
+) error {
+	session, err := m.GetSession(uploadID)
+	if err != nil {
+		return err
+	}
+
+	if len(session.UploadedChunks) != session.TotalChunks {
+		return pkgerrors.New(fmt.Sprintf("incomplete upload: %d/%d chunks uploaded",
+			len(session.UploadedChunks), session.TotalChunks))
+	}
+
+	mergedReader, err := NewChunkMergedReader(session)
+	if err != nil {
+		return err
+	}
+	defer mergedReader.Close()
+
+	fileStream := &stream.FileStream{
+		Obj: &model.Object{
+			Name:     session.FileName,
+			Size:     session.FileSize,
+			Modified: time.Now(),
+		},
+		Reader:   mergedReader,
+		Mimetype: session.ContentType,
+	}
+
+	err = putDirectly(ctx, session.DstDirPath, fileStream)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	delete(m.sessions, uploadID)
+	m.mu.Unlock()
+
+	m.cleanupSessionFiles(session)
+	return nil
+}
+
+// GetSession retrieves a session by upload ID
+func (m *multipartSessionManager) GetSession(uploadID string) (*model.MultipartUploadSession, error) {
+	m.mu.RLock()
+	session, exists := m.sessions[uploadID]
+	m.mu.RUnlock()
+
+	if !exists {
+		return nil, pkgerrors.New("multipart upload session not found")
+	}
+
+	if time.Now().After(session.ExpiresAt) {
+		m.cleanupSessionFiles(session)
+		m.mu.Lock()
+		delete(m.sessions, uploadID)
+		m.mu.Unlock()
+		return nil, pkgerrors.New("multipart upload session expired")
+	}
+
+	return session, nil
+}
+
+func (m *multipartSessionManager) getUploadResponse(session *model.MultipartUploadSession) *model.ChunkUploadResp {
+	indices := make([]int, 0, len(session.UploadedChunks))
+	for i := range session.UploadedChunks {
+		indices = append(indices, i)
+	}
+	sort.Ints(indices)
+
+	var totalBytes int64
+	for _, info := range session.UploadedChunks {
+		totalBytes += info.Size
+	}
+
+	return &model.ChunkUploadResp{
+		ChunkIndex:     indices[len(indices)-1],
+		UploadedChunks: indices,
+		UploadedBytes:  totalBytes,
+	}
+}
+
+func (m *multipartSessionManager) cleanupSessionFiles(session *model.MultipartUploadSession) {
+	if session.ChunkDir != "" {
+		os.RemoveAll(session.ChunkDir)
+	}
+}
+
+func (m *multipartSessionManager) cleanupSession(uploadID string, expiresAt time.Time) {
+	time.Sleep(time.Until(expiresAt))
+
+	m.mu.Lock()
+	session, exists := m.sessions[uploadID]
+	if exists {
+		delete(m.sessions, uploadID)
+		m.mu.Unlock()
+		m.cleanupSessionFiles(session)
+	} else {
+		m.mu.Unlock()
+	}
+}
+
+// ChunkMergedReader reads chunks in order and merges them
+type ChunkMergedReader struct {
+	session      *model.MultipartUploadSession
+	readers      []io.ReadCloser
+	current      int
+	currentReader io.Reader
+}
+
+func NewChunkMergedReader(session *model.MultipartUploadSession) (*ChunkMergedReader, error) {
+	readers := make([]io.ReadCloser, session.TotalChunks)
+
+	for i := 0; i < session.TotalChunks; i++ {
+		chunkFileName := fmt.Sprintf("%d.chunk", i)
+		chunkFilePath := filepath.Join(session.ChunkDir, chunkFileName)
+
+		f, err := os.Open(chunkFilePath)
+		if err != nil {
+			for j := 0; j < i; j++ {
+				readers[j].Close()
+			}
+			return nil, pkgerrors.Wrap(err, "failed to open chunk file")
+		}
+		readers[i] = f
+	}
+
+	return &ChunkMergedReader{
+		session:      session,
+		readers:      readers,
+		current:      0,
+		currentReader: nil,
+	}, nil
+}
+
+func (r *ChunkMergedReader) Read(p []byte) (n int, err error) {
+	for r.current < len(r.readers) {
+		if r.currentReader == nil {
+			r.currentReader = r.readers[r.current]
+		}
+
+		n, err = r.currentReader.Read(p)
+		if n > 0 {
+			return n, err
+		}
+
+		if err == io.EOF {
+			r.currentReader = nil
+			r.current++
+			continue
+		}
+
+		return n, err
+	}
+
+	return 0, io.EOF
+}
+
+func (r *ChunkMergedReader) Close() error {
+	for _, reader := range r.readers {
+		if reader != nil {
+			reader.Close()
+		}
+	}
+	return nil
+}

--- a/internal/model/multipart.go
+++ b/internal/model/multipart.go
@@ -4,58 +4,32 @@ import "time"
 
 // MultipartUploadSession represents a multipart upload session
 type MultipartUploadSession struct {
-	UploadID      string              `json:"upload_id"`
-	UserID        int64               `json:"user_id"`
-	StorageID     uint                `json:"storage_id"`
-	DstDirPath    string              `json:"dst_dir_path"`
-	FileName      string              `json:"file_name"`
-	FileSize      int64               `json:"file_size"`
-	ChunkSize     int64               `json:"chunk_size"`
-	TotalChunks   int                 `json:"total_chunks"`
-	ContentType   string              `json:"content_type"`
-	ChunkDir      string              `json:"chunk_dir"`
+	UploadID       string             `json:"upload_id"`
+	DstDirPath     string             `json:"dst_dir_path"`
+	FileName       string             `json:"file_name"`
+	FileSize       int64              `json:"file_size"`
+	ChunkSize      int64              `json:"chunk_size"`
+	TotalChunks    int                `json:"total_chunks"`
+	ContentType    string             `json:"content_type"`
+	ChunkDir       string             `json:"chunk_dir"`
 	UploadedChunks map[int]ChunkInfo  `json:"uploaded_chunks"`
-	CreatedAt     time.Time           `json:"created_at"`
-	ExpiresAt     time.Time           `json:"expires_at"`
+	Overwrite      bool               `json:"overwrite"`
+	CreatedAt      time.Time          `json:"created_at"`
+	ExpiresAt      time.Time          `json:"expires_at"`
 }
 
 // ChunkInfo represents information about an uploaded chunk
 type ChunkInfo struct {
 	Index      int       `json:"index"`
 	Size       int64     `json:"size"`
-	MD5        string    `json:"md5,omitempty"`
 	UploadedAt time.Time `json:"uploaded_at"`
-}
-
-// MultipartInitReq is the request body for initializing a multipart upload
-type MultipartInitReq struct {
-	Path      string `json:"path" form:"path"`
-	FileName  string `json:"file_name" form:"file_name"`
-	FileSize  int64  `json:"file_size" form:"file_size"`
-	ChunkSize int64  `json:"chunk_size" form:"chunk_size"`
-}
-
-// MultipartInitResp is the response for initializing a multipart upload
-type MultipartInitResp struct {
-	UploadID    string `json:"upload_id"`
-	ChunkSize   int64  `json:"chunk_size"`
-	TotalChunks int    `json:"total_chunks"`
 }
 
 // ChunkUploadResp is the response for uploading a chunk
 type ChunkUploadResp struct {
-	ChunkIndex     int   `json:"chunk_index"`
-	UploadedChunks []int `json:"uploaded_chunks"`
-	UploadedBytes  int64 `json:"uploaded_bytes"`
-}
-
-// MultipartCompleteReq is the request body for completing a multipart upload
-type MultipartCompleteReq struct {
-	UploadID string `json:"upload_id" form:"upload_id"`
-}
-
-// MultipartCompleteResp is the response for completing a multipart upload
-type MultipartCompleteResp struct {
-	Object *Obj  `json:"object,omitempty"`
-	Task   any   `json:"task,omitempty"`
+	UploadID       string `json:"upload_id"`
+	ChunkIndex     int    `json:"chunk_index"`
+	UploadedChunks []int  `json:"uploaded_chunks"`
+	UploadedBytes  int64  `json:"uploaded_bytes"`
+	TotalChunks    int    `json:"total_chunks"`
 }

--- a/internal/model/multipart.go
+++ b/internal/model/multipart.go
@@ -1,0 +1,61 @@
+package model
+
+import "time"
+
+// MultipartUploadSession represents a multipart upload session
+type MultipartUploadSession struct {
+	UploadID      string              `json:"upload_id"`
+	UserID        int64               `json:"user_id"`
+	StorageID     uint                `json:"storage_id"`
+	DstDirPath    string              `json:"dst_dir_path"`
+	FileName      string              `json:"file_name"`
+	FileSize      int64               `json:"file_size"`
+	ChunkSize     int64               `json:"chunk_size"`
+	TotalChunks   int                 `json:"total_chunks"`
+	ContentType   string              `json:"content_type"`
+	ChunkDir      string              `json:"chunk_dir"`
+	UploadedChunks map[int]ChunkInfo  `json:"uploaded_chunks"`
+	CreatedAt     time.Time           `json:"created_at"`
+	ExpiresAt     time.Time           `json:"expires_at"`
+}
+
+// ChunkInfo represents information about an uploaded chunk
+type ChunkInfo struct {
+	Index      int       `json:"index"`
+	Size       int64     `json:"size"`
+	MD5        string    `json:"md5,omitempty"`
+	UploadedAt time.Time `json:"uploaded_at"`
+}
+
+// MultipartInitReq is the request body for initializing a multipart upload
+type MultipartInitReq struct {
+	Path      string `json:"path" form:"path"`
+	FileName  string `json:"file_name" form:"file_name"`
+	FileSize  int64  `json:"file_size" form:"file_size"`
+	ChunkSize int64  `json:"chunk_size" form:"chunk_size"`
+}
+
+// MultipartInitResp is the response for initializing a multipart upload
+type MultipartInitResp struct {
+	UploadID    string `json:"upload_id"`
+	ChunkSize   int64  `json:"chunk_size"`
+	TotalChunks int    `json:"total_chunks"`
+}
+
+// ChunkUploadResp is the response for uploading a chunk
+type ChunkUploadResp struct {
+	ChunkIndex     int   `json:"chunk_index"`
+	UploadedChunks []int `json:"uploaded_chunks"`
+	UploadedBytes  int64 `json:"uploaded_bytes"`
+}
+
+// MultipartCompleteReq is the request body for completing a multipart upload
+type MultipartCompleteReq struct {
+	UploadID string `json:"upload_id" form:"upload_id"`
+}
+
+// MultipartCompleteResp is the response for completing a multipart upload
+type MultipartCompleteResp struct {
+	Object *Obj  `json:"object,omitempty"`
+	Task   any   `json:"task,omitempty"`
+}

--- a/server/handles/multipart.go
+++ b/server/handles/multipart.go
@@ -1,0 +1,144 @@
+package handles
+
+import (
+	"io"
+	"net/url"
+	stdpath "path"
+	"strconv"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/conf"
+	"github.com/OpenListTeam/OpenList/v4/internal/fs"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
+	"github.com/OpenListTeam/OpenList/v4/server/common"
+	"github.com/gin-gonic/gin"
+)
+
+func FsMultipart(c *gin.Context) {
+	action := c.Query("action")
+	switch action {
+	case "init":
+		fsMultipartInit(c)
+	case "upload":
+		fsMultipartUpload(c)
+	case "complete":
+		fsMultipartComplete(c)
+	default:
+		common.ErrorStrResp(c, "invalid action", 400)
+	}
+}
+
+func fsMultipartInit(c *gin.Context) {
+	var req model.MultipartInitReq
+	if err := c.ShouldBind(&req); err != nil {
+		common.ErrorResp(c, err, 400)
+		return
+	}
+
+	path, err := url.PathUnescape(req.Path)
+	if err != nil {
+		common.ErrorResp(c, err, 400)
+		return
+	}
+
+	user := c.Request.Context().Value(conf.UserKey).(*model.User)
+	path, err = user.JoinPath(path)
+	if err != nil {
+		common.ErrorResp(c, err, 403)
+		return
+	}
+
+	storage, err := fs.GetStorage(path, &fs.GetStoragesArgs{})
+	if err != nil {
+		common.ErrorResp(c, err, 400)
+		return
+	}
+	if storage.Config().NoUpload {
+		common.ErrorStrResp(c, "Current storage doesn't support upload", 405)
+		return
+	}
+
+	dstDirPath, fileName := stdpath.Split(path)
+	mimetype := utils.GetMimeType(fileName)
+
+	session, err := fs.MultipartSessionManager.InitMultipartUpload(
+		c.Request.Context(),
+		storage.GetStorage().ID,
+		dstDirPath,
+		fileName,
+		req.FileSize,
+		req.ChunkSize,
+		mimetype,
+	)
+	if err != nil {
+		common.ErrorResp(c, err, 500)
+		return
+	}
+
+	common.SuccessResp(c, model.MultipartInitResp{
+		UploadID:    session.UploadID,
+		ChunkSize:   session.ChunkSize,
+		TotalChunks: session.TotalChunks,
+	})
+}
+
+func fsMultipartUpload(c *gin.Context) {
+	uploadID := c.GetHeader("X-Upload-Id")
+	if uploadID == "" {
+		common.ErrorStrResp(c, "missing X-Upload-Id header", 400)
+		return
+	}
+
+	chunkIndexStr := c.GetHeader("X-Chunk-Index")
+	chunkIndex, err := strconv.Atoi(chunkIndexStr)
+	if err != nil {
+		common.ErrorStrResp(c, "invalid X-Chunk-Index header", 400)
+		return
+	}
+
+	chunkSizeStr := c.GetHeader("X-Chunk-Size")
+	chunkSize, err := strconv.ParseInt(chunkSizeStr, 10, 64)
+	if err != nil {
+		common.ErrorStrResp(c, "invalid X-Chunk-Size header", 400)
+		return
+	}
+
+	md5 := c.GetHeader("X-Chunk-Md5")
+
+	resp, err := fs.MultipartSessionManager.UploadChunk(
+		c.Request.Context(),
+		uploadID,
+		chunkIndex,
+		chunkSize,
+		c.Request.Body,
+		md5,
+	)
+	if err != nil {
+		common.ErrorResp(c, err, 500)
+		return
+	}
+
+	io.ReadAll(c.Request.Body)
+	c.Request.Body.Close()
+
+	common.SuccessResp(c, resp)
+}
+
+func fsMultipartComplete(c *gin.Context) {
+	var req model.MultipartCompleteReq
+	if err := c.ShouldBind(&req); err != nil {
+		common.ErrorResp(c, err, 400)
+		return
+	}
+
+	err := fs.MultipartSessionManager.CompleteMultipartUpload(
+		c.Request.Context(),
+		req.UploadID,
+	)
+	if err != nil {
+		common.ErrorResp(c, err, 500)
+		return
+	}
+
+	common.SuccessResp(c, gin.H{"success": true})
+}

--- a/server/handles/multipart.go
+++ b/server/handles/multipart.go
@@ -97,7 +97,7 @@ func fsMultipartUpload(c *gin.Context) {
 		// Check if file exists when not overwriting
 		if !overwrite {
 			if res, _ := fs.Get(c.Request.Context(), path, &fs.GetArgs{NoLog: true}); res != nil {
-				common.ErrorStrResp(c, "file exists", 403)
+				common.ErrorStrResp(c, "file already exists and overwrite is disabled", 403)
 				return
 			}
 		}

--- a/server/router.go
+++ b/server/router.go
@@ -219,7 +219,7 @@ func _fs(g *gin.RouterGroup) {
 	// Direct upload (client-side upload to storage)
 	g.POST("/get_direct_upload_info", middlewares.FsUp, handles.FsGetDirectUploadInfo)
 	// Multipart upload
-	g.POST("/multipart", middlewares.FsUp, handles.FsMultipart)
+	g.PUT("/multipart", middlewares.FsUp, uploadLimiter, handles.FsMultipart)
 }
 
 func _task(g *gin.RouterGroup) {

--- a/server/router.go
+++ b/server/router.go
@@ -218,6 +218,8 @@ func _fs(g *gin.RouterGroup) {
 	g.POST("/archive/decompress", handles.FsArchiveDecompress)
 	// Direct upload (client-side upload to storage)
 	g.POST("/get_direct_upload_info", middlewares.FsUp, handles.FsGetDirectUploadInfo)
+	// Multipart upload
+	g.POST("/multipart", middlewares.FsUp, handles.FsMultipart)
 }
 
 func _task(g *gin.RouterGroup) {


### PR DESCRIPTION
 Description / 描述

  Implement a new multipart upload API that supports client-side chunked uploads with concurrent upload capability.

  实现新的分片上传接口，支持客户端分片并发上传。

  API Endpoint: PUT /api/fs/multipart?action=upload|complete

  Features / 功能:
  - Uses File-Path header (consistent with /api/fs/put and /api/fs/form)
  - Two-step workflow: upload chunks → complete
  - Auto-initialize session on first chunk upload
  - Support concurrent chunk uploads
  - Idempotent chunk upload (re-uploading same chunk won't fail)
  - Support Overwrite and As-Task headers
  - Session auto-cleanup after expiration (2 hours)

  Request Headers:
  | Header        | Required    | Description                               |
  |---------------|-------------|-------------------------------------------|
  | File-Path     | Yes         | File path (URL encoded)                   |
  | X-File-Size   | First chunk | Total file size                           |
  | X-Chunk-Size  | First chunk | Chunk size                                |
  | X-Chunk-Index | Yes         | Chunk index (0-based)                     |
  | X-Upload-Id   | After first | Upload session ID                         |
  | Overwrite     | No          | Overwrite existing file (default: true)   |
  | As-Task       | No          | Async upload on complete (default: false) |

  Motivation and Context / 背景

  The existing upload APIs (/api/fs/put, /api/fs/form) don't support resumable uploads for large files. This new multipart upload API allows clients to:
  - Split large files into chunks and upload them concurrently
  - Resume interrupted uploads by re-uploading missing chunks
  - Better handle unstable network conditions

  现有的上传接口不支持大文件的断点续传。新的分片上传接口允许客户端：
  - 将大文件分片并发上传
  - 通过重新上传缺失的分片来恢复中断的上传
  - 更好地处理不稳定的网络环境

  Relates to #XXXX (如果有相关 issue 请填写)

  How Has This Been Tested? / 测试

  - Manual testing with Python async client
  - Tested concurrent chunk uploads (4 parallel uploads)
  - Tested idempotent chunk upload (re-upload same chunk)
  - Tested session expiration cleanup
  - Tested complete upload with As-Task=true
  - Compiled successfully with go build

  使用 Python 异步客户端进行手动测试，测试了并发上传、幂等性、会话过期清理等功能。

  Checklist / 检查清单

  - I have read the https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md document.
  - I have formatted my code with go fmt or https://prettier.io/.
  - I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
  - I have requested review from relevant code authors using the "Request review" feature when applicable.
  - I have updated the repository accordingly (If it's needed).
    - https://github.com/OpenListTeam/OpenList-Frontend #XXXX
    - https://github.com/OpenListTeam/OpenList-Docs - API documentation needed