### PR TITLE
fix(offline_download): prevent infinite retry on status update failure

### DIFF
--- a/internal/offline_download/tool/download.go
+++ b/internal/offline_download/tool/download.go
@@ -147,10 +147,10 @@ func (t *DownloadTask) Update() (bool, error) {
 	if err != nil {
 		t.callStatusRetried++
 		log.Errorf("failed to get status of %s, retried %d times", t.ID, t.callStatusRetried)
+		if t.callStatusRetried > 5 {
+			return true, errors.Errorf("failed to get status of %s, retried %d times", t.ID, t.callStatusRetried)
+		}
 		return false, nil
-	}
-	if t.callStatusRetried > 5 {
-		return true, errors.Errorf("failed to get status of %s, retried %d times", t.ID, t.callStatusRetried)
 	}
 	t.callStatusRetried = 0
 	t.SetProgress(info.Progress)


### PR DESCRIPTION
## Description / 描述

代码原意应该是失败5次后就退出，但因为代码顺序问题，导致 `t.tool.Status(t)` 失败超过5次后不会自动退出，出现无限次重试。

## Motivation and Context / 背景

错误日志：

```
ERRO[2026-03-05 17:03:05] failed to get status of pyGVF4hJtjt7kHyQtl878, retried 1848 times
ERRO[2026-03-05 17:03:08] failed to get status of 51FeEG1KM_tYLLond7A2u, retried 5940 times
ERRO[2026-03-05 17:03:08] failed to get status of _n5JQoHVyoUV2cXhJNOZd, retried 1850 times
ERRO[2026-03-05 17:03:08] failed to get status of UttGaFfIZrAjqabQ1PKsR, retried 1849 times
ERRO[2026-03-05 17:03:08] failed to get status of pyGVF4hJtjt7kHyQtl878, retried 1849 times
```


## How Has This Been Tested? / 测试

<!-- Please describe in detail how you tested your changes. -->
<!-- 请详细描述您如何测试更改 -->

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
