### PR TITLE
fix(offline_download): fix login failure caused by qBittorrent 5.2.0 returning HTTP 204 No Content on successful authentication

### DIFF
--- a/pkg/qbittorrent/client.go
+++ b/pkg/qbittorrent/client.go
@@ -99,12 +99,14 @@ func (c *client) login() error {
 	defer resp.Body.Close()
 
 	// avoid long waiting time if being upgraded to websocket connections (e.g. 101 responses)
-	// as per API documentation, qBittorrent returns only 200 on successful login
-	// so we safely treat any non-200 response as a failure
-	if resp.StatusCode != http.StatusOK {
+	// as per API documentation, qBittorrent returns only 200 on successful login (qBittorrent < 5.2.0)
+	// qBittorrent 5.2.0 /api/v2/auth/login returns HTTP 204 on success
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		return errors.New("failed to login into qBittorrent webui with status code: " + resp.Status)
 	}
-
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
 	// check result
 	body := make([]byte, 2)
 	_, err = resp.Body.Read(body)
@@ -180,6 +182,10 @@ func (c *client) AddFromLink(link string, savePath string, id string) error {
 		return err
 	}
 	defer resp.Body.Close()
+	// qBittorrent 5.2.0 returns 204 on success.
+	if resp.StatusCode != http.StatusNoContent {
+		return nil
+	}
 
 	// check result
 	body := make([]byte, 2)


### PR DESCRIPTION
fix(offline_download): fix login failure caused by qBittorrent 5.2.0 returning HTTP 204 No Content on successful authentication

<!--
  Provide a general summary of your changes in the Title above.
  The PR title must start with `feat(): `, `docs(): `, `fix(): `, `style(): `, or `refactor(): `, `chore(): `. For example: `feat(component): add new feature`.
  If it spans multiple components, use the main component as the prefix and enumerate in the title, describe in the body.
  For breaking changes, add `!` after the type, e.g., `feat(component)!: breaking change`.
-->
<!--
  在上方标题中提供您更改的总体摘要。
  PR 标题需以 `feat(): `, `docs(): `, `fix(): `, `style(): `, `refactor(): `, `chore(): ` 其中之一开头，例如：`feat(component): 新增功能`。
  如果跨多个组件，请使用主要组件作为前缀，并在标题中枚举、描述中说明。
  如果是破坏性变更，请在类型后添加 `!`，例如 `feat(component)!: 破坏性变更`。
-->

## Description / 描述
Fix qBittorrent login failure when using version 5.2.0 or later.

Starting from qBittorrent 5.2.0, the WebUI login API returns `204 No Content` on successful authentication instead of `200 OK` with "Ok" response body. This causes the current client implementation to fail with an EOF error when reading the empty response body.

<!-- Describe your changes in detail -->
<!-- 详细描述您的更改 -->

## Motivation and Context / 背景
The current qBittorrent client implementation expects login success to return status code 200 with "Ok" response body. However, qBittorrent 5.2.0 returns 204 No Content with an empty body, causing:

- EOF error when reading empty response body
- Failed to initialize qBittorrent offline download tool

<!-- Why is this change required? What problem does it solve? -->
<!-- 为什么需要此更改？它解决了什么问题？ -->

<!-- If it fixes an open issue, please link to the issue here. -->
<!-- 如果修复了一个打开的issue，请在此处链接到该issue -->

## How Has This Been Tested? / 测试

- qBittorrent 5.1.4: ✅ Login success (200 OK)
- qBittorrent 5.2.0: ✅ Login success (204 No Content)

## Checklist / 检查清单

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- 检查以下所有要点，并在所有适用的框中打`x` -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- 如果您对其中任何一项不确定，请不要犹豫提问。我们会帮助您！ -->

- [x] I have read the [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) document.
      我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md) 文档。
- [x] I have formatted my code with `go fmt` or [prettier](https://prettier.io/).
      我已使用 `go fmt` 或 [prettier](https://prettier.io/) 格式化提交的代码。
- [ ] I have added appropriate labels to this PR (or mentioned needed labels in the description if lacking permissions).
      我已为此 PR 添加了适当的标签（如无权限或需要的标签不存在，请在描述中说明，管理员将后续处理）。
- [x] I have requested review from relevant code authors using the "Request review" feature when applicable.
      我已在适当情况下使用"Request review"功能请求相关代码作者进行审查。
- [ ] I have updated the repository accordingly (If it’s needed).
      我已相应更新了相关仓库（若适用）。
  - [ ] [OpenList-Frontend](https://github.com/OpenListTeam/OpenList-Frontend) #XXXX
  - [ ] [OpenList-Docs](https://github.com/OpenListTeam/OpenList-Docs) #XXXX
