### PR TITLE
feat(fs): support recursive file listing

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -219,6 +219,7 @@ func _fs(g *gin.RouterGroup) {
 	g.POST("/archive/decompress", handles.FsArchiveDecompress)
 	// Direct upload (client-side upload to storage)
 	g.POST("/get_direct_upload_info", middlewares.FsUp, handles.FsGetDirectUploadInfo)
+	g.POST("/recurse_list", handles.FsRecurseList)
 }
 
 func _task(g *gin.RouterGroup) {


### PR DESCRIPTION
## Description / 描述

增加递归扫描文件夹的按钮。

## Motivation and Context / 背景

- 通过递归扫描文件夹，以支持strm文件的自动生成
- 通过递归扫描文件夹，以触发目录的缓存更新操作

当前在索引界面虽有手动触发扫描的方式，但使用较不方便，需要回到管理页面添加路径触发扫描。通过此功能，可以在目录即时触发扫描操作，借助异步扫描和扫描间隔的机制，避免风控和长时间的等待。

## How Has This Been Tested? / 测试

本地测试strm文件的生成。

## Checklist / 检查清单


- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #OpenListTeam/OpenList-Frontend#385
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
