### PR TITLE
fix(cmd/start): use absolute executable path for child process

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -31,14 +31,23 @@ func start() {
 			return
 		}
 	}
-	args := os.Args
-	args[1] = "server"
-	args = append(args, "--force-bin-dir")
-	cmd := &exec.Cmd{
-		Path: args[0],
-		Args: args,
-		Env:  os.Environ(),
+	exe, err := os.Executable()
+	if err != nil {
+		log.Fatal("failed to resolve executable path: ", err)
 	}
+	childArgs := append([]string{"server"}, os.Args[2:]...)
+	hasForceBinDir := false
+	for _, arg := range childArgs {
+		if arg == "--force-bin-dir" {
+			hasForceBinDir = true
+			break
+		}
+	}
+	if !hasForceBinDir {
+		childArgs = append(childArgs, "--force-bin-dir")
+	}
+	cmd := exec.Command(exe, childArgs...)
+	cmd.Env = os.Environ()
 	stdout, err := os.OpenFile(filepath.Join(filepath.Dir(pidFile), "start.log"), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {
 		log.Fatal(os.Getpid(), ": failed to open start log file:", err)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -38,7 +39,7 @@ func start() {
 	childArgs := append([]string{"server"}, os.Args[2:]...)
 	hasForceBinDir := false
 	for _, arg := range childArgs {
-		if arg == "--force-bin-dir" {
+		if arg == "--force-bin-dir" || strings.HasPrefix(arg, "--force-bin-dir=") {
 			hasForceBinDir = true
 			break
 		}


### PR DESCRIPTION
<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
  For breaking changes, add `!` after the type, e.g., `feat(component)!: breaking change`.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
  如果是破坏性变更，请在类型后添加 `!`，例如 `feat(component)!: 破坏性变更`。
-->

## Description / 描述

- 将 `start` 命令启动子进程时使用的路径从 `os.Args[0]` 改为 `os.Executable()`。
- 透传 `start` 后的用户参数（`os.Args[2:]`）给 `server`。
- 当已传入 `--force-bin-dir` 时不再重复追加。

## Motivation and Context / 背景

在 Windows 上，当添加了可执行文件目录环境变量后，从非可执行文件目录调用 `openlist start` 时，`os.Args[0]` 可能是相对路径（如 `.\openlist`），导致子进程启动失败：
`exec: ".\\openlist": executable file not found in %PATH%`。

## How Has This Been Tested? / 测试

在非可执行文件目录执行 `openlist start`，确认不再出现 `exec: ".\\openlist": executable file not found in %PATH%`，确认 `start` 能成功拉起子进程（日志显示 `success start pid`）。

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
