### PR TITLE
fix(fs): clear skipped names before copy and move tasks

### DIFF
--- a/server/handles/fsmanage.go
+++ b/server/handles/fsmanage.go
@@ -119,6 +119,7 @@ func FsMove(c *gin.Context) {
 			req.Names[i] = ""
 			continue
 		}
+		req.Names[i] = srcPath
 		if !req.Overwrite {
 			base := stdpath.Base(srcPath)
 			if base == "." || base == "/" {
@@ -129,12 +130,11 @@ func FsMove(c *gin.Context) {
 				if !req.SkipExisting {
 					common.ErrorStrResp(c, fmt.Sprintf("file [%s] exists", name), 403)
 					return
-				} else {
-					continue
 				}
+				req.Names[i] = ""
+				continue
 			}
 		}
-		req.Names[i] = srcPath
 	}
 
 	// Create all tasks immediately without any synchronous validation
@@ -222,6 +222,7 @@ func FsCopy(c *gin.Context) {
 			req.Names[i] = ""
 			continue
 		}
+		req.Names[i] = srcPath
 		if !req.Overwrite {
 			base := stdpath.Base(srcPath)
 			if base == "." || base == "/" {
@@ -233,11 +234,11 @@ func FsCopy(c *gin.Context) {
 					common.ErrorStrResp(c, fmt.Sprintf("file [%s] exists", name), 403)
 					return
 				} else if !req.Merge || !res.IsDir() {
+					req.Names[i] = ""
 					continue
 				}
 			}
 		}
-		req.Names[i] = srcPath
 	}
 
 	// Create all tasks immediately without any synchronous validation


### PR DESCRIPTION
## Summary / 摘要

- Fixed a bug in batch copy and move where skip_existing could still pass raw item names into task creation.
- Normalized each valid source entry to full source path before destination conflict checks in FsCopy and FsMove.
- Explicitly cleared skipped entries so the downstream task loop cannot consume stale raw names.
- User-visible behavior change: when skip_existing is enabled and destination already contains same-name objects, the request now skips correctly instead of triggering storage not found with rawPath.
- No breaking change.
- No public API, config, storage format, or migration change.

## Related Issues / 关联 Issue

Fixes #2519

## Testing / 测试

- [ ] go test ./...
- [x] Targeted test: go test ./server/handles
- [x] Targeted test: go test ./server/...
- [ ] Manual test / 手动测试:

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with gofmt, go fmt, or prettier where applicable.
      / 我已按适用情况使用 gofmt、go fmt 或 prettier 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。
