### PR TITLE
fix(build): lock musl outputs to fully static linking in build script and CI workflows

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -67,32 +67,39 @@ jobs:
             goflags: ""
           - target: "linux-(mips|mips64|mipsle|mips64le|loong64)-musl*" # musl-compat-family
             hash: "md5-linux-musl-mips"
-            flags: ""
+            flags: "-ldflags=-linkmode external -extldflags '-static -fpic'"
             goflags: ""
+            musl_static: "true"
           - target: "linux-!(arm*|mips|mips64|mipsle|mips64le|loong64)-musl*" # musl-not-arm (exclude compat-family)
             hash: "md5-linux-musl"
-            flags: ""
+            flags: "-ldflags=-linkmode external -extldflags '-static -fpic'"
             goflags: ""
+            musl_static: "true"
           - target: "linux-arm*-musl*" #musl-arm
             hash: "md5-linux-musl-arm"
-            flags: ""
+            flags: "-ldflags=-linkmode external -extldflags '-static -fpic'"
             goflags: ""
+            musl_static: "true"
           - target: "windows-arm64" #win-arm64
             hash: "md5-windows-arm64"
             flags: ""
             goflags: ""
+            musl_static: "false"
           - target: "windows7-*" #win7
             hash: "md5-windows7"
             flags: ""
             goflags: "-tags=sqlite_cgo_compat"
+            musl_static: "false"
           - target: "android-*" #android
             hash: "md5-android"
             flags: ""
             goflags: ""
+            musl_static: "false"
           - target: "freebsd-*" #freebsd
             hash: "md5-freebsd"
             flags: ""
             goflags: ""
+            musl_static: "false"
 
     name: Beta Release
     runs-on: ubuntu-latest
@@ -118,6 +125,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
           flags: ${{ matrix.flags || '-ldflags=' }}
+          static-link-for-musl: true
           musl-target-format: $os-$musl-$arch
           github-token: ${{ secrets.GITHUB_TOKEN }}
           out-dir: build
@@ -131,6 +139,24 @@ jobs:
             github.com/OpenListTeam/OpenList/v4/internal/conf.WebVersion=rolling
         env:
           GOFLAGS: ${{ matrix.goflags }}
+
+      - name: Verify musl binaries are static
+        if: matrix.musl_static == 'true'
+        run: |
+          set -e
+          shopt -s nullglob
+          files=(build/openlist-*-musl-*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No musl binaries found"
+            exit 1
+          fi
+          for f in "${files[@]}"; do
+            if readelf -l "$f" | grep -q "Requesting program interpreter"; then
+              echo "Dynamic binary detected: $f"
+              readelf -l "$f" | grep "Requesting program interpreter" || true
+              exit 1
+            fi
+          done
 
       - name: Compress
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,8 @@ jobs:
         uses: OpenListTeam/cgo-actions@v1.2.2
         with:
           targets: ${{ matrix.target }}
+          flags: ${{ contains(matrix.target, '-musl') && '-ldflags=-linkmode external -extldflags ''-static -fpic''' || '-ldflags=' }}
+          static-link-for-musl: true
           musl-target-format: $os-$musl-$arch
           github-token: ${{ secrets.GITHUB_TOKEN }}
           out-dir: build
@@ -55,6 +57,16 @@ jobs:
             github.com/OpenListTeam/OpenList/v4/internal/conf.Version=$tag
             github.com/OpenListTeam/OpenList/v4/internal/conf.WebVersion=rolling
           output: openlist$ext
+
+      - name: Verify musl binary is static
+        if: contains(matrix.target, '-musl')
+        run: |
+          set -e
+          if readelf -l build/openlist | grep -q "Requesting program interpreter"; then
+            echo "Dynamic binary detected: build/openlist"
+            readelf -l build/openlist | grep "Requesting program interpreter" || true
+            exit 1
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/build.sh
+++ b/build.sh
@@ -61,6 +61,41 @@ GetBuildTagsForTarget() {
   esac
 }
 
+# Keep musl static link flags centralized for all musl build paths.
+GetMuslStaticLdflags() {
+  echo "-linkmode external -extldflags '-static -fpic' $ldflags"
+}
+
+# Fail fast if a musl build artifact is not fully static.
+AssertStaticBinary() {
+  local binary="$1"
+  if [ ! -f "$binary" ]; then
+    echo "Error: binary not found: $binary"
+    return 1
+  fi
+
+  if command -v readelf >/dev/null 2>&1; then
+    if readelf -l "$binary" 2>/dev/null | grep -q "Requesting program interpreter"; then
+      echo "Error: binary is not fully static: $binary"
+      readelf -l "$binary" | grep "Requesting program interpreter" || true
+      return 1
+    fi
+    return 0
+  fi
+
+  if command -v file >/dev/null 2>&1; then
+    if file "$binary" | grep -qi "dynamically linked"; then
+      echo "Error: binary is dynamically linked: $binary"
+      file "$binary"
+      return 1
+    fi
+    return 0
+  fi
+
+  echo "Warning: readelf/file not found, skip static verification for $binary"
+  return 0
+}
+
 FetchWebRolling() {
   pre_release_json=$(eval "curl -fsSL --max-time 2 $githubAuthArgs -H \"Accept: application/vnd.github.v3+json\" \"https://api.github.com/repos/$frontendRepo/releases/tags/rolling\"")
   pre_release_assets=$(echo "$pre_release_json" | jq -r '.assets[].browser_download_url')
@@ -145,7 +180,7 @@ BuildWin7() {
 BuildDev() {
   rm -rf .git/
   mkdir -p "dist"
-  muslflags="--extldflags '-static -fpic' $ldflags"
+  muslflags="$(GetMuslStaticLdflags)"
   BASE="https://github.com/OpenListTeam/musl-compilers/releases/latest/download/"
   FILES=(x86_64-linux-musl-cross aarch64-linux-musl-cross)
   for i in "${FILES[@]}"; do
@@ -163,7 +198,8 @@ BuildDev() {
     export GOARCH=${os_arch##*-}
     export CC=${cgo_cc}
     export CGO_ENABLED=1
-    go build -o ./dist/$appName-$os_arch -ldflags="$muslflags" -tags=jsoniter .
+    CGO_LDFLAGS="-static" go build -o ./dist/$appName-$os_arch -ldflags="$muslflags" -tags=jsoniter .
+    AssertStaticBinary "./dist/$appName-$os_arch"
   done
   xgo -targets=windows/amd64,darwin/amd64,darwin/arm64 -out "$appName" -ldflags="$ldflags" -tags=jsoniter .
   mv "$appName"-* dist
@@ -197,7 +233,7 @@ BuildDockerMultiplatform() {
   # run PrepareBuildDockerMusl before build
   export PATH=$PATH:$PWD/build/musl-libs/bin
 
-  docker_lflags="--extldflags '-static -fpic' $ldflags"
+  docker_lflags="$(GetMuslStaticLdflags)"
   export CGO_ENABLED=1
 
   OS_ARCHES=(linux-amd64 linux-arm64 linux-386 linux-riscv64 linux-ppc64le linux-loong64) ## Disable linux-s390x builds
@@ -212,7 +248,8 @@ BuildDockerMultiplatform() {
     export GOARCH=$arch
     export CC=${cgo_cc}
     echo "building for $os_arch"
-    go build -o build/$os/$arch/"$appName" -ldflags="$docker_lflags" -tags="$build_tags" .
+    CGO_LDFLAGS="-static" go build -o build/$os/$arch/"$appName" -ldflags="$docker_lflags" -tags="$build_tags" .
+    AssertStaticBinary "build/$os/$arch/$appName"
   done
 
   DOCKER_ARM_ARCHES=(linux-arm/v6 linux-arm/v7)
@@ -226,7 +263,8 @@ BuildDockerMultiplatform() {
     export GOARM=${GO_ARM[$i]}
     export CC=${cgo_cc}
     echo "building for $docker_arch"
-    go build -o build/${docker_arch%%-*}/${docker_arch##*-}/"$appName" -ldflags="$docker_lflags" -tags=jsoniter .
+    CGO_LDFLAGS="-static" go build -o build/${docker_arch%%-*}/${docker_arch##*-}/"$appName" -ldflags="$docker_lflags" -tags=jsoniter .
+    AssertStaticBinary "build/${docker_arch%%-*}/${docker_arch##*-}/$appName"
   done
 }
 
@@ -406,7 +444,7 @@ BuildLoongGLIBC() {
 BuildReleaseLinuxMusl() {
   rm -rf .git/
   mkdir -p "build"
-  muslflags="--extldflags '-static -fpic' $ldflags"
+  muslflags="$(GetMuslStaticLdflags)"
   BASE="https://github.com/OpenListTeam/musl-compilers/releases/latest/download/"
   # Keep mips-family targets enabled; sqlite driver selection is handled by Go build tags.
   FILES=(x86_64-linux-musl-cross aarch64-linux-musl-cross mips-linux-musl-cross mips64-linux-musl-cross mips64el-linux-musl-cross mipsel-linux-musl-cross powerpc64le-linux-musl-cross s390x-linux-musl-cross loongarch64-linux-musl-cross)
@@ -427,14 +465,15 @@ BuildReleaseLinuxMusl() {
     export GOARCH=${os_arch##*-}
     export CC=${cgo_cc}
     export CGO_ENABLED=1
-    go build -o ./build/$appName-$os_arch -ldflags="$muslflags" -tags="$build_tags" .
+    CGO_LDFLAGS="-static" go build -o ./build/$appName-$os_arch -ldflags="$muslflags" -tags="$build_tags" .
+    AssertStaticBinary "./build/$appName-$os_arch"
   done
 }
 
 BuildReleaseLinuxMuslArm() {
   rm -rf .git/
   mkdir -p "build"
-  muslflags="--extldflags '-static -fpic' $ldflags"
+  muslflags="$(GetMuslStaticLdflags)"
   BASE="https://github.com/OpenListTeam/musl-compilers/releases/latest/download/"
   FILES=(arm-linux-musleabi-cross arm-linux-musleabihf-cross armel-linux-musleabi-cross armel-linux-musleabihf-cross armv5l-linux-musleabi-cross armv5l-linux-musleabihf-cross armv6-linux-musleabi-cross armv6-linux-musleabihf-cross armv7l-linux-musleabihf-cross armv7m-linux-musleabi-cross armv7r-linux-musleabihf-cross)
   for i in "${FILES[@]}"; do
@@ -456,7 +495,8 @@ BuildReleaseLinuxMuslArm() {
     export CC=${cgo_cc}
     export CGO_ENABLED=1
     export GOARM=${arm}
-    go build -o ./build/$appName-$os_arch -ldflags="$muslflags" -tags=jsoniter .
+    CGO_LDFLAGS="-static" go build -o ./build/$appName-$os_arch -ldflags="$muslflags" -tags=jsoniter .
+    AssertStaticBinary "./build/$appName-$os_arch"
   done
 }
 


### PR DESCRIPTION
## Description / 描述

在构建脚本中统一 musl 的 ldflags，并强制外部静态链接模式。
在构建脚本中增加产物静态性校验，若出现动态链接则立即失败。
在 Beta Release 工作流中为 musl 矩阵显式设置静态 ldflags。
显式开启 cgo-actions 的 static-link-for-musl。
在工作流中增加 readelf 静态校验步骤，防止动态 musl 产物被打包发布。
保持现有 x-flags 注入逻辑，不影响非 musl 目标行为。

## Motivation and Context / 背景

部分 musl 目标在某些构建路径下出现了动态链接产物，导致在无兼容 musl 运行时/加载器环境中无法执行。
本次修改通过参数锁定和校验步骤双重保证静态产物，并在 CI 阶段及时拦截回归

fix https://github.com/OpenListTeam/OpenList/pull/2296 

## How Has This Been Tested? / 测试

已在脚本与 CI 工作流中加入确定性的静态校验（readelf 解释器段检测）。

全量跨平台产物结果将通过后续 CI 运行进一步确认。

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [x] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
