### PR TITLE
fix(fs): panic when failed to get storage details

### DIFF
--- a/drivers/115_open/driver.go
+++ b/drivers/115_open/driver.go
@@ -331,11 +331,11 @@ func (d *Open115) GetDetails(ctx context.Context) (*model.StorageDetails, error)
 	if err != nil {
 		return nil, err
 	}
-	total, err := userInfo.RtSpaceInfo.AllTotal.Size.Int64()
+	total, err := ParseInt64(userInfo.RtSpaceInfo.AllTotal.Size)
 	if err != nil {
 		return nil, err
 	}
-	used, err := userInfo.RtSpaceInfo.AllUse.Size.Int64()
+	used, err := ParseInt64(userInfo.RtSpaceInfo.AllUse.Size)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/115_open/util.go
+++ b/drivers/115_open/util.go
@@ -1,3 +1,15 @@
 package _115_open
 
-// do others that not defined in Driver interface
+import "encoding/json"
+
+func ParseInt64(v json.Number) (int64, error) {
+	i, err := v.Int64()
+	if err == nil {
+		return i, nil
+	}
+	f, e1 := v.Float64()
+	if e1 == nil {
+		return int64(f), nil
+	}
+	return int64(0), err
+}

--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -218,8 +218,8 @@ func (d *Alias) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 			}
 			if details, ok := model.GetStorageDetails(obj); ok {
 				objRet = &model.ObjStorageDetails{
-					Obj:                    objRet,
-					StorageDetailsWithName: *details,
+					Obj:            objRet,
+					StorageDetails: details,
 				}
 			}
 			objMap[name] = objRet

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -50,11 +50,8 @@ func (d *Alias) listRoot(ctx context.Context, withDetails, refresh bool) []model
 			continue
 		}
 		objs[idx] = &model.ObjStorageDetails{
-			Obj: objs[idx],
-			StorageDetailsWithName: model.StorageDetailsWithName{
-				StorageDetails: nil,
-				DriverName:     remoteDriver.Config().Name,
-			},
+			Obj:            objs[idx],
+			StorageDetails: nil,
 		}
 		workerCount++
 		go func(dri driver.Driver, i int) {

--- a/internal/model/storage.go
+++ b/internal/model/storage.go
@@ -79,29 +79,24 @@ type StorageDetails struct {
 	DiskUsage
 }
 
-type StorageDetailsWithName struct {
-	*StorageDetails
-	DriverName string `json:"driver_name"`
-}
-
 type ObjWithStorageDetails interface {
-	GetStorageDetails() *StorageDetailsWithName
+	GetStorageDetails() *StorageDetails
 }
 
 type ObjStorageDetails struct {
 	Obj
-	StorageDetailsWithName
+	*StorageDetails
 }
 
 func (o *ObjStorageDetails) Unwrap() Obj {
 	return o.Obj
 }
 
-func (o ObjStorageDetails) GetStorageDetails() *StorageDetailsWithName {
-	return &o.StorageDetailsWithName
+func (o *ObjStorageDetails) GetStorageDetails() *StorageDetails {
+	return o.StorageDetails
 }
 
-func GetStorageDetails(obj Obj) (*StorageDetailsWithName, bool) {
+func GetStorageDetails(obj Obj) (*StorageDetails, bool) {
 	if obj, ok := obj.(ObjWithStorageDetails); ok {
 		return obj.GetStorageDetails(), true
 	}

--- a/internal/op/storage.go
+++ b/internal/op/storage.go
@@ -353,11 +353,8 @@ func GetStorageVirtualFilesWithDetailsByPath(ctx context.Context, prefix string,
 			return obj
 		}
 		ret := &model.ObjStorageDetails{
-			Obj: obj,
-			StorageDetailsWithName: model.StorageDetailsWithName{
-				StorageDetails: nil,
-				DriverName:     d.Config().Name,
-			},
+			Obj:            obj,
+			StorageDetails: nil,
 		}
 		resultChan := make(chan *model.StorageDetails, 1)
 		go func(dri driver.Driver) {

--- a/server/handles/fsread.go
+++ b/server/handles/fsread.go
@@ -33,17 +33,17 @@ type DirReq struct {
 }
 
 type ObjResp struct {
-	Name         string                        `json:"name"`
-	Size         int64                         `json:"size"`
-	IsDir        bool                          `json:"is_dir"`
-	Modified     time.Time                     `json:"modified"`
-	Created      time.Time                     `json:"created"`
-	Sign         string                        `json:"sign"`
-	Thumb        string                        `json:"thumb"`
-	Type         int                           `json:"type"`
-	HashInfoStr  string                        `json:"hashinfo"`
-	HashInfo     map[*utils.HashType]string    `json:"hash_info"`
-	MountDetails *model.StorageDetailsWithName `json:"mount_details,omitempty"`
+	Name         string                     `json:"name"`
+	Size         int64                      `json:"size"`
+	IsDir        bool                       `json:"is_dir"`
+	Modified     time.Time                  `json:"modified"`
+	Created      time.Time                  `json:"created"`
+	Sign         string                     `json:"sign"`
+	Thumb        string                     `json:"thumb"`
+	Type         int                        `json:"type"`
+	HashInfoStr  string                     `json:"hashinfo"`
+	HashInfo     map[*utils.HashType]string `json:"hash_info"`
+	MountDetails *model.StorageDetails      `json:"mount_details,omitempty"`
 }
 
 type FsListResp struct {


### PR DESCRIPTION
## Description / 描述

修复
1. beta 版本显示驱动剩余空间时`/fs/list`会 panic 的问题。
2. 115open 驱动在总空间大于约 100TiB 后，API 返回的总空间数值会变成浮点数，导致反序列化为 int64 失败。

问题1原因：一个很神奇的问题，简单地说，以下代码会 panic：
```go
type DiskUsage struct {}

func (d DiskUsage) MarshalJSON() ([]byte, error) {
    // 没有这个函数时不会 panic
}

type StorageDetails struct {
    DiskUsage
}

type StorageDetailsWithName struct {
    *StorageDetails
    Name string `json:"name"`
}

func main() {
    _, _ = json.Marshal(&StorageDetailsWithName{
        StorageDetails: nil,
        Name: "",
    })
}
```

考虑到`name`字段已无作用，删除了`StorageDetailsWithName`结构体。

## Motivation and Context / 背景

## How Has This Been Tested? / 测试

没测

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
