### PR TITLE
fix(drivers/wps): implement driver.GetRooter interface

### DIFF
--- a/drivers/wps/driver.go
+++ b/drivers/wps/driver.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
+	"strings"
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/errs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -59,6 +60,59 @@ func (d *Wps) Drop(ctx context.Context) error {
 	return nil
 }
 
+func (d *Wps) GetRoot(ctx context.Context) (model.Obj, error) {
+	root := &Obj{
+		Obj: &model.Object{
+			Path:     "/",
+			Name:     "root",
+			Modified: d.Modified,
+			Ctime:    d.Modified,
+			IsFolder: true,
+		},
+		Kind: "root",
+	}
+	rootPath := d.RootFolderPath
+	if rootPath != "" && rootPath != "/" {
+		parts := strings.Split(strings.Trim(rootPath, "/"), "/")
+		groups, err := d.getGroups(ctx)
+		if err != nil {
+			return nil, err
+		}
+		var current *Obj
+		for _, g := range groups {
+			if g.Name == parts[0] {
+				current = g.groupToObj("/")
+				break
+			}
+		}
+		if current == nil {
+			return nil, fmt.Errorf("root path %q not found", rootPath)
+		}
+		parentID := int64(0)
+		for _, name := range parts[1:] {
+			files, err := d.getFiles(ctx, current.GroupID, parentID)
+			if err != nil {
+				return nil, err
+			}
+			var next *Obj
+			for _, f := range files {
+				if f.Type == "folder" && f.Name == name {
+					next = f.fileToObj(current.GetPath(), d.isPersonal())
+					break
+				}
+			}
+			if next == nil {
+				return nil, fmt.Errorf("root path %q not found", rootPath)
+			}
+			current = next
+			parentID = current.FileID
+		}
+		current.Obj = &model.Object{ID: current.GetID(), Path: "/", Name: current.GetName(), IsFolder: true}
+		root = current
+	}
+	return root, nil
+}
+
 func (d *Wps) List(ctx context.Context, dir model.Obj, _ model.ListArgs) ([]model.Obj, error) {
 	basePath := "/"
 	if dir != nil {
@@ -66,33 +120,18 @@ func (d *Wps) List(ctx context.Context, dir model.Obj, _ model.ListArgs) ([]mode
 			basePath = p
 		}
 	}
-	if basePath == "/" {
+	node, err := unwrapWpsObj(dir)
+	if err != nil {
+		return nil, err
+	}
+	if node.Kind == "root" {
 		groups, err := d.getGroups(ctx)
 		if err != nil {
 			return nil, err
 		}
-		res := make([]model.Obj, 0, len(groups))
-		for _, g := range groups {
-			path := joinPath(basePath, g.Name)
-			obj := &Obj{
-				Obj: &model.Object{
-					ID:       strconv.FormatInt(g.GroupID, 10),
-					Path:     path,
-					Name:     g.Name,
-					Modified: parseTime(0),
-					Ctime:    parseTime(0),
-					IsFolder: true,
-				},
-				Kind:    "group",
-				GroupID: g.GroupID,
-			}
-			res = append(res, obj)
-		}
-		return res, nil
-	}
-	node, err := unwrapWpsObj(dir)
-	if err != nil {
-		return nil, err
+		return utils.SliceConvert(groups, func(g Group) (model.Obj, error) {
+			return g.groupToObj(basePath), nil
+		})
 	}
 	if node.Kind != "group" && node.Kind != "folder" {
 		return nil, nil
@@ -105,11 +144,9 @@ func (d *Wps) List(ctx context.Context, dir model.Obj, _ model.ListArgs) ([]mode
 	if err != nil {
 		return nil, err
 	}
-	res := make([]model.Obj, 0, len(files))
-	for _, f := range files {
-		res = append(res, f.fileToObj(basePath, d.isPersonal()))
-	}
-	return res, nil
+	return utils.SliceConvert(files, func(f FileInfo) (model.Obj, error) {
+		return f.fileToObj(basePath, d.isPersonal()), nil
+	})
 }
 
 func (d *Wps) Link(ctx context.Context, file model.Obj, _ model.LinkArgs) (*model.Link, error) {
@@ -357,3 +394,4 @@ func (d *Wps) GetDetails(ctx context.Context) (*model.StorageDetails, error) {
 }
 
 var _ driver.Driver = (*Wps)(nil)
+var _ driver.GetRooter = (*Wps)(nil)

--- a/drivers/wps/driver.go
+++ b/drivers/wps/driver.go
@@ -175,7 +175,13 @@ func (d *Wps) Link(ctx context.Context, file model.Obj, _ model.LinkArgs) (*mode
 	if resp.URL == "" {
 		return nil, fmt.Errorf("empty download url")
 	}
-	return &model.Link{URL: resp.URL, Header: http.Header{}}, nil
+	return &model.Link{
+		URL: resp.URL,
+		Header: http.Header{
+			"User-Agent": []string{d.getUA()},
+			"Referer":    []string{d.driveHost()},
+		},
+	}, nil
 }
 
 func (d *Wps) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {

--- a/drivers/wps/meta.go
+++ b/drivers/wps/meta.go
@@ -13,11 +13,10 @@ type Addition struct {
 }
 
 var config = driver.Config{
-	Name:              "WPS",
-	LocalSort:         true,
-	DefaultRoot:       "/",
-	Alert:             "",
-	NoOverwriteUpload: true,
+	Name:        "WPS",
+	LocalSort:   true,
+	DefaultRoot: "/",
+	Alert:       "",
 }
 
 func init() {

--- a/drivers/wps/types.go
+++ b/drivers/wps/types.go
@@ -93,6 +93,19 @@ func (f FileInfo) fileToObj(basePath string, isPersonal bool) *Obj {
 	return obj
 }
 
+func (g Group) groupToObj(basePath string) *Obj {
+	return &Obj{
+		Obj: &model.Object{
+			ID:       strconv.FormatInt(g.GroupID, 10),
+			Path:     joinPath(basePath, g.Name),
+			Name:     g.Name,
+			IsFolder: true,
+		},
+		Kind:    "group",
+		GroupID: g.GroupID,
+	}
+}
+
 type filesResp struct {
 	Files      []FileInfo `json:"files"`
 	NextOffset int        `json:"next_offset"`


### PR DESCRIPTION
<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
  For breaking changes, add `!` after the type, e.g., `feat(component)!: breaking change`.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
  如果是破坏性变更，请在类型后添加 `!`，例如 `feat(component)!: 破坏性变更`。
-->

## Description / 描述

<!-- Describe your changes in detail -->
<!-- 详细描述您的更改 -->

- 实现 `driver.GetRooter` 接口，修复 #2411 引入的bug——不支持修改根文件夹路径。
- 为 Group 实现 groupToObj
- 为 Link 方法增加头部信息
- 修复覆盖上传失败

## Motivation and Context / 背景

<!-- Why is this change required? What problem does it solve? -->
<!-- 为什么需要此更改？它解决了什么问题？ -->

<!-- If it fixes an open issue, please link to the issue here. -->
<!-- 如果修复了一个打开的issue，请在此处链接到该issue -->

Relates to #2411

## How Has This Been Tested? / 测试

<!-- Please describe in detail how you tested your changes. -->
<!-- 请详细描述您如何测试更改 -->

将配置路径为 `/我的云文档/Share` 后，文件增删改查复制等正常。

覆盖上传同名文件正常，不会报参数错误。

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [x] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
