### PR TITLE
feat(settings): add custom domain settings for share and direct links

### DIFF
--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -173,6 +173,8 @@ func InitialSettings() []model.SettingItem {
 		{Key: conf.ForwardDirectLinkParams, Value: "false", Type: conf.TypeBool, Group: model.GLOBAL},
 		{Key: conf.IgnoreDirectLinkParams, Value: "sign,openlist_ts,raw", Type: conf.TypeString, Group: model.GLOBAL},
 		{Key: conf.WebauthnLoginEnabled, Value: "false", Type: conf.TypeBool, Group: model.GLOBAL, Flag: model.PUBLIC},
+		{Key: conf.ShareUrlDomain, Value: "", Type: conf.TypeString, Group: model.GLOBAL, Flag: model.PUBLIC, Help: "Custom domain for share links"},
+		{Key: conf.DirectLinkUrlDomain, Value: "", Type: conf.TypeString, Group: model.GLOBAL, Flag: model.PUBLIC, Help: "Custom domain for direct links"},
 		{Key: conf.SharePreview, Value: "false", Type: conf.TypeBool, Group: model.GLOBAL, Flag: model.PUBLIC},
 		{Key: conf.ShareArchivePreview, Value: "false", Type: conf.TypeBool, Group: model.GLOBAL, Flag: model.PUBLIC},
 		{Key: conf.ShareForceProxy, Value: "true", Type: conf.TypeBool, Group: model.GLOBAL, Flag: model.PRIVATE},

--- a/internal/conf/const.go
+++ b/internal/conf/const.go
@@ -56,6 +56,8 @@ const (
 	ShareArchivePreview     = "share_archive_preview"
 	ShareForceProxy         = "share_force_proxy"
 	ShareSummaryContent     = "share_summary_content"
+	ShareUrlDomain          = "share_url_domain"
+	DirectLinkUrlDomain     = "direct_link_url_domain"
 	HandleHookAfterWriting  = "handle_hook_after_writing"
 	HandleHookRateLimit     = "handle_hook_rate_limit"
 	IgnoreSystemFiles       = "ignore_system_files"


### PR DESCRIPTION
## Description / 描述

Add two new global settings to allow users to configure custom domains for share links and direct links:
- `share_url_domain`: Custom domain for share links
- `direct_link_url_domain`: Custom domain for direct links

添加两个新的全局设置，允许用户为分享链接和直链配置自定义域名：
- `share_url_domain`：分享链接的自定义域名
- `direct_link_url_domain`：直链的自定义域名

## Motivation and Context / 背景

When OpenList is deployed behind a reverse proxy or accessed via different domains (internal vs external), users may want share links and direct links to use a public domain instead of the internal IP address.

For example:
- Internal access: `http://192.168.0.107:5244`
- Public share links: `https://share.example.com`

This allows users to share links that work externally without exposing internal network addresses.

当 OpenList 部署在反向代理后面或通过不同域名访问时（内网 vs 外网），用户可能希望分享链接和直链使用公网域名而非内网IP。

例如：
- 内网访问：`http://192.168.0.107:5244`
- 公网分享链接：`https://share.example.com`

这允许用户分享可以从外部访问的链接，而无需暴露内部网络地址。

## How Has This Been Tested? / 测试

- Configured both settings with custom domains
- Verified share links use the configured `share_url_domain`
- Verified direct links use the configured `direct_link_url_domain`
- Confirmed empty settings fall back to default behavior (using `location.origin`)

## Checklist / 检查清单

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
      Labels needed: `enhancement`, `Module: Settings`
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it's needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) https://github.com/OpenListTeam/OpenList-Frontend/pull/361
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX