### PR TITLE
fix(driver): json: cannot unmarshal number into Go struct field RenameResp.id of type string

### DIFF
--- a/drivers/189pc/types.go
+++ b/drivers/189pc/types.go
@@ -432,7 +432,7 @@ type RenameResp struct {
 	ResMsg      string `json:"res_message"`
 	CreateDate  Time   `json:"createDate"`
 	FileCate    int    `json:"fileCata"`
-	ID          string `json:"id"`
+	ID          String `json:"id"`
 	LastOpTime  Time   `json:"lastOpTime"`
 	MD5         string `json:"md5"`
 	MediaType   int    `json:"mediaType"`
@@ -446,7 +446,7 @@ type RenameResp struct {
 
 func (r *RenameResp) toFile(f *Cloud189File) *Cloud189File {
 	return &Cloud189File{
-		ID:         String(r.ID),
+		ID:         r.ID,
 		Name:       r.Name,
 		Size:       r.Size,
 		Md5:        r.MD5,
@@ -458,7 +458,7 @@ func (r *RenameResp) toFile(f *Cloud189File) *Cloud189File {
 
 func (r *RenameResp) toFolder() *Cloud189Folder {
 	return &Cloud189Folder{
-		ID:         String(r.ID),
+		ID:         r.ID,
 		Name:       r.Name,
 		ParentID:   r.ParentID,
 		LastOpTime: r.LastOpTime,


### PR DESCRIPTION
<!--
PR title / PR 标题:
fix(189pc): cannot unmarshal number into RenameResp.id of type string
-->

## Summary / 摘要

修复天翼云网盘家庭模式（Family）下，rename 接口返回的 `id` 字段为数字类型导致 JSON 反序列化失败的问题。

家庭模式 API 返回 `{"id": 12345678}`（number），而个人模式返回 `{"id": "12345678"}`（string）。
原 `RenameResp.ID` 字段类型为 Go 原生 `string`，无法兼容数字类型的 JSON 值。

将 `RenameResp.ID` 字段类型从 `string` 改为项目中已有的自定义 `String` 类型，该类型实现了 `UnmarshalJSON` 方法，可同时处理 string 和 number 两种 JSON 格式。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: N/A
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

## Testing / 测试

- 手动测试：本地文件复制到天翼云家庭空间，rename 操作不再报错 `json: cannot unmarshal number into Go struct field RenameResp.id of type string`

- [ ] `go test ./...`
- [x] Manual test / 手动测试: 本地复制文件到天翼云家庭空间，验证上传后 rename 正常完成

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
