### PR TITLE
fix(driver/quark_uc): Fix display of non-compliant filenames

### DIFF
--- a/drivers/quark_uc/util.go
+++ b/drivers/quark_uc/util.go
@@ -73,6 +73,8 @@ func (d *QuarkOrUC) GetFiles(parent string) ([]model.Obj, error) {
 		"pdir_fid":     parent,
 		"_size":        strconv.Itoa(size),
 		"_fetch_total": "1",
+		"fetch_all_file": "1",
+		"fetch_risk_file_name": "1",
 	}
 	if d.OrderBy != "none" {
 		query["_sort"] = "file_type:asc," + d.OrderBy + ":" + d.OrderDirection


### PR DESCRIPTION
## Description / 描述

Non-compliant files are displayed as X*** in OpenList.  
盘内违规文件在 OpenList 中显示为 X*** 

For directory listing requests, adding the `fetch_all_file` and `fetch_risk_file_name` parameters allows retrieving the complete file names. This change does not affect other existing functionalities.
在列目录请求上，增加 `fetch_all_file` `fetch_risk_file_name` 两个参数可获取到完整文件名，此更改不影响其他现有功能。

<img width="1165" height="464" alt="image" src="https://github.com/user-attachments/assets/1490a56b-8b3b-4799-9f5a-b1564ae5a90e" />


## Motivation and Context / 背景

同上

## How Has This Been Tested? / 测试

已抓包测试

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [X] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [X] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [X] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [X] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [X] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
