### PR TITLE
fix(webauthn): fix webauthn key option during registration to impl discoverable key

### DIFF
--- a/server/handles/webauthn.go
+++ b/server/handles/webauthn.go
@@ -133,7 +133,10 @@ func BeginAuthnRegistration(c *gin.Context) {
 		return
 	}
 
-	options, sessionData, err := authnInstance.BeginRegistration(user)
+	options, sessionData, err := authnInstance.BeginRegistration(
+		user,
+		webauthn.WithResidentKeyRequirement(protocol.ResidentKeyRequirementRequired),
+	)
 
 	if err != nil {
 		common.ErrorResp(c, err, 400)


### PR DESCRIPTION
## Description / 描述

**一句话：现在使用通行密钥登录时，不用提前输入用户名了。**
修复 WebAuthn 注册流程中的 key option 配置，注册时显式要求使用 discoverable key（resident key）。
## Motivation and Context / 背景
当前注册流程中未明确要求 discoverable key，可能导致部分依赖该能力的 WebAuthn 注册/认证场景行为不符合预期。
这次修改通过在注册阶段增加 `ResidentKeyRequirementRequired` 配置，使注册结果更符合 discoverable key 的预期使用方式

修改前：不提前输入用户名，密码管理器不会罗列该站点的通行密钥
<img width="1862" height="1224" alt="ScreenShot 2026-05-07 at 16 45 18@2x" src="https://github.com/user-attachments/assets/ee63df18-5d27-46f9-b999-45ebd5d53fcd" />

修改后：不提前输入用户名，密码管理器可以正常罗列该站点的所有通行密钥
<img width="1856" height="1216" alt="ScreenShot 2026-05-07 at 16 47 12@2x" src="https://github.com/user-attachments/assets/ddd3bb76-358d-4439-900e-c477b39cad7e" />

## How Has This Been Tested? / 测试
基于本次提交内容进行了代码层面的检查，确认：
- 本次改动范围集中在 `server/handles/webauthn.go`，未引入额外接口变更。
- 已验证 WebAuthn 注册流程可正常返回注册参数；```  {
    "authenticatorSelection": {
        "requireResidentKey": true,
        "residentKey": "required"
    }
}``` 
- 已验证登录流程，在不传`username`参数时，客户端可发现该站点所有通行密钥，服务端接收请求时可正常从通行密钥中解析出用户并完成登录流程；
## Checklist / 检查清单
- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [ ] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).