### PR TITLE
fix(internal/conf): override config path with datadir via CLI flag

### DIFF
--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -78,6 +78,17 @@ func InitConfig() {
 		if err != nil {
 			log.Fatalf("load config error: %+v", err)
 		}
+		if flags.DataDir != "" {
+			conf.Conf.Database.DBFile = filepath.Join(flags.DataDir, "data.db")
+			conf.Conf.TempDir = filepath.Join(flags.DataDir, "temp")
+			conf.Conf.BleveDir = filepath.Join(flags.DataDir, "bleve")
+			if conf.Conf.Log.Enable {
+				conf.Conf.Log.Name = filepath.Join(flags.DataDir, "log/log.log")
+			}
+			if conf.Conf.DistDir != "" {
+				conf.Conf.DistDir = filepath.Join(flags.DataDir, "dist")
+			}
+		}
 		LastLaunchedVersion = conf.Conf.LastLaunchedVersion
 		if strings.HasPrefix(conf.Version, "v") || LastLaunchedVersion == "" {
 			conf.Conf.LastLaunchedVersion = conf.Version

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -85,7 +85,7 @@ func InitConfig() {
 			if conf.Conf.Log.Enable {
 				conf.Conf.Log.Name = filepath.Join(flags.DataDir, "log/log.log")
 			}
-			if conf.Conf.DistDir != "" {
+			if conf.Conf.DistDir == "" {
 				conf.Conf.DistDir = filepath.Join(flags.DataDir, "dist")
 			}
 		}

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -82,12 +82,7 @@ func InitConfig() {
 			conf.Conf.Database.DBFile = filepath.Join(flags.DataDir, "data.db")
 			conf.Conf.TempDir = filepath.Join(flags.DataDir, "temp")
 			conf.Conf.BleveDir = filepath.Join(flags.DataDir, "bleve")
-			if conf.Conf.Log.Enable {
-				conf.Conf.Log.Name = filepath.Join(flags.DataDir, "log/log.log")
-			}
-			if conf.Conf.DistDir == "" {
-				conf.Conf.DistDir = filepath.Join(flags.DataDir, "dist")
-			}
+			conf.Conf.Log.Name = filepath.Join(flags.DataDir, "log/log.log")
 		}
 		LastLaunchedVersion = conf.Conf.LastLaunchedVersion
 		if strings.HasPrefix(conf.Version, "v") || LastLaunchedVersion == "" {


### PR DESCRIPTION
## Description / 描述

原先的读取配置文件逻辑：

通过命令行传入的datadir做conf的初始化，然后读取配置文件覆盖conf

修改后的逻辑：

配置文件覆盖conf之后，根据命令行传入的datadir做路径重写

## Motivation and Context / 背景

issue #2268

## How Has This Been Tested? / 测试

分别使用不传入datadir的命令和传入datadir的命令启动服务，正常运行

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
