### PR TITLE
fix(op): invalidate new path cache on meta path update

### DIFF
--- a/internal/op/meta.go
+++ b/internal/op/meta.go
@@ -78,6 +78,7 @@ func UpdateMeta(u *model.Meta) error {
 		return err
 	}
 	metaCache.Del(old.Path)
+	metaCache.Del(u.Path)
 	return db.UpdateMeta(u)
 }
 


### PR DESCRIPTION
## 问题

修改 meta 的路径后，新路径不会立即生效。

**根因：**`UpdateMeta` 更新路径时，只清除了旧路径的缓存（`old.Path`），
但未清除新路径可能已存在的缓存。如果新路径曾被访问过（缓存了 `nil`，
即"不存在"），该负缓存不会被清除，导致访问新路径时仍命中缓存返回
`MetaNotFound`，最长持续 1 小时（缓存 TTL）。

## 修复

在 `UpdateMeta` 中同时清除新路径的缓存，确保下次访问时从数据库重新加载。

## 变更

- `internal/op/meta.go`：`UpdateMeta` 增加 `metaCache.Del(u.Path)`
