### PR TITLE
fix(drivers/github_releases): skip broken repos instead of returning 500

### DIFF
--- a/drivers/github_releases/driver.go
+++ b/drivers/github_releases/driver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/internal/errs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
+	log "github.com/sirupsen/logrus"
 )
 
 type GithubReleases struct {
@@ -45,9 +46,14 @@ func (d *GithubReleases) List(ctx context.Context, dir model.Obj, args model.Lis
 		point := &d.points[i]
 
 		if !d.Addition.ShowAllVersion { // latest
-			point.RequestRelease(d.GetRequest, args.Refresh)
+			if err := point.RequestRelease(d.GetRequest, args.Refresh); err != nil {
+				log.Warnf("failed to request release for %s: %v", point.Repo, err)
+			}
 
 			if point.Point == path { // 与仓库路径相同
+				if point.Release == nil {
+					return nil, fmt.Errorf("failed to get release for %s", point.Repo)
+				}
 				files = append(files, point.GetLatestRelease()...)
 				if d.Addition.ShowReadme {
 					files = append(files, point.GetOtherFile(d.GetRequest, args.Refresh)...)
@@ -70,21 +76,31 @@ func (d *GithubReleases) List(ctx context.Context, dir model.Obj, args model.Lis
 					}
 				}
 				if !hasSameDir {
+					var updateAt, createAt string
+					if point.Release != nil {
+						updateAt = point.Release.PublishedAt
+						createAt = point.Release.CreatedAt
+					}
 					files = append(files, File{
 						Path:     stdpath.Join(path, nextDir),
 						FileName: nextDir,
 						Size:     point.GetLatestSize(),
-						UpdateAt: point.Release.PublishedAt,
-						CreateAt: point.Release.CreatedAt,
+						UpdateAt: updateAt,
+						CreateAt: createAt,
 						Type:     "dir",
 						Url:      "",
 					})
 				}
 			}
 		} else { // all version
-			point.RequestReleases(d.GetRequest, args.Refresh)
+			if err := point.RequestReleases(d.GetRequest, args.Refresh); err != nil {
+				log.Warnf("failed to request releases for %s: %v", point.Repo, err)
+			}
 
 			if point.Point == path { // 与仓库路径相同
+				if point.Releases == nil {
+					return nil, fmt.Errorf("failed to get releases for %s", point.Repo)
+				}
 				files = append(files, point.GetAllVersion()...)
 				if d.Addition.ShowReadme {
 					files = append(files, point.GetOtherFile(d.GetRequest, args.Refresh)...)
@@ -104,12 +120,17 @@ func (d *GithubReleases) List(ctx context.Context, dir model.Obj, args model.Lis
 					}
 				}
 				if !hasSameDir {
+					var updateAt, createAt string
+					if point.Releases != nil && len(*point.Releases) > 0 {
+						updateAt = (*point.Releases)[0].PublishedAt
+						createAt = (*point.Releases)[0].CreatedAt
+					}
 					files = append(files, File{
 						FileName: nextDir,
 						Path:     stdpath.Join(path, nextDir),
 						Size:     point.GetAllVersionSize(),
-						UpdateAt: (*point.Releases)[0].PublishedAt,
-						CreateAt: (*point.Releases)[0].CreatedAt,
+						UpdateAt: updateAt,
+						CreateAt: createAt,
 						Type:     "dir",
 						Url:      "",
 					})
@@ -118,6 +139,9 @@ func (d *GithubReleases) List(ctx context.Context, dir model.Obj, args model.Lis
 				tagName := GetNextDir(path, point.Point)
 				if tagName == "" {
 					continue
+				}
+				if point.Releases == nil {
+					return nil, fmt.Errorf("failed to get releases for %s", point.Repo)
 				}
 
 				files = append(files, point.GetReleaseByTagName(tagName)...)

--- a/drivers/github_releases/driver.go
+++ b/drivers/github_releases/driver.go
@@ -46,17 +46,25 @@ func (d *GithubReleases) List(ctx context.Context, dir model.Obj, args model.Lis
 		point := &d.points[i]
 
 		if !d.Addition.ShowAllVersion { // latest
-			if err := point.RequestRelease(d.GetRequest, args.Refresh); err != nil {
+			err := point.RequestRelease(d.GetRequest, args.Refresh)
+			if err != nil {
 				log.Warnf("failed to request release for %s: %v", point.Repo, err)
 			}
 
 			if point.Point == path { // 与仓库路径相同
 				if point.Release == nil {
-					return nil, fmt.Errorf("failed to get release for %s", point.Repo)
+					if err != nil {
+						return nil, fmt.Errorf("failed to get release for %s: %w", point.Repo, err)
+					}
+					return nil, fmt.Errorf("failed to get release for %s: unknown error", point.Repo)
 				}
 				files = append(files, point.GetLatestRelease()...)
 				if d.Addition.ShowReadme {
-					files = append(files, point.GetOtherFile(d.GetRequest, args.Refresh)...)
+					otherFiles, err := point.GetOtherFile(d.GetRequest, args.Refresh)
+					if err != nil {
+						return nil, fmt.Errorf("failed to get other files for %s: %w", point.Repo, err)
+					}
+					files = append(files, otherFiles...)
 				}
 				if d.Addition.ShowSourceCode {
 					files = append(files, point.GetSourceCode()...)
@@ -65,6 +73,9 @@ func (d *GithubReleases) List(ctx context.Context, dir model.Obj, args model.Lis
 				nextDir := GetNextDir(point.Point, path)
 				if nextDir == "" {
 					continue
+				}
+				if err != nil {
+					return nil, fmt.Errorf("failed to get release for %s: %w", point.Repo, err)
 				}
 
 				hasSameDir := false
@@ -93,22 +104,33 @@ func (d *GithubReleases) List(ctx context.Context, dir model.Obj, args model.Lis
 				}
 			}
 		} else { // all version
-			if err := point.RequestReleases(d.GetRequest, args.Refresh); err != nil {
+			err := point.RequestReleases(d.GetRequest, args.Refresh)
+			if err != nil {
 				log.Warnf("failed to request releases for %s: %v", point.Repo, err)
 			}
 
 			if point.Point == path { // 与仓库路径相同
 				if point.Releases == nil {
-					return nil, fmt.Errorf("failed to get releases for %s", point.Repo)
+					if err != nil {
+						return nil, fmt.Errorf("failed to get releases for %s: %w", point.Repo, err)
+					}
+					return nil, fmt.Errorf("failed to get releases for %s: unknown error", point.Repo)
 				}
 				files = append(files, point.GetAllVersion()...)
 				if d.Addition.ShowReadme {
-					files = append(files, point.GetOtherFile(d.GetRequest, args.Refresh)...)
+					otherFiles, err := point.GetOtherFile(d.GetRequest, args.Refresh)
+					if err != nil {
+						return nil, fmt.Errorf("failed to get other files for %s: %w", point.Repo, err)
+					}
+					files = append(files, otherFiles...)
 				}
 			} else if strings.HasPrefix(point.Point, path) { // 仓库目录的父目录
 				nextDir := GetNextDir(point.Point, path)
 				if nextDir == "" {
 					continue
+				}
+				if err != nil {
+					return nil, fmt.Errorf("failed to get releases for %s: %w", point.Repo, err)
 				}
 
 				hasSameDir := false
@@ -141,7 +163,10 @@ func (d *GithubReleases) List(ctx context.Context, dir model.Obj, args model.Lis
 					continue
 				}
 				if point.Releases == nil {
-					return nil, fmt.Errorf("failed to get releases for %s", point.Repo)
+					if err != nil {
+						return nil, fmt.Errorf("failed to get releases for %s: %w", point.Repo, err)
+					}
+					return nil, fmt.Errorf("failed to get releases for %s: unknown error", point.Repo)
 				}
 
 				files = append(files, point.GetReleaseByTagName(tagName)...)

--- a/drivers/github_releases/types.go
+++ b/drivers/github_releases/types.go
@@ -19,33 +19,54 @@ type MountPoint struct {
 }
 
 // 请求最新版本
-func (m *MountPoint) RequestRelease(get func(url string) (*resty.Response, error), refresh bool) {
+func (m *MountPoint) RequestRelease(get func(url string) (*resty.Response, error), refresh bool) error {
 	if m.Repo == "" {
-		return
+		return nil
 	}
 
 	if m.Release == nil || refresh {
-		resp, _ := get("https://api.github.com/repos/" + m.Repo + "/releases/latest")
-		m.Release = new(Release)
-		json.Unmarshal(resp.Body(), m.Release)
+		resp, err := get("https://api.github.com/repos/" + m.Repo + "/releases/latest")
+		if err != nil {
+			m.Release = nil
+			return err
+		}
+		release := new(Release)
+		if err := json.Unmarshal(resp.Body(), release); err != nil {
+			m.Release = nil
+			return err
+		}
+		m.Release = release
 	}
+	return nil
 }
 
 // 请求所有版本
-func (m *MountPoint) RequestReleases(get func(url string) (*resty.Response, error), refresh bool) {
+func (m *MountPoint) RequestReleases(get func(url string) (*resty.Response, error), refresh bool) error {
 	if m.Repo == "" {
-		return
+		return nil
 	}
 
 	if m.Releases == nil || refresh {
-		resp, _ := get("https://api.github.com/repos/" + m.Repo + "/releases")
-		m.Releases = new([]Release)
-		json.Unmarshal(resp.Body(), m.Releases)
+		resp, err := get("https://api.github.com/repos/" + m.Repo + "/releases")
+		if err != nil {
+			m.Releases = nil
+			return err
+		}
+		releases := new([]Release)
+		if err := json.Unmarshal(resp.Body(), releases); err != nil {
+			m.Releases = nil
+			return err
+		}
+		m.Releases = releases
 	}
+	return nil
 }
 
 // 获取最新版本
 func (m *MountPoint) GetLatestRelease() []File {
+	if m.Release == nil {
+		return nil
+	}
 	files := make([]File, 0, len(m.Release.Assets))
 	for _, asset := range m.Release.Assets {
 		files = append(files, File{
@@ -63,6 +84,9 @@ func (m *MountPoint) GetLatestRelease() []File {
 
 // 获取最新版本大小
 func (m *MountPoint) GetLatestSize() int64 {
+	if m.Release == nil {
+		return 0
+	}
 	size := int64(0)
 	for _, asset := range m.Release.Assets {
 		size += asset.Size
@@ -72,6 +96,9 @@ func (m *MountPoint) GetLatestSize() int64 {
 
 // 获取所有版本
 func (m *MountPoint) GetAllVersion() []File {
+	if m.Releases == nil {
+		return nil
+	}
 	files := make([]File, 0)
 	for _, release := range *m.Releases {
 		file := File{
@@ -93,6 +120,9 @@ func (m *MountPoint) GetAllVersion() []File {
 
 // 根据版本号获取版本
 func (m *MountPoint) GetReleaseByTagName(tagName string) []File {
+	if m.Releases == nil {
+		return nil
+	}
 	for _, item := range *m.Releases {
 		if item.TagName == tagName {
 			files := make([]File, 0)
@@ -145,6 +175,9 @@ func (m *MountPoint) GetAllVersionSize() int64 {
 }
 
 func (m *MountPoint) GetSourceCode() []File {
+	if m.Release == nil {
+		return nil
+	}
 	files := make([]File, 0)
 
 	// 无法获取文件大小，此处设为 1
@@ -171,6 +204,9 @@ func (m *MountPoint) GetSourceCode() []File {
 }
 
 func (m *MountPoint) GetSourceCodeByTagName(tagName string) []File {
+	if m.Releases == nil {
+		return nil
+	}
 	for _, item := range *m.Releases {
 		if item.TagName == tagName {
 			files := make([]File, 0)
@@ -200,9 +236,17 @@ func (m *MountPoint) GetSourceCodeByTagName(tagName string) []File {
 
 func (m *MountPoint) GetOtherFile(get func(url string) (*resty.Response, error), refresh bool) []File {
 	if m.OtherFile == nil || refresh {
-		resp, _ := get("https://api.github.com/repos/" + m.Repo + "/contents")
-		m.OtherFile = new([]FileInfo)
-		json.Unmarshal(resp.Body(), m.OtherFile)
+		resp, err := get("https://api.github.com/repos/" + m.Repo + "/contents")
+		if err != nil {
+			m.OtherFile = nil
+			return nil
+		}
+		otherFile := new([]FileInfo)
+		if err := json.Unmarshal(resp.Body(), otherFile); err != nil {
+			m.OtherFile = nil
+			return nil
+		}
+		m.OtherFile = otherFile
 	}
 
 	files := make([]File, 0)

--- a/drivers/github_releases/types.go
+++ b/drivers/github_releases/types.go
@@ -234,17 +234,17 @@ func (m *MountPoint) GetSourceCodeByTagName(tagName string) []File {
 	return nil
 }
 
-func (m *MountPoint) GetOtherFile(get func(url string) (*resty.Response, error), refresh bool) []File {
+func (m *MountPoint) GetOtherFile(get func(url string) (*resty.Response, error), refresh bool) ([]File, error) {
 	if m.OtherFile == nil || refresh {
 		resp, err := get("https://api.github.com/repos/" + m.Repo + "/contents")
 		if err != nil {
 			m.OtherFile = nil
-			return nil
+			return nil, err
 		}
 		otherFile := new([]FileInfo)
 		if err := json.Unmarshal(resp.Body(), otherFile); err != nil {
 			m.OtherFile = nil
-			return nil
+			return nil, err
 		}
 		m.OtherFile = otherFile
 	}
@@ -264,7 +264,7 @@ func (m *MountPoint) GetOtherFile(get func(url string) (*resty.Response, error),
 			})
 		}
 	}
-	return files
+	return files, nil
 }
 
 type File struct {

--- a/drivers/github_releases/util.go
+++ b/drivers/github_releases/util.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
 	"github.com/go-resty/resty/v2"
-	log "github.com/sirupsen/logrus"
 )
 
 // 发送 GET 请求
@@ -23,7 +22,6 @@ func (d *GithubReleases) GetRequest(url string) (*resty.Response, error) {
 		return nil, err
 	}
 	if res.StatusCode() != 200 {
-		log.Warn("failed to get request: ", res.StatusCode(), res.String())
 		return nil, fmt.Errorf("github api error: status %d", res.StatusCode())
 	}
 	return res, nil

--- a/drivers/github_releases/util.go
+++ b/drivers/github_releases/util.go
@@ -24,6 +24,7 @@ func (d *GithubReleases) GetRequest(url string) (*resty.Response, error) {
 	}
 	if res.StatusCode() != 200 {
 		log.Warn("failed to get request: ", res.StatusCode(), res.String())
+		return nil, fmt.Errorf("github api error: status %d", res.StatusCode())
 	}
 	return res, nil
 }


### PR DESCRIPTION
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->

## Summary / 摘要

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->

When multiple repos are configured and one fails (404, rate limit, etc.), the driver now logs a warning and skips that repo instead of panicking with a nil pointer dereference that caused a 500 error for the entire storage. Added proper error propagation from GetRequest through RequestRelease/RequestReleases/GetOtherFile, and nil checks on all Release/Releases dereferences.

Instead of hiding broken repos entirely, still display them as directory entries in parent listings. Return an error only when the user navigates into a broken repo.

### 背景

挂载好多个仓库（如下），访问挂载的根目录， 报错 500，也没有报错信息。发现是 uv 有问题，删了 astral-sh 那两个就正常。说明 OpenList 没有跳过错误，在挂载多个仓库时，这样会使其他本来能访问的仓库也无法访问，体验不好。


```
frp:fatedier/frp
amlogic-s9xxx-armbian:ophub/amlogic-s9xxx-armbian
EasyTier:EasyTier/EasyTier
rclone:rclone/rclone
uv:astral-sh/uv
python-build-standalone:astral-sh/python-build-standalone
FFmpeg-Builds:KarinJS/FFmpeg-Builds
```


<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:


## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [ ] `go test ./...`
- [x] Manual test / 手动测试:

~~AI 改的，还没测。~~

测试能够实现预期效果：

<img width="1986" height="860" alt="image" src="https://github.com/user-attachments/assets/2f85a6ff-731f-472f-a5f1-bf6fb31ea5b2" />

<img width="1952" height="372" alt="image" src="https://github.com/user-attachments/assets/c19a4243-51d2-4559-a6ad-934f8e372f4f" />


## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。