### PR TITLE
feat(sharing): allow custom share IDs

### DIFF
--- a/internal/db/sharing.go
+++ b/internal/db/sharing.go
@@ -64,6 +64,14 @@ func UpdateSharing(s *model.SharingDB) error {
 	return errors.WithStack(db.Save(s).Error)
 }
 
+func UpdateSharingId(oldId, newId string) error {
+	// Check if new ID already exists
+	if err := db.Where("id = ?", newId).First(&model.SharingDB{}).Error; err == nil {
+		return errors.New("sharing id already exists")
+	}
+	return errors.WithStack(db.Model(&model.SharingDB{}).Where("id = ?", oldId).Update("id", newId).Error)
+}
+
 func DeleteSharingById(id string) error {
 	s := model.SharingDB{ID: id}
 	return errors.WithStack(db.Where(s).Delete(&s).Error)

--- a/internal/model/sharing.go
+++ b/internal/model/sharing.go
@@ -3,7 +3,7 @@ package model
 import "time"
 
 type SharingDB struct {
-	ID          string     `json:"id" gorm:"type:char(12);primaryKey"`
+	ID          string     `json:"id" gorm:"type:varchar(64);primaryKey"`
 	FilesRaw    string     `json:"-" gorm:"type:text"`
 	Expires     *time.Time `json:"expires"`
 	Pwd         string     `json:"pwd"`

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -63,6 +63,7 @@ type User struct {
 	//   12: can read archives
 	//   13: can decompress archives
 	//   14: can share
+	//   15: can customize share id
 	Permission int32  `json:"permission"`
 	OtpSecret  string `json:"-"`
 	SsoID      string `json:"sso_id"` // unique by sso platform
@@ -217,6 +218,14 @@ func CanShare(permission int32) bool {
 
 func (u *User) CanShare() bool {
 	return CanShare(u.Permission)
+}
+
+func CanCustomizeShareID(permission int32) bool {
+	return (permission>>15)&1 == 1
+}
+
+func (u *User) CanCustomizeShareID() bool {
+	return CanCustomizeShareID(u.Permission)
 }
 
 func (u *User) JoinPath(reqPath string) (string, error) {

--- a/internal/op/sharing.go
+++ b/internal/op/sharing.go
@@ -133,6 +133,15 @@ func UpdateSharing(sharing *model.Sharing, skipMarshal ...bool) (err error) {
 	return db.UpdateSharing(sharing.SharingDB)
 }
 
+func UpdateSharingId(sharing *model.Sharing, newId string) error {
+	sharingCache.Del(sharing.ID)
+	if err := db.UpdateSharingId(sharing.ID, newId); err != nil {
+		return err
+	}
+	sharing.ID = newId
+	return nil
+}
+
 func DeleteSharing(sid string) error {
 	sharingCache.Del(sid)
 	return db.DeleteSharingById(sid)

--- a/server/handles/sharing.go
+++ b/server/handles/sharing.go
@@ -3,6 +3,7 @@ package handles
 import (
 	"fmt"
 	stdpath "path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -416,6 +417,19 @@ type UpdateSharingReq struct {
 	CreatorName string `json:"creator"`
 	Accessed    int    `json:"accessed"`
 	ID          string `json:"id"`
+	NewID       string `json:"new_id"`
+}
+
+var validSharingID = regexp.MustCompile(`^[\w\p{Han}\-]+$`)
+
+func validateSharingID(id string) error {
+	if len([]rune(id)) > 64 {
+		return errors.New("share id must be at most 64 characters")
+	}
+	if !validSharingID.MatchString(id) {
+		return errors.New("share id can only contain letters, numbers, underscores, hyphens, and CJK characters")
+	}
+	return nil
 }
 
 func UpdateSharing(c *gin.Context) {
@@ -471,6 +485,20 @@ func UpdateSharing(c *gin.Context) {
 	s.Readme = req.Readme
 	s.Remark = req.Remark
 	s.Creator = user
+	if req.NewID != "" && req.NewID != req.ID {
+		if !reqUser.CanCustomizeShareID() {
+			common.ErrorStrResp(c, "permission denied", 403)
+			return
+		}
+		if err = validateSharingID(req.NewID); err != nil {
+			common.ErrorResp(c, err, 400)
+			return
+		}
+		if err = op.UpdateSharingId(s, req.NewID); err != nil {
+			common.ErrorResp(c, err, 500)
+			return
+		}
+	}
 	if err = op.UpdateSharing(s); err != nil {
 		common.ErrorResp(c, err, 500)
 	} else {
@@ -493,6 +521,12 @@ func CreateSharing(c *gin.Context) {
 		common.ErrorStrResp(c, "must add at least 1 object", 400)
 		return
 	}
+	if req.ID != "" {
+		if err = validateSharingID(req.ID); err != nil {
+			common.ErrorResp(c, err, 400)
+			return
+		}
+	}
 	var user *model.User
 	reqUser := c.Request.Context().Value(conf.UserKey).(*model.User)
 	if reqUser.IsAdmin() && req.CreatorName != "" {
@@ -503,7 +537,7 @@ func CreateSharing(c *gin.Context) {
 		}
 	} else {
 		user = reqUser
-		if !user.CanShare() || (!user.IsAdmin() && req.ID != "") {
+		if !user.CanShare() || (!user.CanCustomizeShareID() && req.ID != "") {
 			common.ErrorStrResp(c, "permission denied", 403)
 			return
 		}


### PR DESCRIPTION
## Description / 描述                                                                
                  
  Allow users to set custom share IDs when creating or updating shares, instead of     
  being limited to random 8-12 character IDs.
                                                                                       
  Changes:        
  - Expand sharing ID column from `char(12)` to `varchar(64)` to support longer custom
  IDs                                                                                  
  - Add `new_id` field to `UpdateSharingReq` for renaming existing share IDs
  - Add server-side ID validation: max 64 characters, allowing letters, numbers,       
  underscores, hyphens, and CJK characters                                             
  - Add duplicate ID conflict check when updating share IDs                            
  - Add `customize_share_id` permission (bit 15) to control which users can set custom 
  IDs                                                                                  
  - Cache invalidation on ID update
                                                                                       
  允许用户在创建或更新分享时设置自定义分享 ID，而不是只能使用随机生成的 8-12 位 ID。   
                                                                                       
  ## Motivation and Context / 背景                                                     
                  
  Random share IDs like `aB3xK9mQ` are hard to remember. Custom IDs (e.g. `my-photos`, 
  `project-docs`) make share links more readable and memorable.
                                                                                       
  随机分享 ID 难以记忆，自定义 ID 让分享链接更易读、更好记。                           
   
  Closes #1806                                                                         
                  
  ## How Has This Been Tested? / 测试

  - Verified GORM `AutoMigrate` correctly alters column from `char(12)` to             
  `varchar(64)`
  - Tested custom ID creation via API with valid/invalid IDs                           
  - Tested ID rename via `new_id` field in update request                              
  - Tested duplicate ID rejection                                                      
  - Tested permission check: users without `customize_share_id` permission cannot set  
  custom IDs                                                                           
                  
  ## Checklist / 检查清单                                                              
                  
  - [x] I have read the                                                                
  [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)
  document.                                                                            
  - [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
  - [ ] I have added appropriate labels to this PR (or mentioned needed labels in the  
  description if lacking permissions).
        Labels needed: `enhancement`, `sharing`                                        
  - [ ] I have requested review from relevant code authors using the "Request review"  
  feature when applicable.
  - [x] I have updated the repository accordingly (If it's needed).                    
    - [x] OpenListTeam/OpenList-Frontend#472
    - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX