### PR TITLE
fix(archive): prefer utf-8 for non-EFS zip names

### DIFF
--- a/internal/archive/zip/utils.go
+++ b/internal/archive/zip/utils.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/fs"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/KirCute/zip"
 	"github.com/OpenListTeam/OpenList/v4/internal/archive/tool"
@@ -99,6 +100,9 @@ func filterPassword(err error) error {
 
 func decodeName(name string, efs bool) string {
 	if efs {
+		return name
+	}
+	if utf8.ValidString(name) {
 		return name
 	}
 	enc, err := ianaindex.IANA.Encoding(setting.GetStr(conf.NonEFSZipEncoding))

--- a/internal/archive/zip/utils_test.go
+++ b/internal/archive/zip/utils_test.go
@@ -1,0 +1,41 @@
+package zip
+
+import (
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/conf"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/internal/op"
+	"github.com/OpenListTeam/OpenList/v4/internal/setting"
+	"github.com/stretchr/testify/require"
+)
+
+func setNonEFSZipEncoding(value string) {
+	op.Cache.SetSetting(conf.NonEFSZipEncoding, &model.SettingItem{
+		Key:   conf.NonEFSZipEncoding,
+		Value: value,
+	})
+}
+
+func TestDecodeNamePrefersValidUTF8WhenEFSDisabled(t *testing.T) {
+	setNonEFSZipEncoding("IBM437")
+
+	name := "中文.txt"
+	require.Equal(t, name, decodeName(name, false))
+	// Ensure the setting still exists to verify we did not bypass config due to missing setup.
+	require.Equal(t, "IBM437", setting.GetStr(conf.NonEFSZipEncoding))
+}
+
+func TestDecodeNameFallsBackToConfiguredEncoding(t *testing.T) {
+	setNonEFSZipEncoding("GB18030")
+
+	name := string([]byte{0xd6, 0xd0, 0xce, 0xc4, '.', 't', 'x', 't'})
+	require.Equal(t, "中文.txt", decodeName(name, false))
+}
+
+func TestDecodeNameRespectsEFSFlag(t *testing.T) {
+	setNonEFSZipEncoding("GB18030")
+
+	name := "utf8-name.txt"
+	require.Equal(t, name, decodeName(name, true))
+}


### PR DESCRIPTION
## Summary / 摘要

This PR fixes garbled filenames when previewing ZIP archives whose entries do not set the EFS flag.

Previously, OpenList always decoded non-EFS ZIP entry names with `non_efs_zip_encoding` (default: `IBM437`). In practice, some ZIP tools store filenames as valid UTF-8 but do not set the EFS flag, which caused Chinese and other non-ASCII filenames to appear garbled.

Changes in this PR:
- Prefer the original filename when the ZIP entry has the EFS flag.
- For non-EFS ZIP entries, return the original name first if it is already valid UTF-8.
- Only fall back to `non_efs_zip_encoding` when the raw filename is not valid UTF-8.
- Add unit tests covering:
  - valid UTF-8 names without EFS
  - fallback decoding with configured encoding
  - unchanged behavior when EFS is set

User-visible behavior:
- ZIP preview now displays more non-EFS UTF-8 filenames correctly.
- Legacy non-UTF-8 ZIP files still use the configured fallback encoding.

Compatibility:
- No breaking changes.
- No public API, config schema, storage format, or migration behavior changes.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Testing / 测试

- [ ] `go test ./...`
- [x] Manual test / 手动测试:
  - `go test ./internal/archive/zip`
  - Verified the updated decoding logic with unit tests for UTF-8-first fallback behavior.

## Checklist / 检查清单

- [ ] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [x] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
