### PR TITLE
fix(qbittorrent): handle non-200 response during login to prevent long startup waits

### DIFF
--- a/pkg/qbittorrent/client.go
+++ b/pkg/qbittorrent/client.go
@@ -43,7 +43,7 @@ func New(webuiUrl string) (Client, error) {
 		IdleConnTimeout:     30 * time.Second,
 		DisableKeepAlives:   false, // Enable connection reuse
 	}
-	
+
 	var c = &client{
 		url: u,
 		client: http.Client{
@@ -97,6 +97,13 @@ func (c *client) login() error {
 		return err
 	}
 	defer resp.Body.Close()
+
+	// avoid long waiting time if being upgraded to websocket connections (e.g. 101 responses)
+	// as per API documentation, qBittorrent returns only 200 on successful login
+	// so we safely treat any non-200 response as a failure
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("failed to login into qBittorrent webui with status code: " + resp.Status)
+	}
 
 	// check result
 	body := make([]byte, 2)


### PR DESCRIPTION
<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
  For breaking changes, add `!` after the type, e.g., `feat(component)!: breaking change`.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
  如果是破坏性变更，请在类型后添加 `!`，例如 `feat(component)!: 破坏性变更`。
-->

## Description / 描述

openlist 默认在启动时访问 8080 端口测试 qbittorrent webui 连通性.
但是如果特殊程序如 vmess websocket 占用 8080, 由于该代理协议的特点, 不会返回任何payload
openlist 尝试登录后会收到 HTTP 101 升级 ws 后会长时间阻塞等待 body, 导致 openlist 在启动半途卡住

```
❯ ./openlist server
INFO[2026-03-23 15:12:05] reading config file: /opt/openlist/data/config.json
INFO[2026-03-23 15:12:05] load config from env with prefix: OPENLIST_
INFO[2026-03-23 15:12:05] max buffer limit: 95MB
INFO[2026-03-23 15:12:05] mmap threshold: 4MB
INFO[2026-03-23 15:12:05] init logrus...
```
会卡在这里完全不动, 有时数分钟无法等到:
```
start HTTP server @ 0.0.0.0:5244
```

可以使用 curl 快速复现卡住:
```
❯ curl -v --header 'Referer: http://localhost:8080' --data 'username=admin&password=adminadmin' http://localhost:8080/api/v2/auth/login
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> POST /api/v2/auth/login HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.5.0
> Accept: */*
> Referer: http://localhost:8080
> Content-Length: 34
> Content-Type: application/x-www-form-urlencoded
>
< HTTP/1.1 101 Switching Protocols
< Connection: upgrade
< Sec-Websocket-Accept: dGhlIHNhbXBsZSBub25jZQ==
< Upgrade: websocket
< Date: Mon, 23 Mar 2026 07:16:03 GMT
<
```

根据 qb 官方 api 文档 <https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#login>, 正常登录仅会返回 HTTP 200
因此可以将非 200 的返回值全部直接视为失败, 从而避免阻塞/卡住

## Motivation and Context / 背景

No related

## How Has This Been Tested? / 测试

添加该patch后, 启动时qb检测环节遇到非200返回能够正常改出, 不再卡住
```
WARN [2026-03-23 03:34:32] /home/xxxxxx/src/OpenListTeam/OpenList/internal/bootstrap/offline_download.go:12 github.com/OpenListTeam/OpenList/v4/internal/bootstrap.InitOfflineDownloadTools() init offline download tool qBittorrent failed: failed to login into qBittorrent webui with status code: 101 Switching Protocols
```

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [x] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [x] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
