### PR TITLE
fix(offline_download): restore SimpleHttp fallback for http links

### DIFF
--- a/internal/offline_download/tool/add.go
+++ b/internal/offline_download/tool/add.go
@@ -69,13 +69,14 @@ func AddURL(ctx context.Context, args *AddURLArgs) (task.TaskExtensionInfo, erro
 	}
 	// try putting url
 	if args.Tool == "SimpleHttp" {
+		if isSimpleHttpSchemeUnsupported(args.URL) {
+			return nil, fmt.Errorf("SimpleHttp tool does not support this URL scheme, please use aria2 or other tools for magnet/ed2k links")
+		}
 		err = tryPutUrl(ctx, args.DstDirPath, args.URL)
 		if err == nil || !errors.Is(err, errs.NotImplement) {
 			return nil, err
 		}
-		// SimpleHttp 不支持非 HTTP/HTTPS 协议（如 magnet、ed2k 等）
-		// tryPutUrl 返回 NotImplement 说明 URL 不是 HTTP/HTTPS
-		return nil, fmt.Errorf("SimpleHttp tool does not support this URL scheme, please use aria2 or other tools for magnet/ed2k links")
+		// Fallback to creating a download task when storage lacks native PutURL support.
 	}
 
 	// ed2k 链接自动路由：如果当前工具不支持 ed2k，自动尝试使用迅雷系工具
@@ -184,15 +185,20 @@ func tryPutUrl(ctx context.Context, path, urlStr string) error {
 	var dstName string
 	u, err := url.Parse(urlStr)
 	if err == nil {
-		// 只支持 HTTP/HTTPS 协议，其他协议（magnet、ed2k 等）返回 NotImplement
-		if u.Scheme != "" && u.Scheme != "http" && u.Scheme != "https" {
-			return errors.WithStack(errs.NotImplement)
-		}
 		dstName = stdpath.Base(u.Path)
 	} else {
 		dstName = "UnnamedURL"
 	}
 	return fs.PutURL(ctx, path, dstName, urlStr)
+}
+
+func isSimpleHttpSchemeUnsupported(urlStr string) bool {
+	u, err := url.Parse(strings.TrimSpace(urlStr))
+	if err != nil || u.Scheme == "" {
+		return false
+	}
+	scheme := strings.ToLower(u.Scheme)
+	return scheme != "http" && scheme != "https"
 }
 
 // isEd2kURL 检测 URL 是否为 ed2k 协议


### PR DESCRIPTION
## Summary / 摘要

- Fixed a regression where SimpleHttp returned the same unsupported scheme error for normal HTTP and HTTPS links.
- Restored fallback behavior: when native PutURL is not implemented by the target storage, the system now creates an offline download task instead of failing early.
- Kept the new protocol guard for SimpleHttp on non-HTTP and non-HTTPS schemes, so magnet and ed2k links still show the expected guidance.
- Kept existing ed2k routing logic for non-SimpleHttp tools unchanged.
- No breaking change.
- No public API, config, storage format, or migration change.

## Related Issues / 关联 Issue

Relates to #2452

## Testing / 测试

- [ ] go test ./...
- [x] Targeted test: go test ./internal/offline_download/tool
- [ ] Manual test / 手动测试:

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
	/ 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
	/ 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with gofmt, go fmt, or prettier where applicable.
	/ 我已按适用情况使用 gofmt、go fmt 或 prettier 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
	/ 我已在适用情况下请求相关维护者或代码所有者审查。