### PR TITLE
feat(auth)!: migrate WebAuthn to Passkey.

### DIFF
--- a/drivers/cloudreve_v4/util.go
+++ b/drivers/cloudreve_v4/util.go
@@ -143,7 +143,7 @@ func (d *CloudreveV4) login() error {
 		return errors.New("password not enabled")
 	}
 	if prepareLogin.WebauthnEnabled {
-		return errors.New("webauthn not support")
+		return errors.New("passkey not support")
 	}
 	for range 5 {
 		err = d.doLogin(siteConfig.LoginCaptcha)

--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -172,7 +172,6 @@ func InitialSettings() []model.SettingItem {
 		{Key: conf.FilenameCharMapping, Value: `{"/": "|"}`, Type: conf.TypeText, Group: model.GLOBAL},
 		{Key: conf.ForwardDirectLinkParams, Value: "false", Type: conf.TypeBool, Group: model.GLOBAL},
 		{Key: conf.IgnoreDirectLinkParams, Value: "sign,openlist_ts,raw", Type: conf.TypeString, Group: model.GLOBAL},
-		{Key: conf.WebauthnLoginEnabled, Value: "false", Type: conf.TypeBool, Group: model.GLOBAL, Flag: model.PUBLIC},
 		{Key: conf.SharePreview, Value: "false", Type: conf.TypeBool, Group: model.GLOBAL, Flag: model.PUBLIC},
 		{Key: conf.ShareArchivePreview, Value: "false", Type: conf.TypeBool, Group: model.GLOBAL, Flag: model.PUBLIC},
 		{Key: conf.ShareForceProxy, Value: "true", Type: conf.TypeBool, Group: model.GLOBAL, Flag: model.PRIVATE},

--- a/internal/bootstrap/patch/v3_32_0/update_authn.go
+++ b/internal/bootstrap/patch/v3_32_0/update_authn.go
@@ -7,7 +7,7 @@ import (
 )
 
 // UpdateAuthnForOldVersion updates users' authn
-// First published: bdfc159 fix: webauthn logspam (#6181) by itsHenry
+// First published: bdfc159 fix: passkey logspam (#6181) by itsHenry
 func UpdateAuthnForOldVersion() {
 	users, _, err := op.GetUsers(1, -1)
 	if err != nil {

--- a/internal/conf/const.go
+++ b/internal/conf/const.go
@@ -51,7 +51,6 @@ const (
 	FilenameCharMapping     = "filename_char_mapping"
 	ForwardDirectLinkParams = "forward_direct_link_params"
 	IgnoreDirectLinkParams  = "ignore_direct_link_params"
-	WebauthnLoginEnabled    = "webauthn_login_enabled"
 	SharePreview            = "share_preview"
 	ShareArchivePreview     = "share_archive_preview"
 	ShareForceProxy         = "share_force_proxy"

--- a/server/router.go
+++ b/server/router.go
@@ -67,7 +67,7 @@ func Init(e *gin.Engine) {
 
 	api := g.Group("/api")
 	auth := api.Group("", middlewares.Auth(false))
-	webauthn := api.Group("/authn", middlewares.Authn)
+	authn := api.Group("/authn", middlewares.Authn)
 
 	api.POST("/auth/login", handles.Login)
 	api.POST("/auth/login/hash", handles.LoginHash)
@@ -87,13 +87,14 @@ func Init(e *gin.Engine) {
 	api.GET("/auth/get_sso_id", handles.SSOLoginCallback)
 	api.GET("/auth/sso_get_token", handles.SSOLoginCallback)
 
-	// webauthn
-	api.GET("/authn/webauthn_begin_login", handles.BeginAuthnLogin)
-	api.POST("/authn/webauthn_finish_login", handles.FinishAuthnLogin)
-	webauthn.GET("/webauthn_begin_registration", handles.BeginAuthnRegistration)
-	webauthn.POST("/webauthn_finish_registration", handles.FinishAuthnRegistration)
-	webauthn.POST("/delete_authn", handles.DeleteAuthnLogin)
-	webauthn.GET("/getcredentials", handles.GetAuthnCredentials)
+	// passkey
+	api.GET("/authn/passkey_begin_login", handles.BeginAuthnLogin)
+	api.GET("/authn/passkey_legacy_status", handles.LegacyAuthnStatus)
+	api.POST("/authn/passkey_finish_login", handles.FinishAuthnLogin)
+	authn.GET("/passkey_begin_registration", handles.BeginAuthnRegistration)
+	authn.POST("/passkey_finish_registration", handles.FinishAuthnRegistration)
+	authn.POST("/delete_authn", handles.DeleteAuthnLogin)
+	authn.GET("/getcredentials", handles.GetAuthnCredentials)
 
 	// no need auth
 	public := api.Group("/public")


### PR DESCRIPTION
feat(passkey)!: 迁移 WebAuthn 至 Passkey 并默认启用，统一后端 API 命名

… management  

- 迁移传统 WebAuthn 至 Passkey，支持云端同步与免用户名认证  
- 将后端所有 WebAuthn API 重命名为 Passkey，提升命名标准化程度  
- 默认启用 Passkey，以符合当前行业推广趋势  
- 在 Passkey 管理页面新增显示用户设备 IP 和 User-Agent（UA），便于设备区分  
- 新增升级流程，将旧版 WebAuthn 凭证迁移至新版 Passkey 格式  
- 在旧凭证未升级或删除前，禁止创建新的 Passkey，避免升级后的兼容性问题  

<!--  
  Provide a general summary of your changes in the Title above.  
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.  
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.  
  For breaking changes, add `!` after the type, e.g., `feat(component)!: breaking change`.  
-->  
<!--  
  在上方标题中提供您更改的总体摘要。  
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。  
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。  
  如果是破坏性变更，请在类型后添加 `!`，例如 `feat(component)!: 破坏性变更`。  
-->  

## Description / 描述  

本次 PR 对现有 WebAuthn 认证体系进行整体升级，统一迁移至 Passkey 方案，并对相关接口与管理页面进行增强。

主要包括：

1. 认证体系升级  
   - 将传统 WebAuthn 迁移为 Passkey  
   - 支持云端同步（multi-device credentials）  
   - 支持免用户名输入（discoverable credentials）

2. 接口命名标准化  
   - 后端所有 `webauthn` 相关 API 重命名为 `passkey`  
   - 同步更新相关调用与文档，避免语义混用

3. 默认策略调整  
   - 将 Passkey 设置为始终启用  
   - 简化认证流程，统一安全策略

4. 管理页面增强  
   - Passkey 管理页面新增设备 IP 与 User-Agent 展示  
   - 提升多设备场景下的可识别性与可管理性

5. 旧凭证升级机制  
   - 新增“升级”按钮，引导用户将旧版 WebAuthn 凭证升级为新版 Passkey  
   - 若存在未升级的旧凭证：  
     - 禁止创建新的 Passkey  
     - 允许通过“升级”或“删除旧凭证”解除限制  

---

## Motivation and Context / 背景  

随着主流科技公司全面推广 Passkey 体系，传统 WebAuthn 命名与使用方式已逐步过时。

本次升级解决以下问题：

- 提升跨设备认证体验（支持云端同步）  
- 支持无用户名输入登录流程  
- 统一后端 API 命名，降低维护成本  
- 避免系统中长期并存两套凭证体系  
- 防止版本升级后旧凭证与新流程不兼容  

---

## How Has This Been Tested? / 测试  

- 本地环境验证：  
  - 新用户注册与创建 Passkey 流程  
  - 免用户名登录流程验证  
- 旧用户升级验证：  
  - 存在旧 WebAuthn 凭证时升级流程测试  
  - 未升级时创建新 Passkey 限制验证  
  - 删除旧凭证后恢复创建能力验证  
- 多设备测试：  
  - 不同浏览器 / 不同设备下创建与识别测试  
- API 回归测试：  
  - 重命名接口的调用路径验证  

---

## Checklist / 检查清单  

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.  
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。  
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).  
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。  
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).  
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。  
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.  
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。  
- [x] I have updated the repository accordingly (If it’s needed).  
      我已相应更新了相关仓库（若适用）。  
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #393