### PR TITLE
fix(doubao_new): remove temp file after cross-storage put

### DIFF
--- a/drivers/doubao_new/driver.go
+++ b/drivers/doubao_new/driver.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -300,7 +301,10 @@ func (d *DoubaoNew) Put(ctx context.Context, dstDir model.Obj, file model.FileSt
 	if err != nil {
 		return nil, err
 	}
-	defer tmpFile.Close()
+	defer func() {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpFile.Name())
+	}()
 
 	blockSize := uploadPrep.BlockSize
 	totalSize := file.GetSize()


### PR DESCRIPTION
## Summary / 摘要

- Fixed a bug where cross-storage copy uploads to Doubao New could leave `temp/file-*` temporary files after upload completion.
- In `drivers/doubao_new/driver.go`, the upload temp file created via `utils.CreateTempFile` is now always cleaned by `defer` with `Close + Remove`.
- User-visible behavior change: after copy tasks complete, temporary files generated for this upload path are cleaned up, preventing Temp directory growth and disk exhaustion.
- Important implementation note: no upload protocol logic was changed; this is a lifecycle cleanup fix only.
- Scope note: this PR does not introduce a global upload framework change; existing drivers that use `os.CreateTemp` were checked and already perform `Close + Remove` in defer.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Related Issues / 关联 Issue

Fixes #2529

## Testing / 测试

- [ ] `go test ./...`
- [x] Targeted test: `go test ./drivers/doubao_new`
- [ ] Manual test / 手动测试:
  Not executed in this change set.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [x] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [x] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
