### PR TITLE
fix(teldrive): avoid index out of range panic when listing an empty dir

### DIFF
--- a/drivers/teldrive/driver.go
+++ b/drivers/teldrive/driver.go
@@ -68,6 +68,12 @@ func (d *Teldrive) List(ctx context.Context, dir model.Obj, args model.ListArgs)
 		return nil, err
 	}
 
+	// An empty directory reports totalPages == 0, which would make
+	// pagesData a zero-length slice and panic on pagesData[0] below.
+	if firstResp.Meta.TotalPages < 1 {
+		return []model.Obj{}, nil
+	}
+
 	pagesData := make([][]Object, firstResp.Meta.TotalPages)
 	pagesData[0] = firstResp.Items
 

--- a/drivers/teldrive/driver_test.go
+++ b/drivers/teldrive/driver_test.go
@@ -1,0 +1,38 @@
+package teldrive
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/drivers/base"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/go-resty/resty/v2"
+)
+
+// An empty directory makes the Teldrive API report totalPages == 0. List used
+// to size pagesData by that value and then write pagesData[0], which panicked
+// with "index out of range [0] with length 0" on every empty folder.
+func TestListEmptyDir(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[],"meta":{"count":0,"totalPages":0,"currentPage":1}}`))
+	}))
+	defer srv.Close()
+
+	oldClient := base.RestyClient
+	base.RestyClient = resty.New()
+	defer func() { base.RestyClient = oldClient }()
+
+	d := &Teldrive{}
+	d.Address = srv.URL
+
+	objs, err := d.List(context.Background(), &model.Object{Path: "/"}, model.ListArgs{})
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(objs) != 0 {
+		t.Fatalf("expected no entries for an empty dir, got %d", len(objs))
+	}
+}


### PR DESCRIPTION
## Summary / 摘要

When a Teldrive folder is empty the API returns `totalPages: 0`, so `List` sized `pagesData` to length 0 and then panicked on `pagesData[0]`. This made copying into an empty Teldrive directory (and listing one) crash with `index out of range [0] with length 0`. Returning early for the no-pages case fixes it; added a regression test that drives `List` against an empty-listing response.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: N/A
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

Closes #2538

## Testing / 测试

- [ ] `go test ./...`
- [x] Manual test / 手动测试: `go test ./drivers/teldrive/...`; the new regression test hits the index out of range panic without the fix and passes with it.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [ ] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [ ] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
