### PR TITLE
fix(cloudreve): Manually set path to avoid empty path

### DIFF
--- a/drivers/cloudreve/driver.go
+++ b/drivers/cloudreve/driver.go
@@ -73,6 +73,7 @@ func (d *Cloudreve) List(ctx context.Context, dir model.Obj, args model.ListArgs
 			}
 			src.Size = dprop.Size
 		}
+		src.Path = path.Join(dir.GetPath(), src.Name)
 		return objectToObj(src, thumb), nil
 	})
 }

--- a/drivers/cloudreve/types.go
+++ b/drivers/cloudreve/types.go
@@ -59,6 +59,7 @@ func objectToObj(f Object, t model.Thumbnail) *model.ObjThumb {
 			Size:     int64(f.Size),
 			Modified: f.Date,
 			IsFolder: f.Type == "dir",
+			Path:     f.Path,
 		},
 		Thumbnail: t,
 	}


### PR DESCRIPTION
<img width="1080" height="192" alt="image" src="https://github.com/user-attachments/assets/70380d9a-8516-4fe8-b05a-cc4de8de6dc0" />


https://github.com/OpenListTeam/OpenList/pull/1734