### PR TITLE
fix(server): add missing return after error responses

### DIFF
--- a/server/handles/offline_download.go
+++ b/server/handles/offline_download.go
@@ -448,6 +448,7 @@ func SetThunderBrowser(c *gin.Context) {
 		case *thunder_browser.ThunderBrowser, *thunder_browser.ThunderBrowserExpert:
 		default:
 			common.ErrorStrResp(c, "unsupported storage driver for offline download, only ThunderBrowser is supported", 400)
+			return
 		}
 	}
 	items := []model.SettingItem{

--- a/server/handles/ssologin.go
+++ b/server/handles/ssologin.go
@@ -256,11 +256,13 @@ func OIDCLoginCallback(c *gin.Context) {
 			user, err = autoRegister(userID, userID, err)
 			if err != nil {
 				common.ErrorResp(c, err, 400)
+				return
 			}
 		}
 		token, err := common.GenerateToken(user)
 		if err != nil {
 			common.ErrorResp(c, err, 400)
+			return
 		}
 		if useCompatibility {
 			c.Redirect(302, common.GetApiUrl(c)+"/@login?token="+token)
@@ -427,6 +429,7 @@ func SSOLoginCallback(c *gin.Context) {
 	token, err := common.GenerateToken(user)
 	if err != nil {
 		common.ErrorResp(c, err, 400)
+		return
 	}
 	if usecompatibility {
 		c.Redirect(302, common.GetApiUrl(c)+"/@login?token="+token)

--- a/server/handles/webauthn.go
+++ b/server/handles/webauthn.go
@@ -130,17 +130,20 @@ func BeginAuthnRegistration(c *gin.Context) {
 	authnInstance, err := authn.NewAuthnInstance(c)
 	if err != nil {
 		common.ErrorResp(c, err, 400)
+		return
 	}
 
 	options, sessionData, err := authnInstance.BeginRegistration(user)
 
 	if err != nil {
 		common.ErrorResp(c, err, 400)
+		return
 	}
 
 	val, err := json.Marshal(sessionData)
 	if err != nil {
 		common.ErrorResp(c, err, 400)
+		return
 	}
 
 	common.SuccessResp(c, gin.H{


### PR DESCRIPTION
## Description / 描述

  Add missing `return` statements after error responses in several HTTP handlers to prevent code from continuing to execute after an error has been sent to the client.

  在多个 HTTP 处理函数中，错误响应后添加缺失的 `return` 语句，以防止在向客户端发送错误后代码继续执行。

  - `server/handles/offline_download.go`: `SetThunderBrowser` — add `return` after unsupported driver error / 不支持的驱动错误后添加 `return`
  - `server/handles/ssologin.go`: `OIDCLoginCallback`, `SSOLoginCallback` — add `return` after error responses / 错误响应后添加 `return`
  - `server/handles/webauthn.go`: `BeginAuthnRegistration` — add `return` after error responses / 错误响应后添加 `return`

  ## Motivation and Context / 背景

  Without `return` after `common.ErrorResp` / `common.ErrorStrResp`, the handler continues executing after writing an error response to the client. This can cause unexpected
  behavior such as writing multiple responses, using nil/invalid values from failed operations, or triggering redirects after an error response has already been sent.

  在调用 `common.ErrorResp` / `common.ErrorStrResp` 后缺少 `return`
  语句，会导致处理函数在向客户端写入错误响应后继续执行。这可能引发意外行为，如多次写入响应、使用失败操作产生的空值/无效值，或在错误响应已发送后仍触发重定向。

  ## How Has This Been Tested? / 测试

  Manually triggered the affected error paths (unsupported driver, OIDC/SSO login failures, WebAuthn registration failures) and verified that execution stops after the error
  response.

  手动触发上述错误路径（不支持的驱动、OIDC/SSO 登录失败、WebAuthn 注册失败），确认在错误响应后执行正常终止。

  ## Checklist / 检查清单

  - [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
        我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
  - [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
        我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
  - [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
        我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
  - [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
        我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
  - [x] I have updated the repository accordingly (If it's needed).
        我已相应更新了相关仓库（若适用）。
