### PR TITLE
fix(server/webdav): improve error handling for PROPFIND

### DIFF
--- a/server/webdav/webdav.go
+++ b/server/webdav/webdav.go
@@ -82,10 +82,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			status, err = h.handleUnlock(brw, r)
 		case "PROPFIND":
 			status, err = h.handlePropfind(brw, r)
-			// if there is a error for PROPFIND, we should be as an empty folder to the client
-			if err != nil {
-				status = http.StatusNotFound
-			}
 		case "PROPPATCH":
 			status, err = h.handleProppatch(brw, r)
 		}
@@ -736,7 +732,10 @@ func (h *Handler) handlePropfind(w http.ResponseWriter, r *http.Request) (status
 		if errs.IsNotFoundError(err) {
 			return http.StatusNotFound, err
 		}
-		return http.StatusMethodNotAllowed, err
+		// It's safer to return 500 Internal Server Error to
+		// prevent clients from deleting files when we fail to read the FS
+		// (timeout, IO error, backend storage disconnected, etc)
+		return http.StatusInternalServerError, err
 	}
 	depth := infiniteDepth
 	if hdr := r.Header.Get("Depth"); hdr != "" {


### PR DESCRIPTION
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->

## Summary / 摘要

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->


让 `PROPFIND` 遇到文件系统错误时返回错误，避免返回空文件夹。


- 在文件同步场景下，报错返回空文件夹是极其危险的，轻则导致反复上传，浪费流量，严重情况下会出现数据误删

- `golang.org/x/net/webdav` 返回的是 `http.StatusMethodNotAllowed` (405)

  https://cs.opensource.google/go/x/net/+/refs/tags/v0.49.0:webdav/webdav.go


<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [x] `go test ./server/webdav`
- [x] Manual test / 手动测试: 修改前，使用 rclone 同步时，如果源存储出错，会返回空文件夹，被 rclone 判断为目标文件不存在，导致反复上传，修改后能够被正确视为错误并在程序内部自动进行指数退避处理。


TODO: 

需要确定:

- [ ] 是否影响 HTTP 207 Multi-Status是否会影响其它客户端
      已知问题：返回空文件夹在部分软件中不会报错，返回错误会弹窗，但个人认为错误弹窗是正确的表现

- [ ] 错误代码返回 500 还是 405

- [ ] 对齐 `golang.org/x/net/webdav` 的 handlePropfindError


## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。
