### PR TITLE
feat(drivers/alidoc): add DingTalk Docs driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ output/
 /!public/dist/README.md
 
 .VSCodeCounter
+
+/alidoc/

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,3 @@ output/
 /!public/dist/README.md
 
 .VSCodeCounter
-
-/alidoc/

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Thank you for your support and understanding of the OpenList project.
   - [x] [OpenList](https://github.com/OpenListTeam/OpenList)
   - [x] [Teldrive](https://github.com/tgdrive/teldrive)
   - [x] [Weiyun](https://www.weiyun.com)
+  - [x] [DingTalk Docs](https://alidocs.dingtalk.com/)
 - [x] Easy to deploy and out-of-the-box
 - [x] File preview (PDF, markdown, code, plain text, ...)
 - [x] Image preview in gallery mode

--- a/README_cn.md
+++ b/README_cn.md
@@ -95,6 +95,7 @@ OpenList 是一个由 OpenList 团队独立维护的开源项目，遵循 AGPL-3
   - [x] [OpenList](https://github.com/OpenListTeam/OpenList)
   - [x] [Teldrive](https://github.com/tgdrive/teldrive)
   - [x] [微云](https://www.weiyun.com)
+  - [x] [钉钉文档](https://alidocs.dingtalk.com/)
 - [x] 部署方便，开箱即用
 - [x] 文件预览（PDF、markdown、代码、纯文本等）
 - [x] 画廊模式下的图片预览

--- a/README_ja.md
+++ b/README_ja.md
@@ -94,6 +94,7 @@ OpenListプロジェクトへのご支援とご理解をありがとうござい
   - [x] [OpenList](https://github.com/OpenListTeam/OpenList)
   - [x] [Teldrive](https://github.com/tgdrive/teldrive)
   - [x] [Weiyun](https://www.weiyun.com)
+  - [x] [DingTalk ドキュメント](https://alidocs.dingtalk.com/)
   - [x] [MediaFire](https://www.mediafire.com)
 - [x] 簡単にデプロイでき、すぐに使える
 - [x] ファイルプレビュー（PDF、markdown、コード、テキストなど）

--- a/README_nl.md
+++ b/README_nl.md
@@ -95,6 +95,7 @@ Dank u voor uw ondersteuning en begrip
   - [x] [OpenList](https://github.com/OpenListTeam/OpenList)
   - [x] [Teldrive](https://github.com/tgdrive/teldrive)
   - [x] [Weiyun](https://www.weiyun.com)
+  - [x] [DingTalk-documenten](https://alidocs.dingtalk.com/)
 - [x] Eenvoudig te implementeren en direct te gebruiken
 - [x] Bestandsvoorbeeld (PDF, markdown, code, platte tekst, ...)
 - [x] Afbeeldingsvoorbeeld in galerijweergave

--- a/drivers/alidoc/driver.go
+++ b/drivers/alidoc/driver.go
@@ -1,0 +1,131 @@
+package alidoc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/OpenListTeam/OpenList/v4/drivers/base"
+	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/go-resty/resty/v2"
+)
+
+type AliDoc struct {
+	model.Storage
+	Addition
+
+	client *resty.Client
+}
+
+func (d *AliDoc) Config() driver.Config {
+	return config
+}
+
+func (d *AliDoc) GetAddition() driver.Additional {
+	return &d.Addition
+}
+
+func (d *AliDoc) Init(ctx context.Context) error {
+	d.Cookie = strings.TrimSpace(d.Cookie)
+	d.RootFolderID = strings.TrimSpace(d.RootFolderID)
+	if d.Cookie == "" {
+		return fmt.Errorf("cookie is empty")
+	}
+	if d.RootFolderID == "" {
+		return fmt.Errorf("root folder id is empty")
+	}
+	d.client = newClient()
+	if _, err := d.list(ctx, d.RootFolderID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *AliDoc) Drop(ctx context.Context) error {
+	d.client = nil
+	return nil
+}
+
+func (d *AliDoc) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
+	parentID := d.RootFolderID
+	parentPath := "/"
+	if dir != nil {
+		if id := strings.TrimSpace(dir.GetID()); id != "" {
+			parentID = id
+		}
+		if p := dir.GetPath(); p != "" {
+			parentPath = p
+		}
+	}
+
+	items, err := d.list(ctx, parentID)
+	if err != nil {
+		return nil, err
+	}
+
+	objs := make([]model.Obj, 0, len(items))
+	for _, item := range items {
+		if strings.TrimSpace(item.DentryUUID) == "" || strings.TrimSpace(item.Name) == "" {
+			continue
+		}
+		objs = append(objs, toObj(parentPath, item))
+	}
+	return objs, nil
+}
+
+func (d *AliDoc) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
+	if file == nil || file.IsDir() {
+		return nil, fmt.Errorf("alidoc does not support directory links")
+	}
+	resp, err := d.download(ctx, file.GetID())
+	if err != nil {
+		return nil, err
+	}
+	url, err := firstDownloadURL(resp)
+	if err != nil {
+		return nil, err
+	}
+	return &model.Link{
+		URL: url,
+		Header: http.Header{
+			"User-Agent": []string{base.UserAgent},
+			"Referer":    []string{apiBase + "/"},
+		},
+	}, nil
+}
+
+func (d *AliDoc) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) (model.Obj, error) {
+	return nil, readonlyError()
+}
+
+func (d *AliDoc) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	return nil, readonlyError()
+}
+
+func (d *AliDoc) Rename(ctx context.Context, srcObj model.Obj, newName string) (model.Obj, error) {
+	return nil, readonlyError()
+}
+
+func (d *AliDoc) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	return nil, readonlyError()
+}
+
+func (d *AliDoc) Remove(ctx context.Context, obj model.Obj) error {
+	return readonlyError()
+}
+
+func (d *AliDoc) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
+	return nil, readonlyError()
+}
+
+var (
+	_ driver.Driver       = (*AliDoc)(nil)
+	_ driver.MkdirResult  = (*AliDoc)(nil)
+	_ driver.MoveResult   = (*AliDoc)(nil)
+	_ driver.RenameResult = (*AliDoc)(nil)
+	_ driver.CopyResult   = (*AliDoc)(nil)
+	_ driver.Remove       = (*AliDoc)(nil)
+	_ driver.PutResult    = (*AliDoc)(nil)
+)

--- a/drivers/alidoc/driver.go
+++ b/drivers/alidoc/driver.go
@@ -101,7 +101,38 @@ func (d *AliDoc) MakeDir(ctx context.Context, parentDir model.Obj, dirName strin
 }
 
 func (d *AliDoc) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
-	return nil, readonlyError()
+	if srcObj == nil {
+		return nil, fmt.Errorf("source object is nil")
+	}
+	if dstDir == nil {
+		return nil, fmt.Errorf("destination directory is nil")
+	}
+	sourceID := strings.TrimSpace(srcObj.GetID())
+	targetID := strings.TrimSpace(dstDir.GetID())
+	if sourceID == "" {
+		return nil, fmt.Errorf("source dentry uuid is empty")
+	}
+	if targetID == "" {
+		return nil, fmt.Errorf("target parent dentry uuid is empty")
+	}
+
+	var result apiResp
+	resp, err := d.request(ctx).
+		SetBody(map[string]interface{}{
+			"targetParentDentryUuid": targetID,
+			"sourceDentryUuid":       sourceID,
+			"operateFrom":            1,
+		}).
+		SetResult(&result).
+		SetError(&result).
+		Post(apiBase + "/box/api/v2/dentry/move")
+	if err != nil {
+		return nil, err
+	}
+	if err := checkResp(resp, result); err != nil {
+		return nil, err
+	}
+	return srcObj, nil
 }
 
 func (d *AliDoc) Rename(ctx context.Context, srcObj model.Obj, newName string) (model.Obj, error) {
@@ -113,11 +144,30 @@ func (d *AliDoc) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj,
 }
 
 func (d *AliDoc) Remove(ctx context.Context, obj model.Obj) error {
-	return readonlyError()
+	if obj == nil {
+		return fmt.Errorf("object is nil")
+	}
+	dentryUUID := strings.TrimSpace(obj.GetID())
+	if dentryUUID == "" {
+		return fmt.Errorf("dentry uuid is empty")
+	}
+
+	var result apiResp
+	resp, err := d.request(ctx).
+		SetBody(map[string]string{
+			"dentryUuid": dentryUUID,
+		}).
+		SetResult(&result).
+		SetError(&result).
+		Post(apiBase + "/box/api/v1/dentry/recycle")
+	if err != nil {
+		return err
+	}
+	return checkResp(resp, result)
 }
 
 func (d *AliDoc) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
-	return nil, readonlyError()
+	return d.put(ctx, dstDir, file, up)
 }
 
 var (

--- a/drivers/alidoc/driver.go
+++ b/drivers/alidoc/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path"
 	"strings"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
@@ -97,7 +98,47 @@ func (d *AliDoc) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 }
 
 func (d *AliDoc) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) (model.Obj, error) {
-	return nil, readonlyError()
+	dirName = strings.TrimSpace(dirName)
+	if dirName == "" {
+		return nil, fmt.Errorf("folder name is empty")
+	}
+
+	parentID := d.RootFolderID
+	parentPath := "/"
+	if parentDir != nil {
+		if id := strings.TrimSpace(parentDir.GetID()); id != "" {
+			parentID = id
+		}
+		if p := parentDir.GetPath(); p != "" {
+			parentPath = p
+		}
+	}
+
+	var result apiResp
+	resp, err := d.request(ctx).
+		SetBody(map[string]string{
+			"dentryType":             "folder",
+			"name":                   dirName,
+			"parentDentryUuid":       parentID,
+			"conflictHandleStrategy": "auto_rename",
+		}).
+		SetResult(&result).
+		SetError(&result).
+		Post(apiBase + "/box/api/v2/dentry/createfolder")
+	if err != nil {
+		return nil, err
+	}
+	if err := checkResp(resp, result); err != nil {
+		return nil, err
+	}
+	return &Object{
+		Object: model.Object{
+			Path:     joinPath(parentPath, dirName),
+			Name:     dirName,
+			IsFolder: true,
+		},
+		DentryType: "folder",
+	}, nil
 }
 
 func (d *AliDoc) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
@@ -136,11 +177,99 @@ func (d *AliDoc) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj,
 }
 
 func (d *AliDoc) Rename(ctx context.Context, srcObj model.Obj, newName string) (model.Obj, error) {
-	return nil, readonlyError()
+	if srcObj == nil {
+		return nil, fmt.Errorf("source object is nil")
+	}
+	newName = strings.TrimSpace(newName)
+	if newName == "" {
+		return nil, fmt.Errorf("new name is empty")
+	}
+	dentryUUID := strings.TrimSpace(srcObj.GetID())
+	if dentryUUID == "" {
+		return nil, fmt.Errorf("dentry uuid is empty")
+	}
+
+	var result apiResp
+	resp, err := d.request(ctx).
+		SetBody(map[string]string{
+			"dentryUuid": dentryUUID,
+			"name":       newName,
+		}).
+		SetResult(&result).
+		SetError(&result).
+		Post(apiBase + "/box/api/v2/dentry/rename")
+	if err != nil {
+		return nil, err
+	}
+	if err := checkResp(resp, result); err != nil {
+		return nil, err
+	}
+
+	newPath := srcObj.GetPath()
+	if newPath != "" {
+		newPath = path.Join(path.Dir(newPath), newName)
+	}
+	return &Object{
+		Object: model.Object{
+			ID:       srcObj.GetID(),
+			Path:     newPath,
+			Name:     newName,
+			Size:     srcObj.GetSize(),
+			Modified: srcObj.ModTime(),
+			Ctime:    srcObj.CreateTime(),
+			IsFolder: srcObj.IsDir(),
+			HashInfo: srcObj.GetHash(),
+		},
+		DentryType: pickAliDocDentryType(srcObj),
+	}, nil
 }
 
 func (d *AliDoc) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
-	return nil, readonlyError()
+	if srcObj == nil {
+		return nil, fmt.Errorf("source object is nil")
+	}
+	if dstDir == nil {
+		return nil, fmt.Errorf("destination directory is nil")
+	}
+	sourceID := strings.TrimSpace(srcObj.GetID())
+	targetID := strings.TrimSpace(dstDir.GetID())
+	if sourceID == "" {
+		return nil, fmt.Errorf("source dentry uuid is empty")
+	}
+	if targetID == "" {
+		return nil, fmt.Errorf("target parent dentry uuid is empty")
+	}
+
+	var result apiResp
+	resp, err := d.request(ctx).
+		SetBody(map[string]interface{}{
+			"sourceDentryUuid":       sourceID,
+			"targetParentDentryUuid": targetID,
+			"operateFrom":            1,
+			"onlyCopyMeta":           false,
+		}).
+		SetResult(&result).
+		SetError(&result).
+		Post(apiBase + "/box/api/v2/dentry/copy")
+	if err != nil {
+		return nil, err
+	}
+	if err := checkResp(resp, result); err != nil {
+		return nil, err
+	}
+
+	return &Object{
+		Object: model.Object{
+			Path:     joinPath(dstDir.GetPath(), srcObj.GetName()),
+			Name:     srcObj.GetName(),
+			Size:     srcObj.GetSize(),
+			Modified: srcObj.ModTime(),
+			Ctime:    srcObj.CreateTime(),
+			IsFolder: srcObj.IsDir(),
+			HashInfo: srcObj.GetHash(),
+		},
+		DentryType: pickAliDocDentryType(srcObj),
+	}, nil
 }
 
 func (d *AliDoc) Remove(ctx context.Context, obj model.Obj) error {

--- a/drivers/alidoc/driver.go
+++ b/drivers/alidoc/driver.go
@@ -65,7 +65,7 @@ func (d *AliDoc) List(ctx context.Context, dir model.Obj, args model.ListArgs) (
 }
 
 func (d *AliDoc) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
-	if file == nil || file.IsDir() {
+	if file.IsDir() {
 		return nil, fmt.Errorf("alidoc does not support directory links")
 	}
 	resp, err := d.download(ctx, file.GetID())
@@ -86,15 +86,10 @@ func (d *AliDoc) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 }
 
 func (d *AliDoc) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) (model.Obj, error) {
-	dirName = strings.TrimSpace(dirName)
-	if dirName == "" {
-		return nil, fmt.Errorf("folder name is empty")
-	}
-
 	err := d.post(ctx, "/box/api/v2/dentry/createfolder", map[string]string{
 		"dentryType":             "folder",
 		"name":                   dirName,
-		"parentDentryUuid":       d.parentID(parentDir),
+		"parentDentryUuid":       parentDir.GetID(),
 		"conflictHandleStrategy": "auto_rename",
 	})
 	if err != nil {
@@ -104,24 +99,9 @@ func (d *AliDoc) MakeDir(ctx context.Context, parentDir model.Obj, dirName strin
 }
 
 func (d *AliDoc) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
-	if srcObj == nil {
-		return nil, fmt.Errorf("source object is nil")
-	}
-	if dstDir == nil {
-		return nil, fmt.Errorf("destination directory is nil")
-	}
-	sourceID := aliDocObjID(srcObj)
-	targetID := aliDocObjID(dstDir)
-	if sourceID == "" {
-		return nil, fmt.Errorf("source dentry uuid is empty")
-	}
-	if targetID == "" {
-		return nil, fmt.Errorf("target parent dentry uuid is empty")
-	}
-
 	err := d.post(ctx, "/box/api/v2/dentry/move", map[string]interface{}{
-		"targetParentDentryUuid": targetID,
-		"sourceDentryUuid":       sourceID,
+		"targetParentDentryUuid": dstDir.GetID(),
+		"sourceDentryUuid":       srcObj.GetID(),
 		"operateFrom":            1,
 	})
 	if err != nil {
@@ -131,71 +111,30 @@ func (d *AliDoc) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj,
 }
 
 func (d *AliDoc) Rename(ctx context.Context, srcObj model.Obj, newName string) (model.Obj, error) {
-	if srcObj == nil {
-		return nil, fmt.Errorf("source object is nil")
-	}
-	newName = strings.TrimSpace(newName)
-	if newName == "" {
-		return nil, fmt.Errorf("new name is empty")
-	}
-	dentryUUID := aliDocObjID(srcObj)
-	if dentryUUID == "" {
-		return nil, fmt.Errorf("dentry uuid is empty")
-	}
-
 	err := d.post(ctx, "/box/api/v2/dentry/rename", map[string]string{
-		"dentryUuid": dentryUUID,
+		"dentryUuid": srcObj.GetID(),
 		"name":       newName,
 	})
 	if err != nil {
 		return nil, err
 	}
-	return nil, nil
+	srcObj.(*model.Object).Name = newName
+	return srcObj, nil
 }
 
-func (d *AliDoc) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
-	if srcObj == nil {
-		return nil, fmt.Errorf("source object is nil")
-	}
-	if dstDir == nil {
-		return nil, fmt.Errorf("destination directory is nil")
-	}
-	sourceID := aliDocObjID(srcObj)
-	targetID := aliDocObjID(dstDir)
-	if sourceID == "" {
-		return nil, fmt.Errorf("source dentry uuid is empty")
-	}
-	if targetID == "" {
-		return nil, fmt.Errorf("target parent dentry uuid is empty")
-	}
-
-	err := d.post(ctx, "/box/api/v2/dentry/copy", map[string]interface{}{
-		"sourceDentryUuid":       sourceID,
-		"targetParentDentryUuid": targetID,
+func (d *AliDoc) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
+	return d.post(ctx, "/box/api/v2/dentry/copy", map[string]interface{}{
+		"sourceDentryUuid":       srcObj.GetID(),
+		"targetParentDentryUuid": dstDir.GetID(),
 		"operateFrom":            1,
 		"onlyCopyMeta":           false,
 	})
-	if err != nil {
-		return nil, err
-	}
-	return nil, nil
 }
 
 func (d *AliDoc) Remove(ctx context.Context, obj model.Obj) error {
-	if obj == nil {
-		return fmt.Errorf("object is nil")
-	}
-	dentryUUID := aliDocObjID(obj)
-	if dentryUUID == "" {
-		return fmt.Errorf("dentry uuid is empty")
-	}
 	return d.post(ctx, "/box/api/v1/dentry/recycle", map[string]string{
-		"dentryUuid": dentryUUID,
+		"dentryUuid": obj.GetID(),
 	})
-}
-
-func (d *AliDoc) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
-	return d.put(ctx, dstDir, file, up)
 }
 
 var (
@@ -203,7 +142,6 @@ var (
 	_ driver.MkdirResult  = (*AliDoc)(nil)
 	_ driver.MoveResult   = (*AliDoc)(nil)
 	_ driver.RenameResult = (*AliDoc)(nil)
-	_ driver.CopyResult   = (*AliDoc)(nil)
+	_ driver.Copy         = (*AliDoc)(nil)
 	_ driver.Remove       = (*AliDoc)(nil)
-	_ driver.PutResult    = (*AliDoc)(nil)
 )

--- a/drivers/alidoc/driver.go
+++ b/drivers/alidoc/driver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"path"
 	"strings"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
@@ -51,13 +50,9 @@ func (d *AliDoc) Drop(ctx context.Context) error {
 
 func (d *AliDoc) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
 	parentID := d.RootFolderID
-	parentPath := "/"
 	if dir != nil {
 		if id := strings.TrimSpace(dir.GetID()); id != "" {
 			parentID = id
-		}
-		if p := dir.GetPath(); p != "" {
-			parentPath = p
 		}
 	}
 
@@ -71,7 +66,7 @@ func (d *AliDoc) List(ctx context.Context, dir model.Obj, args model.ListArgs) (
 		if strings.TrimSpace(item.DentryUUID) == "" || strings.TrimSpace(item.Name) == "" {
 			continue
 		}
-		objs = append(objs, toObj(parentPath, item))
+		objs = append(objs, toObj(item))
 	}
 	return objs, nil
 }
@@ -104,13 +99,9 @@ func (d *AliDoc) MakeDir(ctx context.Context, parentDir model.Obj, dirName strin
 	}
 
 	parentID := d.RootFolderID
-	parentPath := "/"
 	if parentDir != nil {
 		if id := strings.TrimSpace(parentDir.GetID()); id != "" {
 			parentID = id
-		}
-		if p := parentDir.GetPath(); p != "" {
-			parentPath = p
 		}
 	}
 
@@ -133,7 +124,6 @@ func (d *AliDoc) MakeDir(ctx context.Context, parentDir model.Obj, dirName strin
 	}
 	return &Object{
 		Object: model.Object{
-			Path:     joinPath(parentPath, dirName),
 			Name:     dirName,
 			IsFolder: true,
 		},
@@ -204,15 +194,9 @@ func (d *AliDoc) Rename(ctx context.Context, srcObj model.Obj, newName string) (
 	if err := checkResp(resp, result); err != nil {
 		return nil, err
 	}
-
-	newPath := srcObj.GetPath()
-	if newPath != "" {
-		newPath = path.Join(path.Dir(newPath), newName)
-	}
 	return &Object{
 		Object: model.Object{
 			ID:       srcObj.GetID(),
-			Path:     newPath,
 			Name:     newName,
 			Size:     srcObj.GetSize(),
 			Modified: srcObj.ModTime(),
@@ -260,7 +244,6 @@ func (d *AliDoc) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj,
 
 	return &Object{
 		Object: model.Object{
-			Path:     joinPath(dstDir.GetPath(), srcObj.GetName()),
 			Name:     srcObj.GetName(),
 			Size:     srcObj.GetSize(),
 			Modified: srcObj.ModTime(),

--- a/drivers/alidoc/driver.go
+++ b/drivers/alidoc/driver.go
@@ -40,9 +40,6 @@ func (d *AliDoc) Init(ctx context.Context) error {
 	if err := d.checkCookie(ctx); err != nil {
 		return err
 	}
-	if _, err := d.list(ctx, d.RootFolderID); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/drivers/alidoc/driver.go
+++ b/drivers/alidoc/driver.go
@@ -91,37 +91,16 @@ func (d *AliDoc) MakeDir(ctx context.Context, parentDir model.Obj, dirName strin
 		return nil, fmt.Errorf("folder name is empty")
 	}
 
-	parentID := d.RootFolderID
-	if parentDir != nil {
-		if id := strings.TrimSpace(parentDir.GetID()); id != "" {
-			parentID = id
-		}
-	}
-
-	var result apiResp
-	resp, err := d.request(ctx).
-		SetBody(map[string]string{
-			"dentryType":             "folder",
-			"name":                   dirName,
-			"parentDentryUuid":       parentID,
-			"conflictHandleStrategy": "auto_rename",
-		}).
-		SetResult(&result).
-		SetError(&result).
-		Post(apiBase + "/box/api/v2/dentry/createfolder")
+	err := d.post(ctx, "/box/api/v2/dentry/createfolder", map[string]string{
+		"dentryType":             "folder",
+		"name":                   dirName,
+		"parentDentryUuid":       d.parentID(parentDir),
+		"conflictHandleStrategy": "auto_rename",
+	})
 	if err != nil {
 		return nil, err
 	}
-	if err := checkResp(resp, result); err != nil {
-		return nil, err
-	}
-	return &Object{
-		Object: model.Object{
-			Name:     dirName,
-			IsFolder: true,
-		},
-		DentryType: "folder",
-	}, nil
+	return nil, nil
 }
 
 func (d *AliDoc) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
@@ -131,8 +110,8 @@ func (d *AliDoc) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj,
 	if dstDir == nil {
 		return nil, fmt.Errorf("destination directory is nil")
 	}
-	sourceID := strings.TrimSpace(srcObj.GetID())
-	targetID := strings.TrimSpace(dstDir.GetID())
+	sourceID := aliDocObjID(srcObj)
+	targetID := aliDocObjID(dstDir)
 	if sourceID == "" {
 		return nil, fmt.Errorf("source dentry uuid is empty")
 	}
@@ -140,20 +119,12 @@ func (d *AliDoc) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj,
 		return nil, fmt.Errorf("target parent dentry uuid is empty")
 	}
 
-	var result apiResp
-	resp, err := d.request(ctx).
-		SetBody(map[string]interface{}{
-			"targetParentDentryUuid": targetID,
-			"sourceDentryUuid":       sourceID,
-			"operateFrom":            1,
-		}).
-		SetResult(&result).
-		SetError(&result).
-		Post(apiBase + "/box/api/v2/dentry/move")
+	err := d.post(ctx, "/box/api/v2/dentry/move", map[string]interface{}{
+		"targetParentDentryUuid": targetID,
+		"sourceDentryUuid":       sourceID,
+		"operateFrom":            1,
+	})
 	if err != nil {
-		return nil, err
-	}
-	if err := checkResp(resp, result); err != nil {
 		return nil, err
 	}
 	return srcObj, nil
@@ -167,38 +138,19 @@ func (d *AliDoc) Rename(ctx context.Context, srcObj model.Obj, newName string) (
 	if newName == "" {
 		return nil, fmt.Errorf("new name is empty")
 	}
-	dentryUUID := strings.TrimSpace(srcObj.GetID())
+	dentryUUID := aliDocObjID(srcObj)
 	if dentryUUID == "" {
 		return nil, fmt.Errorf("dentry uuid is empty")
 	}
 
-	var result apiResp
-	resp, err := d.request(ctx).
-		SetBody(map[string]string{
-			"dentryUuid": dentryUUID,
-			"name":       newName,
-		}).
-		SetResult(&result).
-		SetError(&result).
-		Post(apiBase + "/box/api/v2/dentry/rename")
+	err := d.post(ctx, "/box/api/v2/dentry/rename", map[string]string{
+		"dentryUuid": dentryUUID,
+		"name":       newName,
+	})
 	if err != nil {
 		return nil, err
 	}
-	if err := checkResp(resp, result); err != nil {
-		return nil, err
-	}
-	return &Object{
-		Object: model.Object{
-			ID:       srcObj.GetID(),
-			Name:     newName,
-			Size:     srcObj.GetSize(),
-			Modified: srcObj.ModTime(),
-			Ctime:    srcObj.CreateTime(),
-			IsFolder: srcObj.IsDir(),
-			HashInfo: srcObj.GetHash(),
-		},
-		DentryType: pickAliDocDentryType(srcObj),
-	}, nil
+	return nil, nil
 }
 
 func (d *AliDoc) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
@@ -208,8 +160,8 @@ func (d *AliDoc) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj,
 	if dstDir == nil {
 		return nil, fmt.Errorf("destination directory is nil")
 	}
-	sourceID := strings.TrimSpace(srcObj.GetID())
-	targetID := strings.TrimSpace(dstDir.GetID())
+	sourceID := aliDocObjID(srcObj)
+	targetID := aliDocObjID(dstDir)
 	if sourceID == "" {
 		return nil, fmt.Errorf("source dentry uuid is empty")
 	}
@@ -217,58 +169,29 @@ func (d *AliDoc) Copy(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj,
 		return nil, fmt.Errorf("target parent dentry uuid is empty")
 	}
 
-	var result apiResp
-	resp, err := d.request(ctx).
-		SetBody(map[string]interface{}{
-			"sourceDentryUuid":       sourceID,
-			"targetParentDentryUuid": targetID,
-			"operateFrom":            1,
-			"onlyCopyMeta":           false,
-		}).
-		SetResult(&result).
-		SetError(&result).
-		Post(apiBase + "/box/api/v2/dentry/copy")
+	err := d.post(ctx, "/box/api/v2/dentry/copy", map[string]interface{}{
+		"sourceDentryUuid":       sourceID,
+		"targetParentDentryUuid": targetID,
+		"operateFrom":            1,
+		"onlyCopyMeta":           false,
+	})
 	if err != nil {
 		return nil, err
 	}
-	if err := checkResp(resp, result); err != nil {
-		return nil, err
-	}
-
-	return &Object{
-		Object: model.Object{
-			Name:     srcObj.GetName(),
-			Size:     srcObj.GetSize(),
-			Modified: srcObj.ModTime(),
-			Ctime:    srcObj.CreateTime(),
-			IsFolder: srcObj.IsDir(),
-			HashInfo: srcObj.GetHash(),
-		},
-		DentryType: pickAliDocDentryType(srcObj),
-	}, nil
+	return nil, nil
 }
 
 func (d *AliDoc) Remove(ctx context.Context, obj model.Obj) error {
 	if obj == nil {
 		return fmt.Errorf("object is nil")
 	}
-	dentryUUID := strings.TrimSpace(obj.GetID())
+	dentryUUID := aliDocObjID(obj)
 	if dentryUUID == "" {
 		return fmt.Errorf("dentry uuid is empty")
 	}
-
-	var result apiResp
-	resp, err := d.request(ctx).
-		SetBody(map[string]string{
-			"dentryUuid": dentryUUID,
-		}).
-		SetResult(&result).
-		SetError(&result).
-		Post(apiBase + "/box/api/v1/dentry/recycle")
-	if err != nil {
-		return err
-	}
-	return checkResp(resp, result)
+	return d.post(ctx, "/box/api/v1/dentry/recycle", map[string]string{
+		"dentryUuid": dentryUUID,
+	})
 }
 
 func (d *AliDoc) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {

--- a/drivers/alidoc/driver.go
+++ b/drivers/alidoc/driver.go
@@ -37,6 +37,9 @@ func (d *AliDoc) Init(ctx context.Context) error {
 		return fmt.Errorf("root folder id is empty")
 	}
 	d.client = newClient()
+	if err := d.checkCookie(ctx); err != nil {
+		return err
+	}
 	if _, err := d.list(ctx, d.RootFolderID); err != nil {
 		return err
 	}

--- a/drivers/alidoc/driver.go
+++ b/drivers/alidoc/driver.go
@@ -49,14 +49,7 @@ func (d *AliDoc) Drop(ctx context.Context) error {
 }
 
 func (d *AliDoc) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
-	parentID := d.RootFolderID
-	if dir != nil {
-		if id := strings.TrimSpace(dir.GetID()); id != "" {
-			parentID = id
-		}
-	}
-
-	items, err := d.list(ctx, parentID)
+	items, err := d.list(ctx, dir.GetID())
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/alidoc/meta.go
+++ b/drivers/alidoc/meta.go
@@ -7,14 +7,14 @@ import (
 
 type Addition struct {
 	driver.RootID
-	Cookie string `json:"cookie" type:"text" required:"true" help:"DingTalk AliDoc web cookie"`
+	Cookie       string `json:"cookie" type:"text" required:"true" help:"钉钉文档网页 Cookie"`
 }
 
 var config = driver.Config{
 	Name:        "AliDoc",
 	LocalSort:   true,
 	DefaultRoot: "",
-	Alert:       "warning|AliDoc uses web cookies captured from the DingTalk document site. Keep the cookie private. This driver is read-only.",
+	Alert:       "info|If you use PDF preview, please enable proxy, otherwise the preview may fail because of CORS.",
 }
 
 func init() {

--- a/drivers/alidoc/meta.go
+++ b/drivers/alidoc/meta.go
@@ -14,7 +14,6 @@ var config = driver.Config{
 	Name:        "AliDoc",
 	LocalSort:   true,
 	DefaultRoot: "",
-	Alert:       "info|This driver supports accessing DingDrive through DingTalk Docs, including listing, download, upload, move, and recycle delete.",
 }
 
 func init() {

--- a/drivers/alidoc/meta.go
+++ b/drivers/alidoc/meta.go
@@ -14,7 +14,7 @@ var config = driver.Config{
 	Name:        "AliDoc",
 	LocalSort:   true,
 	DefaultRoot: "",
-	Alert:       "info|If you use PDF preview, please enable proxy, otherwise the preview may fail because of CORS.",
+	Alert:       "info|This driver supports accessing DingDrive through DingTalk Docs and is currently read-only.",
 }
 
 func init() {

--- a/drivers/alidoc/meta.go
+++ b/drivers/alidoc/meta.go
@@ -1,0 +1,24 @@
+package alidoc
+
+import (
+	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/op"
+)
+
+type Addition struct {
+	driver.RootID
+	Cookie string `json:"cookie" type:"text" required:"true" help:"DingTalk AliDoc web cookie"`
+}
+
+var config = driver.Config{
+	Name:        "AliDoc",
+	LocalSort:   true,
+	DefaultRoot: "",
+	Alert:       "warning|AliDoc uses web cookies captured from the DingTalk document site. Keep the cookie private. This driver is read-only.",
+}
+
+func init() {
+	op.RegisterDriver(func() driver.Driver {
+		return &AliDoc{}
+	})
+}

--- a/drivers/alidoc/meta.go
+++ b/drivers/alidoc/meta.go
@@ -7,14 +7,14 @@ import (
 
 type Addition struct {
 	driver.RootID
-	Cookie       string `json:"cookie" type:"text" required:"true" help:"钉钉文档网页 Cookie"`
+	Cookie string `json:"cookie" type:"text" required:"true" help:"钉钉文档网页 Cookie"`
 }
 
 var config = driver.Config{
 	Name:        "AliDoc",
 	LocalSort:   true,
 	DefaultRoot: "",
-	Alert:       "info|This driver supports accessing DingDrive through DingTalk Docs and is currently read-only.",
+	Alert:       "info|This driver supports accessing DingDrive through DingTalk Docs, including listing, download, upload, move, and recycle delete.",
 }
 
 func init() {

--- a/drivers/alidoc/types.go
+++ b/drivers/alidoc/types.go
@@ -1,7 +1,5 @@
 package alidoc
 
-import "github.com/OpenListTeam/OpenList/v4/internal/model"
-
 type apiResp struct {
 	Status    int    `json:"status"`
 	IsSuccess bool   `json:"isSuccess"`
@@ -86,13 +84,4 @@ type uploadSTSSignatureInfo struct {
 	Cname                 string `json:"cname"`
 	EndPoint              string `json:"endPoint"`
 	ObjectKey             string `json:"objectKey"`
-}
-
-type Object struct {
-	model.Object
-	DentryType  string
-	ContentType string
-	Extension   string
-	PreviewURL  string
-	EditURL     string
 }

--- a/drivers/alidoc/types.go
+++ b/drivers/alidoc/types.go
@@ -1,0 +1,67 @@
+package alidoc
+
+import "github.com/OpenListTeam/OpenList/v4/internal/model"
+
+type apiResp struct {
+	Status    int    `json:"status"`
+	IsSuccess bool   `json:"isSuccess"`
+	Message   string `json:"message"`
+	Msg       string `json:"msg"`
+}
+
+func (r apiResp) ErrMessage() string {
+	if r.Message != "" {
+		return r.Message
+	}
+	if r.Msg != "" {
+		return r.Msg
+	}
+	return ""
+}
+
+type listResp struct {
+	apiResp
+	Data listData `json:"data"`
+}
+
+type listData struct {
+	Children []dentry `json:"children"`
+}
+
+type dentry struct {
+	DentryType      string `json:"dentryType"`
+	DentryUUID      string `json:"dentryUuid"`
+	Name            string `json:"name"`
+	FileSize        int64  `json:"fileSize"`
+	CreatedTime     int64  `json:"createdTime"`
+	UpdatedTime     int64  `json:"updatedTime"`
+	ContentType     string `json:"contentType"`
+	Extension       string `json:"extension"`
+	DentryStatistic struct {
+		ChildrenCount int `json:"childrenCount"`
+	} `json:"dentryStatistic"`
+	URL struct {
+		PCChildAppPreviewURL string `json:"pcChildAppPreviewUrl"`
+		PCChildAppURL        string `json:"pcChildAppUrl"`
+	} `json:"url"`
+}
+
+type downloadResp struct {
+	apiResp
+	Data downloadData `json:"data"`
+}
+
+type downloadData struct {
+	OSSURLPreSignatureInfo struct {
+		PreSignURLs []string `json:"preSignUrls"`
+	} `json:"ossUrlPreSignatureInfo"`
+}
+
+type Object struct {
+	model.Object
+	DentryType  string
+	ContentType string
+	Extension   string
+	PreviewURL  string
+	EditURL     string
+}

--- a/drivers/alidoc/types.go
+++ b/drivers/alidoc/types.go
@@ -29,15 +29,17 @@ type listData struct {
 }
 
 type dentry struct {
-	DentryType      string `json:"dentryType"`
-	DentryUUID      string `json:"dentryUuid"`
-	Name            string `json:"name"`
-	FileSize        int64  `json:"fileSize"`
-	CreatedTime     int64  `json:"createdTime"`
-	UpdatedTime     int64  `json:"updatedTime"`
-	ContentType     string `json:"contentType"`
-	Extension       string `json:"extension"`
-	DentryStatistic struct {
+	DentryType       string `json:"dentryType"`
+	DentryUUID       string `json:"dentryUuid"`
+	ParentDentryUUID string `json:"parentDentryUuid"`
+	Name             string `json:"name"`
+	Path             string `json:"path"`
+	FileSize         int64  `json:"fileSize"`
+	CreatedTime      int64  `json:"createdTime"`
+	UpdatedTime      int64  `json:"updatedTime"`
+	ContentType      string `json:"contentType"`
+	Extension        string `json:"extension"`
+	DentryStatistic  struct {
 		ChildrenCount int `json:"childrenCount"`
 	} `json:"dentryStatistic"`
 	URL struct {
@@ -55,6 +57,35 @@ type downloadData struct {
 	OSSURLPreSignatureInfo struct {
 		PreSignURLs []string `json:"preSignUrls"`
 	} `json:"ossUrlPreSignatureInfo"`
+}
+
+type uploadInfoResp struct {
+	apiResp
+	Data uploadInfoData `json:"data"`
+}
+
+type uploadInfoData struct {
+	CurrentTimestamp         int64                  `json:"currentTimestamp"`
+	FileUploadProtocolConfig uploadProtocolConfig   `json:"fileUploadProtocolConfig"`
+	STSSignatureInfo         uploadSTSSignatureInfo `json:"stsSignatureInfo"`
+	UploadKey                string                 `json:"uploadKey"`
+	UploadType               string                 `json:"uploadType"`
+}
+
+type uploadProtocolConfig struct {
+	MinPartSize int64 `json:"minPartSize"`
+}
+
+type uploadSTSSignatureInfo struct {
+	AccelerateCname       string `json:"accelerateCname"`
+	AccessKeyID           string `json:"accessKeyId"`
+	AccessKeySecret       string `json:"accessKeySecret"`
+	AccessToken           string `json:"accessToken"`
+	AccessTokenExpiration int64  `json:"accessTokenExpiration"`
+	Bucket                string `json:"bucket"`
+	Cname                 string `json:"cname"`
+	EndPoint              string `json:"endPoint"`
+	ObjectKey             string `json:"objectKey"`
 }
 
 type Object struct {

--- a/drivers/alidoc/upload.go
+++ b/drivers/alidoc/upload.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	netutil "github.com/OpenListTeam/OpenList/v4/internal/net"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/google/uuid"
 )
 
 const (
@@ -67,6 +68,9 @@ func (d *AliDoc) put(ctx context.Context, dstDir model.Obj, file model.FileStrea
 		err = d.singleUpload(ctx, src, size, info, up)
 	}
 	if err != nil {
+		return nil, err
+	}
+	if err := d.commitUpload(ctx, parentID, file.GetName(), size, info.Data.UploadKey); err != nil {
 		return nil, err
 	}
 
@@ -145,6 +149,35 @@ func (d *AliDoc) getUploadInfo(ctx context.Context, parentDentryUUID, name strin
 		return result, fmt.Errorf("empty upload bucket")
 	}
 	return result, nil
+}
+
+func (d *AliDoc) commitUpload(ctx context.Context, parentDentryUUID, name string, fileSize int64, uploadKey string) error {
+	uploadKey = strings.TrimSpace(uploadKey)
+	if uploadKey == "" {
+		return fmt.Errorf("empty upload key")
+	}
+
+	var result apiResp
+	body := map[string]interface{}{
+		"parentDentryUuid":      parentDentryUUID,
+		"uploadKey":             uploadKey,
+		"fileSize":              fileSize,
+		"name":                  name,
+		"toPrevDentryUuid":      nil,
+		"toNextDentryUuid":      nil,
+		"batchId":               uuid.NewString(),
+		"batchUploadType":       1,
+		"batchParentDentryUuid": parentDentryUUID,
+	}
+	resp, err := d.request(ctx).
+		SetBody(body).
+		SetResult(&result).
+		SetError(&result).
+		Post(apiBase + "/box/api/v2/file/commit")
+	if err != nil {
+		return err
+	}
+	return checkResp(resp, result)
 }
 
 func calcAliDocPartSize(fileSize, minPartSize int64) int64 {
@@ -247,13 +280,7 @@ func (d *AliDoc) newOSSBucket(info uploadInfoResp) (*oss.Bucket, string, error) 
 		return nil, "", fmt.Errorf("empty upload object key")
 	}
 
-	endpoint := strings.TrimSpace(sts.AccelerateCname)
-	if endpoint == "" {
-		endpoint = strings.TrimSpace(sts.Cname)
-	}
-	if endpoint == "" {
-		endpoint = strings.TrimSpace(sts.EndPoint)
-	}
+	endpoint, useCname := pickAliDocOSSEndpoint(sts)
 	if endpoint == "" {
 		return nil, "", fmt.Errorf("empty upload endpoint")
 	}
@@ -261,11 +288,15 @@ func (d *AliDoc) newOSSBucket(info uploadInfoResp) (*oss.Bucket, string, error) 
 		endpoint = "https://" + endpoint
 	}
 
+	options := []oss.ClientOption{oss.SecurityToken(sts.AccessToken)}
+	if useCname {
+		options = append(options, oss.UseCname(true))
+	}
 	client, err := netutil.NewOSSClient(
 		endpoint,
 		sts.AccessKeyID,
 		sts.AccessKeySecret,
-		oss.SecurityToken(sts.AccessToken),
+		options...,
 	)
 	if err != nil {
 		return nil, "", err
@@ -275,6 +306,19 @@ func (d *AliDoc) newOSSBucket(info uploadInfoResp) (*oss.Bucket, string, error) 
 		return nil, "", err
 	}
 	return bucket, objectKey, nil
+}
+
+func pickAliDocOSSEndpoint(sts uploadSTSSignatureInfo) (endpoint string, useCname bool) {
+	if endpoint = strings.TrimSpace(sts.EndPoint); endpoint != "" {
+		return endpoint, false
+	}
+	if endpoint = strings.TrimSpace(sts.Cname); endpoint != "" {
+		return endpoint, true
+	}
+	if endpoint = strings.TrimSpace(sts.AccelerateCname); endpoint != "" {
+		return endpoint, true
+	}
+	return "", false
 }
 
 func (d *AliDoc) findUploadedObj(ctx context.Context, parentID, parentPath, name string, size int64, startedAt time.Time) (model.Obj, error) {

--- a/drivers/alidoc/upload.go
+++ b/drivers/alidoc/upload.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"math"
 	"strings"
-	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
@@ -30,19 +29,15 @@ func (d *AliDoc) put(ctx context.Context, dstDir model.Obj, file model.FileStrea
 	}
 
 	parentID := d.RootFolderID
-	parentPath := "/"
 	if dstDir != nil {
 		if id := strings.TrimSpace(dstDir.GetID()); id != "" {
 			parentID = id
 		}
-		if p := dstDir.GetPath(); p != "" {
-			parentPath = p
-		}
 	}
 
-	src, size, err := prepareAliDocUploadFile(file)
-	if err != nil {
-		return nil, err
+	size := file.GetSize()
+	if size < 0 {
+		return nil, fmt.Errorf("unknown file size is not supported")
 	}
 
 	useMultipart := size > defaultAliDocMultipartThreshold
@@ -61,11 +56,14 @@ func (d *AliDoc) put(ctx context.Context, dstDir model.Obj, file model.FileStrea
 		}
 	}
 
-	startedAt := time.Now()
 	if useMultipart && size > 0 {
+		src, err := prepareAliDocUploadFile(file)
+		if err != nil {
+			return nil, err
+		}
 		err = d.multipartUpload(ctx, src, size, info, up)
 	} else {
-		err = d.singleUpload(ctx, src, size, info, up)
+		err = d.singleUpload(ctx, file, size, info, up)
 	}
 	if err != nil {
 		return nil, err
@@ -73,55 +71,25 @@ func (d *AliDoc) put(ctx context.Context, dstDir model.Obj, file model.FileStrea
 	if err := d.commitUpload(ctx, parentID, file.GetName(), size, info.Data.UploadKey); err != nil {
 		return nil, err
 	}
-
-	if obj, err := d.findUploadedObj(ctx, parentID, parentPath, file.GetName(), size, startedAt); err == nil && obj != nil {
-		return obj, nil
-	}
-
-	return &Object{
-		Object: model.Object{
-			Path:     joinPath(parentPath, file.GetName()),
-			Name:     file.GetName(),
-			Size:     size,
-			Modified: startedAt,
-			Ctime:    startedAt,
-		},
-		DentryType: "file",
-	}, nil
+	return nil, nil
 }
 
-func prepareAliDocUploadFile(file model.FileStreamer) (model.File, int64, error) {
-	size := file.GetSize()
-	if src := file.GetFile(); src != nil && size >= 0 {
+func prepareAliDocUploadFile(file model.FileStreamer) (model.File, error) {
+	if src := file.GetFile(); src != nil {
 		if _, err := src.Seek(0, io.SeekStart); err != nil {
-			return nil, 0, err
+			return nil, err
 		}
-		return src, size, nil
+		return src, nil
 	}
 
 	src, err := file.CacheFullAndWriter(nil, nil)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	if _, err := src.Seek(0, io.SeekStart); err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	size = file.GetSize()
-	if size < 0 {
-		cur, err := src.Seek(0, io.SeekCurrent)
-		if err != nil {
-			return nil, 0, err
-		}
-		end, err := src.Seek(0, io.SeekEnd)
-		if err != nil {
-			return nil, 0, err
-		}
-		size = end
-		if _, err := src.Seek(cur, io.SeekStart); err != nil {
-			return nil, 0, err
-		}
-	}
-	return src, size, nil
+	return src, nil
 }
 
 func (d *AliDoc) getUploadInfo(ctx context.Context, parentDentryUUID, name string, fileSize int64, multipart bool) (uploadInfoResp, error) {
@@ -195,18 +163,14 @@ func calcAliDocPartSize(fileSize, minPartSize int64) int64 {
 	return partSize
 }
 
-func (d *AliDoc) singleUpload(ctx context.Context, src model.File, size int64, info uploadInfoResp, up driver.UpdateProgress) error {
+func (d *AliDoc) singleUpload(ctx context.Context, src model.FileStreamer, size int64, info uploadInfoResp, up driver.UpdateProgress) error {
 	bucket, objectKey, err := d.newOSSBucket(info)
 	if err != nil {
 		return err
 	}
-	if _, err := src.Seek(0, io.SeekStart); err != nil {
-		return err
-	}
-	reader := io.NewSectionReader(src, 0, size)
 	err = bucket.PutObject(
 		objectKey,
-		driver.NewLimitedUploadStream(ctx, io.TeeReader(reader, driver.NewProgress(size, up))),
+		driver.NewLimitedUploadStream(ctx, io.TeeReader(src, driver.NewProgress(size, up))),
 	)
 	if err != nil {
 		return err
@@ -319,48 +283,4 @@ func pickAliDocOSSEndpoint(sts uploadSTSSignatureInfo) (endpoint string, useCnam
 		return endpoint, true
 	}
 	return "", false
-}
-
-func (d *AliDoc) findUploadedObj(ctx context.Context, parentID, parentPath, name string, size int64, startedAt time.Time) (model.Obj, error) {
-	for attempt := 0; attempt < 5; attempt++ {
-		items, err := d.list(ctx, parentID)
-		if err != nil {
-			return nil, err
-		}
-		var (
-			matched    dentry
-			hasMatched bool
-		)
-		for i := range items {
-			item := items[i]
-			if item.DentryType != "file" || item.Name != name {
-				continue
-			}
-			if size >= 0 && item.FileSize != size {
-				continue
-			}
-			if !hasMatched || item.UpdatedTime > matched.UpdatedTime {
-				matched = item
-				hasMatched = true
-			}
-		}
-		if hasMatched {
-			obj := toObj(parentPath, matched)
-			if !obj.ModTime().IsZero() && obj.ModTime().Before(startedAt.Add(-5*time.Second)) {
-				// Keep polling briefly if only an older homonymous file is visible.
-			} else {
-				return obj, nil
-			}
-		}
-		if attempt < 4 {
-			timer := time.NewTimer(time.Duration(attempt+1) * 300 * time.Millisecond)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return nil, ctx.Err()
-			case <-timer.C:
-			}
-		}
-	}
-	return nil, fmt.Errorf("uploaded object not found")
 }

--- a/drivers/alidoc/upload.go
+++ b/drivers/alidoc/upload.go
@@ -1,0 +1,322 @@
+package alidoc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	netutil "github.com/OpenListTeam/OpenList/v4/internal/net"
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+)
+
+const (
+	defaultAliDocMultipartThreshold = 16 * 1024 * 1024
+	defaultAliDocPartSize           = 100 * 1024
+	maxAliDocMultipartParts         = 10000
+)
+
+func (d *AliDoc) put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
+	if file == nil {
+		return nil, fmt.Errorf("file is nil")
+	}
+	if up == nil {
+		up = func(float64) {}
+	}
+
+	parentID := d.RootFolderID
+	parentPath := "/"
+	if dstDir != nil {
+		if id := strings.TrimSpace(dstDir.GetID()); id != "" {
+			parentID = id
+		}
+		if p := dstDir.GetPath(); p != "" {
+			parentPath = p
+		}
+	}
+
+	src, size, err := prepareAliDocUploadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	useMultipart := size > defaultAliDocMultipartThreshold
+	info, err := d.getUploadInfo(ctx, parentID, file.GetName(), size, useMultipart)
+	if err != nil {
+		return nil, err
+	}
+	if size > 0 {
+		partSize := calcAliDocPartSize(size, info.Data.FileUploadProtocolConfig.MinPartSize)
+		if size > partSize && !useMultipart {
+			useMultipart = true
+			info, err = d.getUploadInfo(ctx, parentID, file.GetName(), size, true)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	startedAt := time.Now()
+	if useMultipart && size > 0 {
+		err = d.multipartUpload(ctx, src, size, info, up)
+	} else {
+		err = d.singleUpload(ctx, src, size, info, up)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if obj, err := d.findUploadedObj(ctx, parentID, parentPath, file.GetName(), size, startedAt); err == nil && obj != nil {
+		return obj, nil
+	}
+
+	return &Object{
+		Object: model.Object{
+			Path:     joinPath(parentPath, file.GetName()),
+			Name:     file.GetName(),
+			Size:     size,
+			Modified: startedAt,
+			Ctime:    startedAt,
+		},
+		DentryType: "file",
+	}, nil
+}
+
+func prepareAliDocUploadFile(file model.FileStreamer) (model.File, int64, error) {
+	size := file.GetSize()
+	if src := file.GetFile(); src != nil && size >= 0 {
+		if _, err := src.Seek(0, io.SeekStart); err != nil {
+			return nil, 0, err
+		}
+		return src, size, nil
+	}
+
+	src, err := file.CacheFullAndWriter(nil, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	if _, err := src.Seek(0, io.SeekStart); err != nil {
+		return nil, 0, err
+	}
+	size = file.GetSize()
+	if size < 0 {
+		cur, err := src.Seek(0, io.SeekCurrent)
+		if err != nil {
+			return nil, 0, err
+		}
+		end, err := src.Seek(0, io.SeekEnd)
+		if err != nil {
+			return nil, 0, err
+		}
+		size = end
+		if _, err := src.Seek(cur, io.SeekStart); err != nil {
+			return nil, 0, err
+		}
+	}
+	return src, size, nil
+}
+
+func (d *AliDoc) getUploadInfo(ctx context.Context, parentDentryUUID, name string, fileSize int64, multipart bool) (uploadInfoResp, error) {
+	var result uploadInfoResp
+	body := map[string]interface{}{
+		"uploadType":         "STS_SIGNATURE",
+		"supportUploadTypes": []string{"STS_SIGNATURE", "HTTP_TO_CENTER"},
+		"parentDentryUuid":   parentDentryUUID,
+		"fileSize":           fileSize,
+		"name":               name,
+		"multipart":          multipart,
+	}
+	resp, err := d.request(ctx).
+		SetBody(body).
+		SetResult(&result).
+		SetError(&result).
+		Post(apiBase + "/box/api/v2/file/uploadinfo")
+	if err != nil {
+		return result, err
+	}
+	if err := checkResp(resp, result.apiResp); err != nil {
+		return result, err
+	}
+	if strings.TrimSpace(result.Data.STSSignatureInfo.Bucket) == "" {
+		return result, fmt.Errorf("empty upload bucket")
+	}
+	return result, nil
+}
+
+func calcAliDocPartSize(fileSize, minPartSize int64) int64 {
+	partSize := minPartSize
+	if partSize <= 0 {
+		partSize = defaultAliDocPartSize
+	}
+	if fileSize <= 0 {
+		return partSize
+	}
+	minRequired := int64(math.Ceil(float64(fileSize) / maxAliDocMultipartParts))
+	if minRequired > partSize {
+		partSize = minRequired
+	}
+	return partSize
+}
+
+func (d *AliDoc) singleUpload(ctx context.Context, src model.File, size int64, info uploadInfoResp, up driver.UpdateProgress) error {
+	bucket, objectKey, err := d.newOSSBucket(info)
+	if err != nil {
+		return err
+	}
+	if _, err := src.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	reader := io.NewSectionReader(src, 0, size)
+	err = bucket.PutObject(
+		objectKey,
+		driver.NewLimitedUploadStream(ctx, io.TeeReader(reader, driver.NewProgress(size, up))),
+	)
+	if err != nil {
+		return err
+	}
+	up(100)
+	return nil
+}
+
+func (d *AliDoc) multipartUpload(ctx context.Context, src model.File, size int64, info uploadInfoResp, up driver.UpdateProgress) error {
+	bucket, objectKey, err := d.newOSSBucket(info)
+	if err != nil {
+		return err
+	}
+
+	imur, err := bucket.InitiateMultipartUpload(objectKey, oss.Sequential())
+	if err != nil {
+		return err
+	}
+
+	partSize := calcAliDocPartSize(size, info.Data.FileUploadProtocolConfig.MinPartSize)
+	partNum := int((size + partSize - 1) / partSize)
+	parts := make([]oss.UploadPart, 0, partNum)
+	progress := driver.NewProgress(size, up)
+
+	var offset int64
+	for partNumber := 1; partNumber <= partNum; partNumber++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		length := partSize
+		if remain := size - offset; remain < length {
+			length = remain
+		}
+
+		var part oss.UploadPart
+		var uploadErr error
+		for attempt := 0; attempt < 3; attempt++ {
+			reader := io.NewSectionReader(src, offset, length)
+			part, uploadErr = bucket.UploadPart(
+				imur,
+				driver.NewLimitedUploadStream(ctx, io.TeeReader(reader, progress)),
+				length,
+				partNumber,
+			)
+			if uploadErr == nil {
+				break
+			}
+		}
+		if uploadErr != nil {
+			return uploadErr
+		}
+		parts = append(parts, part)
+		offset += length
+	}
+
+	_, err = bucket.CompleteMultipartUpload(imur, parts)
+	if err != nil {
+		return err
+	}
+	up(100)
+	return nil
+}
+
+func (d *AliDoc) newOSSBucket(info uploadInfoResp) (*oss.Bucket, string, error) {
+	sts := info.Data.STSSignatureInfo
+	objectKey := strings.TrimSpace(sts.ObjectKey)
+	if objectKey == "" {
+		objectKey = strings.TrimSpace(info.Data.UploadKey)
+	}
+	if objectKey == "" {
+		return nil, "", fmt.Errorf("empty upload object key")
+	}
+
+	endpoint := strings.TrimSpace(sts.AccelerateCname)
+	if endpoint == "" {
+		endpoint = strings.TrimSpace(sts.Cname)
+	}
+	if endpoint == "" {
+		endpoint = strings.TrimSpace(sts.EndPoint)
+	}
+	if endpoint == "" {
+		return nil, "", fmt.Errorf("empty upload endpoint")
+	}
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		endpoint = "https://" + endpoint
+	}
+
+	client, err := netutil.NewOSSClient(
+		endpoint,
+		sts.AccessKeyID,
+		sts.AccessKeySecret,
+		oss.SecurityToken(sts.AccessToken),
+	)
+	if err != nil {
+		return nil, "", err
+	}
+	bucket, err := client.Bucket(sts.Bucket)
+	if err != nil {
+		return nil, "", err
+	}
+	return bucket, objectKey, nil
+}
+
+func (d *AliDoc) findUploadedObj(ctx context.Context, parentID, parentPath, name string, size int64, startedAt time.Time) (model.Obj, error) {
+	for attempt := 0; attempt < 5; attempt++ {
+		items, err := d.list(ctx, parentID)
+		if err != nil {
+			return nil, err
+		}
+		var (
+			matched    dentry
+			hasMatched bool
+		)
+		for i := range items {
+			item := items[i]
+			if item.DentryType != "file" || item.Name != name {
+				continue
+			}
+			if size >= 0 && item.FileSize != size {
+				continue
+			}
+			if !hasMatched || item.UpdatedTime > matched.UpdatedTime {
+				matched = item
+				hasMatched = true
+			}
+		}
+		if hasMatched {
+			obj := toObj(parentPath, matched)
+			if !obj.ModTime().IsZero() && obj.ModTime().Before(startedAt.Add(-5*time.Second)) {
+				// Keep polling briefly if only an older homonymous file is visible.
+			} else {
+				return obj, nil
+			}
+		}
+		if attempt < 4 {
+			timer := time.NewTimer(time.Duration(attempt+1) * 300 * time.Millisecond)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+	return nil, fmt.Errorf("uploaded object not found")
+}

--- a/drivers/alidoc/upload.go
+++ b/drivers/alidoc/upload.go
@@ -217,6 +217,7 @@ func (d *AliDoc) multipartUpload(ctx context.Context, src model.FileStreamer, si
 			return err
 		}
 		parts = append(parts, part)
+		up(100 * float64(len(parts)) / float64(partNum+1))
 		offset += length
 	}
 

--- a/drivers/alidoc/upload.go
+++ b/drivers/alidoc/upload.go
@@ -6,12 +6,14 @@ import (
 	"io"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	netutil "github.com/OpenListTeam/OpenList/v4/internal/net"
 	streamPkg "github.com/OpenListTeam/OpenList/v4/internal/stream"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/avast/retry-go"
 	"github.com/google/uuid"
 )
 
@@ -187,13 +189,15 @@ func (d *AliDoc) multipartUpload(ctx context.Context, src model.FileStreamer, si
 			length = remain
 		}
 
+		reader, err := ss.GetSectionReader(offset, length)
+		if err != nil {
+			return err
+		}
 		var part oss.UploadPart
 		var uploadErr error
-		var reader io.ReadSeeker
-		for attempt := 0; attempt < 3; attempt++ {
-			reader, uploadErr = ss.GetSectionReader(offset, length)
-			if uploadErr != nil {
-				break
+		err = retry.Do(func() error {
+			if _, err := reader.Seek(0, io.SeekStart); err != nil {
+				return err
 			}
 			part, uploadErr = bucket.UploadPart(
 				imur,
@@ -201,13 +205,16 @@ func (d *AliDoc) multipartUpload(ctx context.Context, src model.FileStreamer, si
 				length,
 				partNumber,
 			)
-			ss.FreeSectionReader(reader)
-			if uploadErr == nil {
-				break
-			}
-		}
-		if uploadErr != nil {
 			return uploadErr
+		},
+			retry.Context(ctx),
+			retry.Attempts(3),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Delay(time.Second),
+		)
+		ss.FreeSectionReader(reader)
+		if err != nil {
+			return err
 		}
 		parts = append(parts, part)
 		offset += length

--- a/drivers/alidoc/upload.go
+++ b/drivers/alidoc/upload.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	netutil "github.com/OpenListTeam/OpenList/v4/internal/net"
+	streamPkg "github.com/OpenListTeam/OpenList/v4/internal/stream"
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
 	"github.com/google/uuid"
 )
@@ -57,11 +58,7 @@ func (d *AliDoc) put(ctx context.Context, dstDir model.Obj, file model.FileStrea
 	}
 
 	if useMultipart && size > 0 {
-		src, err := prepareAliDocUploadFile(file)
-		if err != nil {
-			return nil, err
-		}
-		err = d.multipartUpload(ctx, src, size, info, up)
+		err = d.multipartUpload(ctx, file, size, info, up)
 	} else {
 		err = d.singleUpload(ctx, file, size, info, up)
 	}
@@ -72,24 +69,6 @@ func (d *AliDoc) put(ctx context.Context, dstDir model.Obj, file model.FileStrea
 		return nil, err
 	}
 	return nil, nil
-}
-
-func prepareAliDocUploadFile(file model.FileStreamer) (model.File, error) {
-	if src := file.GetFile(); src != nil {
-		if _, err := src.Seek(0, io.SeekStart); err != nil {
-			return nil, err
-		}
-		return src, nil
-	}
-
-	src, err := file.CacheFullAndWriter(nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := src.Seek(0, io.SeekStart); err != nil {
-		return nil, err
-	}
-	return src, nil
 }
 
 func (d *AliDoc) getUploadInfo(ctx context.Context, parentDentryUUID, name string, fileSize int64, multipart bool) (uploadInfoResp, error) {
@@ -179,7 +158,7 @@ func (d *AliDoc) singleUpload(ctx context.Context, src model.FileStreamer, size 
 	return nil
 }
 
-func (d *AliDoc) multipartUpload(ctx context.Context, src model.File, size int64, info uploadInfoResp, up driver.UpdateProgress) error {
+func (d *AliDoc) multipartUpload(ctx context.Context, src model.FileStreamer, size int64, info uploadInfoResp, up driver.UpdateProgress) error {
 	bucket, objectKey, err := d.newOSSBucket(info)
 	if err != nil {
 		return err
@@ -193,7 +172,10 @@ func (d *AliDoc) multipartUpload(ctx context.Context, src model.File, size int64
 	partSize := calcAliDocPartSize(size, info.Data.FileUploadProtocolConfig.MinPartSize)
 	partNum := int((size + partSize - 1) / partSize)
 	parts := make([]oss.UploadPart, 0, partNum)
-	progress := driver.NewProgress(size, up)
+	ss, err := streamPkg.NewStreamSectionReader(src, int(partSize), &up)
+	if err != nil {
+		return err
+	}
 
 	var offset int64
 	for partNumber := 1; partNumber <= partNum; partNumber++ {
@@ -207,14 +189,19 @@ func (d *AliDoc) multipartUpload(ctx context.Context, src model.File, size int64
 
 		var part oss.UploadPart
 		var uploadErr error
+		var reader io.ReadSeeker
 		for attempt := 0; attempt < 3; attempt++ {
-			reader := io.NewSectionReader(src, offset, length)
+			reader, uploadErr = ss.GetSectionReader(offset, length)
+			if uploadErr != nil {
+				break
+			}
 			part, uploadErr = bucket.UploadPart(
 				imur,
-				driver.NewLimitedUploadStream(ctx, io.TeeReader(reader, progress)),
+				driver.NewLimitedUploadStream(ctx, reader),
 				length,
 				partNumber,
 			)
+			ss.FreeSectionReader(reader)
 			if uploadErr == nil {
 				break
 			}

--- a/drivers/alidoc/upload.go
+++ b/drivers/alidoc/upload.go
@@ -23,54 +23,36 @@ const (
 	maxAliDocMultipartParts         = 10000
 )
 
-func (d *AliDoc) put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) (model.Obj, error) {
-	if file == nil {
-		return nil, fmt.Errorf("file is nil")
-	}
-	if up == nil {
-		up = func(float64) {}
-	}
-
-	parentID := d.RootFolderID
-	if dstDir != nil {
-		if id := strings.TrimSpace(dstDir.GetID()); id != "" {
-			parentID = id
-		}
-	}
-
+func (d *AliDoc) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer, up driver.UpdateProgress) error {
 	size := file.GetSize()
-	if size < 0 {
-		return nil, fmt.Errorf("unknown file size is not supported")
-	}
-
 	useMultipart := size > defaultAliDocMultipartThreshold
-	info, err := d.getUploadInfo(ctx, parentID, file.GetName(), size, useMultipart)
+	info, err := d.getUploadInfo(ctx, dstDir.GetID(), file.GetName(), size, useMultipart)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if size > 0 {
 		partSize := calcAliDocPartSize(size, info.Data.FileUploadProtocolConfig.MinPartSize)
 		if size > partSize && !useMultipart {
 			useMultipart = true
-			info, err = d.getUploadInfo(ctx, parentID, file.GetName(), size, true)
+			info, err = d.getUploadInfo(ctx, dstDir.GetID(), file.GetName(), size, true)
 			if err != nil {
-				return nil, err
+				return err
 			}
 		}
 	}
 
-	if useMultipart && size > 0 {
+	if useMultipart {
 		err = d.multipartUpload(ctx, file, size, info, up)
 	} else {
 		err = d.singleUpload(ctx, file, size, info, up)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if err := d.commitUpload(ctx, parentID, file.GetName(), size, info.Data.UploadKey); err != nil {
-		return nil, err
+	if err := d.commitUpload(ctx, dstDir.GetID(), file.GetName(), size, info.Data.UploadKey); err != nil {
+		return err
 	}
-	return nil, nil
+	return nil
 }
 
 func (d *AliDoc) getUploadInfo(ctx context.Context, parentDentryUUID, name string, fileSize int64, multipart bool) (uploadInfoResp, error) {

--- a/drivers/alidoc/util.go
+++ b/drivers/alidoc/util.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
-	"github.com/OpenListTeam/OpenList/v4/internal/errs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/go-resty/resty/v2"
 )
@@ -92,10 +91,6 @@ func toObjWithPath(fullPath string, item dentry) model.Obj {
 		// Keep size as 0 for folders; childrenCount is intentionally ignored.
 	}
 	return obj
-}
-
-func readonlyError() error {
-	return fmt.Errorf("alidoc driver is read-only: %w", errs.NotSupport)
 }
 
 func firstDownloadURL(resp downloadResp) (string, error) {

--- a/drivers/alidoc/util.go
+++ b/drivers/alidoc/util.go
@@ -1,0 +1,135 @@
+package alidoc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/drivers/base"
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/go-resty/resty/v2"
+)
+
+const apiBase = "https://alidocs.dingtalk.com"
+
+func (d *AliDoc) request(ctx context.Context) *resty.Request {
+	return d.client.R().
+		SetContext(ctx).
+		SetHeader("Cookie", d.Cookie).
+		SetHeader("Accept", "application/json, text/plain, */*").
+		SetHeader("Referer", apiBase+"/").
+		SetHeader("Origin", apiBase)
+}
+
+func joinPath(basePath, name string) string {
+	if basePath == "" || basePath == "/" {
+		return "/" + name
+	}
+	return strings.TrimRight(basePath, "/") + "/" + name
+}
+
+func msToTime(v int64) time.Time {
+	if v <= 0 {
+		return time.Time{}
+	}
+	return time.UnixMilli(v)
+}
+
+func checkResp(resp *resty.Response, result apiResp) error {
+	if resp != nil && resp.IsError() {
+		if msg := result.ErrMessage(); msg != "" {
+			return fmt.Errorf("%s", msg)
+		}
+		return fmt.Errorf("http error: %d", resp.StatusCode())
+	}
+	if !result.IsSuccess || result.Status != 200 {
+		msg := result.ErrMessage()
+		if msg == "" {
+			msg = "request failed"
+		}
+		return fmt.Errorf("%s", msg)
+	}
+	return nil
+}
+
+func toObj(parentPath string, item dentry) model.Obj {
+	obj := &Object{
+		Object: model.Object{
+			ID:       item.DentryUUID,
+			Path:     joinPath(parentPath, item.Name),
+			Name:     item.Name,
+			Size:     item.FileSize,
+			Modified: msToTime(item.UpdatedTime),
+			Ctime:    msToTime(item.CreatedTime),
+			IsFolder: item.DentryType == "folder",
+		},
+		DentryType:  item.DentryType,
+		ContentType: item.ContentType,
+		Extension:   item.Extension,
+		PreviewURL:  item.URL.PCChildAppPreviewURL,
+		EditURL:     item.URL.PCChildAppURL,
+	}
+	if obj.IsDir() && item.DentryStatistic.ChildrenCount > 0 && obj.Size == 0 {
+		// Keep size as 0 for folders; childrenCount is intentionally ignored.
+	}
+	return obj
+}
+
+func readonlyError() error {
+	return fmt.Errorf("alidoc driver is read-only: %w", errs.NotSupport)
+}
+
+func firstDownloadURL(resp downloadResp) (string, error) {
+	if len(resp.Data.OSSURLPreSignatureInfo.PreSignURLs) == 0 {
+		return "", fmt.Errorf("empty download url")
+	}
+	return resp.Data.OSSURLPreSignatureInfo.PreSignURLs[0], nil
+}
+
+func newClient() *resty.Client {
+	client := base.NewRestyClient()
+	client.SetHeader("User-Agent", base.UserAgent)
+	return client
+}
+
+func (d *AliDoc) list(ctx context.Context, dentryUUID string) ([]dentry, error) {
+	var result listResp
+	resp, err := d.request(ctx).
+		SetQueryParam("dentryUuid", dentryUUID).
+		SetQueryParam("withParentAncestors", "true").
+		SetQueryParam("orderType", "SORT_KEY").
+		SetQueryParam("sortType", "desc").
+		SetQueryParam("listDentrySource", "2").
+		SetQueryParam("pageSize", "1000").
+		SetResult(&result).
+		SetError(&result).
+		Get(apiBase + "/box/api/v2/dentry/list")
+	if err != nil {
+		return nil, err
+	}
+	if err := checkResp(resp, result.apiResp); err != nil {
+		return nil, err
+	}
+	return result.Data.Children, nil
+}
+
+func (d *AliDoc) download(ctx context.Context, dentryUUID string) (downloadResp, error) {
+	var result downloadResp
+	resp, err := d.request(ctx).
+		SetQueryParam("dentryUuid", dentryUUID).
+		SetQueryParam("version", "1").
+		SetQueryParam("supportDownloadTypes", "URL_PRE_SIGNATURE,HTTP_TO_CENTER").
+		SetQueryParam("downloadType", "URL_PRE_SIGNATURE").
+		SetResult(&result).
+		SetError(&result).
+		Get(apiBase + "/box/api/v2/file/download")
+	if err != nil {
+		return result, err
+	}
+	if err := checkResp(resp, result.apiResp); err != nil {
+		return result, err
+	}
+	return result, nil
+}

--- a/drivers/alidoc/util.go
+++ b/drivers/alidoc/util.go
@@ -3,6 +3,7 @@ package alidoc
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -55,11 +56,27 @@ func checkResp(resp *resty.Response, result apiResp) error {
 }
 
 func toObj(parentPath string, item dentry) model.Obj {
+	return toObjWithPath(joinPath(parentPath, item.Name), item)
+}
+
+func toObjUsingBestPath(parentPath string, item dentry) model.Obj {
+	fullPath := strings.TrimSpace(item.Path)
+	if fullPath == "" {
+		fullPath = joinPath(parentPath, item.Name)
+	}
+	return toObjWithPath(fullPath, item)
+}
+
+func toObjWithPath(fullPath string, item dentry) model.Obj {
+	name := item.Name
+	if name == "" {
+		name = path.Base(fullPath)
+	}
 	obj := &Object{
 		Object: model.Object{
 			ID:       item.DentryUUID,
-			Path:     joinPath(parentPath, item.Name),
-			Name:     item.Name,
+			Path:     fullPath,
+			Name:     name,
 			Size:     item.FileSize,
 			Modified: msToTime(item.UpdatedTime),
 			Ctime:    msToTime(item.CreatedTime),

--- a/drivers/alidoc/util.go
+++ b/drivers/alidoc/util.go
@@ -3,7 +3,6 @@ package alidoc
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
@@ -47,25 +46,14 @@ func checkResp(resp *resty.Response, result apiResp) error {
 }
 
 func toObj(item dentry) model.Obj {
-	obj := &Object{
-		Object: model.Object{
-			ID:       item.DentryUUID,
-			Name:     item.Name,
-			Size:     item.FileSize,
-			Modified: msToTime(item.UpdatedTime),
-			Ctime:    msToTime(item.CreatedTime),
-			IsFolder: item.DentryType == "folder",
-		},
-		DentryType:  item.DentryType,
-		ContentType: item.ContentType,
-		Extension:   item.Extension,
-		PreviewURL:  item.URL.PCChildAppPreviewURL,
-		EditURL:     item.URL.PCChildAppURL,
+	return &model.Object{
+		ID:       item.DentryUUID,
+		Name:     item.Name,
+		Size:     item.FileSize,
+		Modified: msToTime(item.UpdatedTime),
+		Ctime:    msToTime(item.CreatedTime),
+		IsFolder: item.DentryType == "folder",
 	}
-	if obj.IsDir() && item.DentryStatistic.ChildrenCount > 0 && obj.Size == 0 {
-		// Keep size as 0 for folders; childrenCount is intentionally ignored.
-	}
-	return obj
 }
 
 func firstDownloadURL(resp downloadResp) (string, error) {
@@ -79,30 +67,6 @@ func newClient() *resty.Client {
 	client := base.NewRestyClient()
 	client.SetHeader("User-Agent", base.UserAgent)
 	return client
-}
-
-func aliDocObjID(obj model.Obj) string {
-	if obj == nil {
-		return ""
-	}
-	return strings.TrimSpace(obj.GetID())
-}
-
-func (d *AliDoc) parentID(dir model.Obj) string {
-	if id := aliDocObjID(dir); id != "" {
-		return id
-	}
-	return d.RootFolderID
-}
-
-func pickAliDocDentryType(obj model.Obj) string {
-	if o, ok := obj.(*Object); ok && strings.TrimSpace(o.DentryType) != "" {
-		return o.DentryType
-	}
-	if obj != nil && obj.IsDir() {
-		return "folder"
-	}
-	return "file"
 }
 
 func (d *AliDoc) post(ctx context.Context, path string, body interface{}) error {

--- a/drivers/alidoc/util.go
+++ b/drivers/alidoc/util.go
@@ -22,13 +22,6 @@ func (d *AliDoc) request(ctx context.Context) *resty.Request {
 		SetHeader("Origin", apiBase)
 }
 
-func joinPath(basePath, name string) string {
-	if basePath == "" || basePath == "/" {
-		return "/" + name
-	}
-	return strings.TrimRight(basePath, "/") + "/" + name
-}
-
 func msToTime(v int64) time.Time {
 	if v <= 0 {
 		return time.Time{}
@@ -88,6 +81,20 @@ func newClient() *resty.Client {
 	return client
 }
 
+func aliDocObjID(obj model.Obj) string {
+	if obj == nil {
+		return ""
+	}
+	return strings.TrimSpace(obj.GetID())
+}
+
+func (d *AliDoc) parentID(dir model.Obj) string {
+	if id := aliDocObjID(dir); id != "" {
+		return id
+	}
+	return d.RootFolderID
+}
+
 func pickAliDocDentryType(obj model.Obj) string {
 	if o, ok := obj.(*Object); ok && strings.TrimSpace(o.DentryType) != "" {
 		return o.DentryType
@@ -96,6 +103,19 @@ func pickAliDocDentryType(obj model.Obj) string {
 		return "folder"
 	}
 	return "file"
+}
+
+func (d *AliDoc) post(ctx context.Context, path string, body interface{}) error {
+	var result apiResp
+	resp, err := d.request(ctx).
+		SetBody(body).
+		SetResult(&result).
+		SetError(&result).
+		Post(apiBase + path)
+	if err != nil {
+		return err
+	}
+	return checkResp(resp, result)
 }
 
 func (d *AliDoc) list(ctx context.Context, dentryUUID string) ([]dentry, error) {

--- a/drivers/alidoc/util.go
+++ b/drivers/alidoc/util.go
@@ -3,7 +3,6 @@ package alidoc
 import (
 	"context"
 	"fmt"
-	"path"
 	"strings"
 	"time"
 
@@ -54,28 +53,11 @@ func checkResp(resp *resty.Response, result apiResp) error {
 	return nil
 }
 
-func toObj(parentPath string, item dentry) model.Obj {
-	return toObjWithPath(joinPath(parentPath, item.Name), item)
-}
-
-func toObjUsingBestPath(parentPath string, item dentry) model.Obj {
-	fullPath := strings.TrimSpace(item.Path)
-	if fullPath == "" {
-		fullPath = joinPath(parentPath, item.Name)
-	}
-	return toObjWithPath(fullPath, item)
-}
-
-func toObjWithPath(fullPath string, item dentry) model.Obj {
-	name := item.Name
-	if name == "" {
-		name = path.Base(fullPath)
-	}
+func toObj(item dentry) model.Obj {
 	obj := &Object{
 		Object: model.Object{
 			ID:       item.DentryUUID,
-			Path:     fullPath,
-			Name:     name,
+			Name:     item.Name,
 			Size:     item.FileSize,
 			Modified: msToTime(item.UpdatedTime),
 			Ctime:    msToTime(item.CreatedTime),

--- a/drivers/alidoc/util.go
+++ b/drivers/alidoc/util.go
@@ -82,6 +82,18 @@ func (d *AliDoc) post(ctx context.Context, path string, body interface{}) error 
 	return checkResp(resp, result)
 }
 
+func (d *AliDoc) checkCookie(ctx context.Context) error {
+	var result apiResp
+	resp, err := d.request(ctx).
+		SetResult(&result).
+		SetError(&result).
+		Get(apiBase + "/portal/api/v1/mine/info")
+	if err != nil {
+		return err
+	}
+	return checkResp(resp, result)
+}
+
 func (d *AliDoc) list(ctx context.Context, dentryUUID string) ([]dentry, error) {
 	var result listResp
 	resp, err := d.request(ctx).

--- a/drivers/alidoc/util.go
+++ b/drivers/alidoc/util.go
@@ -111,6 +111,16 @@ func newClient() *resty.Client {
 	return client
 }
 
+func pickAliDocDentryType(obj model.Obj) string {
+	if o, ok := obj.(*Object); ok && strings.TrimSpace(o.DentryType) != "" {
+		return o.DentryType
+	}
+	if obj != nil && obj.IsDir() {
+		return "folder"
+	}
+	return "file"
+}
+
 func (d *AliDoc) list(ctx context.Context, dentryUUID string) ([]dentry, error) {
 	var result listResp
 	resp, err := d.request(ctx).

--- a/drivers/all.go
+++ b/drivers/all.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/189_tv"
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/189pc"
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/alias"
+	_ "github.com/OpenListTeam/OpenList/v4/drivers/alidoc"
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/alist_v3"
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/aliyundrive"
 	_ "github.com/OpenListTeam/OpenList/v4/drivers/aliyundrive_open"

--- a/drivers/wps/driver.go
+++ b/drivers/wps/driver.go
@@ -45,6 +45,9 @@ func (d *Wps) Init(ctx context.Context) error {
 	if !resp.IsSuccess() {
 		return fmt.Errorf("failed to check login status, status code: %d, body: %s", resp.StatusCode(), resp.String())
 	}
+	if d.login == nil {
+		return fmt.Errorf("wps login failed: empty login state, please check cookie")
+	}
 
 	return nil
 }
@@ -382,6 +385,10 @@ func (d *Wps) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer
 }
 
 func (d *Wps) GetDetails(ctx context.Context) (*model.StorageDetails, error) {
+	if d.login == nil {
+		return nil, fmt.Errorf("wps login state is nil, please reinitialize or check cookie")
+	}
+
 	if d.isPersonal() {
 		url := ENDPOINT_PERSONAL + "/api/v3/spaces"
 		var resp spacesResp
@@ -399,6 +406,11 @@ func (d *Wps) GetDetails(ctx context.Context) (*model.StorageDetails, error) {
 			},
 		}, nil
 	}
+
+	if d.login.CompanyID == 0 {
+		return nil, fmt.Errorf("wps company id is empty, please check business account login")
+	}
+
 	url := ENDPOINT_BUSINESS + "/3rd/plussvr/compose/v1/u/companies/batch/service-space?comp_ids=" + fmt.Sprint(d.login.CompanyID)
 	var resp serviceSpaceResp
 	r, err := d.request(ctx).SetResult(&resp).SetError(&resp).Get(url)

--- a/drivers/wps/driver.go
+++ b/drivers/wps/driver.go
@@ -38,28 +38,23 @@ func (d *Wps) Init(ctx context.Context) error {
 
 	d.client = base.NewRestyClient()
 
-	resp, err := d.request(ctx).SetResult(&d.login).Get("https://account.kdocs.cn/api/v3/islogin")
+	d.login = &loginState{}
+	resp, err := d.request(ctx).SetResult(d.login).Get("https://account.kdocs.cn/api/v3/islogin")
 	if err != nil {
 		return err
 	}
 	if !resp.IsSuccess() {
 		return fmt.Errorf("failed to check login status, status code: %d, body: %s", resp.StatusCode(), resp.String())
 	}
-	if d.login == nil {
-		return fmt.Errorf("wps login failed: empty login state, please check cookie")
+	if d.login.CompanyID == 0 {
+		return fmt.Errorf("wps company id is empty, please check business account login")
 	}
-
 	return nil
 }
 
 func (d *Wps) Drop(ctx context.Context) error {
-
-	if d.client != nil {
-		d.client = nil
-	}
-	if d.login != nil {
-		d.login = nil
-	}
+	d.client = nil
+	d.login = nil
 	return nil
 }
 
@@ -385,10 +380,6 @@ func (d *Wps) Put(ctx context.Context, dstDir model.Obj, file model.FileStreamer
 }
 
 func (d *Wps) GetDetails(ctx context.Context) (*model.StorageDetails, error) {
-	if d.login == nil {
-		return nil, fmt.Errorf("wps login state is nil, please reinitialize or check cookie")
-	}
-
 	if d.isPersonal() {
 		url := ENDPOINT_PERSONAL + "/api/v3/spaces"
 		var resp spacesResp
@@ -406,11 +397,6 @@ func (d *Wps) GetDetails(ctx context.Context) (*model.StorageDetails, error) {
 			},
 		}, nil
 	}
-
-	if d.login.CompanyID == 0 {
-		return nil, fmt.Errorf("wps company id is empty, please check business account login")
-	}
-
 	url := ENDPOINT_BUSINESS + "/3rd/plussvr/compose/v1/u/companies/batch/service-space?comp_ids=" + fmt.Sprint(d.login.CompanyID)
 	var resp serviceSpaceResp
 	r, err := d.request(ctx).SetResult(&resp).SetError(&resp).Get(url)

--- a/drivers/wps/meta.go
+++ b/drivers/wps/meta.go
@@ -16,7 +16,7 @@ var config = driver.Config{
 	Name:        "WPS",
 	LocalSort:   true,
 	DefaultRoot: "/",
-	Alert:       "",
+	CheckStatus: true,
 }
 
 func init() {


### PR DESCRIPTION
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->

## Summary / 摘要

Add a new read-only `AliDoc` driver for accessing DingDrive through DingTalk Docs, and harden the WPS driver against empty login-state responses so initialization and details queries fail with clear errors instead of unstable behavior.

新增 `AliDoc` 驱动，用于通过钉钉文档访问钉盘，支持列出文件、查看文件、删除文件、移动文件、上传文件、创建文件夹、复制文件和重命名文件；同时增强 WPS 驱动在登录状态为空时的错误处理，使初始化和空间信息查询返回明确错误，而不是产生不稳定行为。

- Add `drivers/alidoc` with Cookie-based initialization, folder listing, and file download link resolution.
- Register the new driver in `drivers/all.go` and ignore local `alidoc/` reverse-engineering materials.
- Return user-friendly errors in WPS when login state or business company id is missing.
- Related frontend changes are needed to add `AliDoc` i18n entries and alert copy.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: OpenListTeam/OpenList-Frontend#536
- OpenList-Docs: OpenListTeam/OpenList-Docs#335

## Testing / 测试

- [x] `go test ./drivers/alidoc`
- [x] `go test ./drivers`
- [x] Manual test / 手动测试:
      可正常列出、查看、删除、移动、上传、复制和重命名文本、图片、视频和PDF。可正常创建和移动文件夹

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [x] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [x] Documentation / 文档
- [ ] Tests / 测试
- [x] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
