### PR TITLE
fix(fs): handle non-existent destination directory in file transfer

### DIFF
--- a/internal/fs/copy_move.go
+++ b/internal/fs/copy_move.go
@@ -191,7 +191,12 @@ func (t *FileTransferTask) RunWithNextTaskCallback(f func(nextTask *FileTransfer
 
 		existedObjs := make(map[string]bool)
 		if t.TaskType == merge {
-			dstObjs, _ := op.List(t.Ctx(), t.DstStorage, dstActualPath, model.ListArgs{})
+			dstObjs, err := op.List(t.Ctx(), t.DstStorage, dstActualPath, model.ListArgs{})
+			if err != nil && !errors.Is(err, errs.ObjectNotFound) {
+				// 目标文件夹不存在的情况不是错误，会在之后新建文件夹
+				// 这种情况显然不需要统计existedObjs，dstObjs保持为nil，下面这个for将不会执行
+				return errors.WithMessagef(err, "failed list dst [%s] objs", dstActualPath)
+			}
 			for _, obj := range dstObjs {
 				if err := t.Ctx().Err(); err != nil {
 					return err


### PR DESCRIPTION
fix  https://github.com/OpenListTeam/OpenList/issues/1878
## 描述

### 修复的问题
在执行文件传输任务（TaskType == merge）时，如果目标目录（dstActualPath）在目标存储中尚未创建，原代码会直接调用 `op.List`。这会导致程序返回错误 `failed list dst [...] objs` 并中断任务，无法正常完成首次同步或跨存储同步。
