### PR TITLE
fix(drivers/quark): apply html escaping in quark

### DIFF
--- a/drivers/quark_uc/util.go
+++ b/drivers/quark_uc/util.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"strconv"
@@ -70,10 +71,10 @@ func (d *QuarkOrUC) GetFiles(parent string) ([]model.Obj, error) {
 	page := 1
 	size := 100
 	query := map[string]string{
-		"pdir_fid":     parent,
-		"_size":        strconv.Itoa(size),
-		"_fetch_total": "1",
-		"fetch_all_file": "1",
+		"pdir_fid":             parent,
+		"_size":                strconv.Itoa(size),
+		"_fetch_total":         "1",
+		"fetch_all_file":       "1",
 		"fetch_risk_file_name": "1",
 	}
 	if d.OrderBy != "none" {
@@ -89,6 +90,7 @@ func (d *QuarkOrUC) GetFiles(parent string) ([]model.Obj, error) {
 			return nil, err
 		}
 		for _, file := range resp.Data.List {
+			file.FileName = html.UnescapeString(file.FileName)
 			if d.OnlyListVideoFile {
 				// 开启后 只列出视频文件和文件夹
 				if file.IsDir() || file.Category == 1 {


### PR DESCRIPTION
## Description / 描述

夸克网盘在存储字符串的时候会对字符串做html转义，导致文件名中包含 '、" 等html特殊字符的时候会出现一些不可预期的错误。这个提交对夸克网盘list接口列出的文件夹做了html解码，恢复字符串的显示，保证与缓存一致。

## Motivation and Context / 背景

原来夸克网盘的list接口没有经过解码，直接显示转义后的html字符串。会造成一些不必要的麻烦。

Closes #2003 

## How Has This Been Tested? / 测试

列举文件测试

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
