### PR TITLE
feat(onedrive_sharelink): support direct download redirects

### DIFF
--- a/drivers/onedrive_sharelink/driver.go
+++ b/drivers/onedrive_sharelink/driver.go
@@ -2,6 +2,7 @@ package onedrive_sharelink
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,7 +22,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const headerTTL = 25 * time.Minute
+const (
+	headerTTL     = 25 * time.Minute
+	directLinkTTL = 20 * time.Minute
+)
 
 type OnedriveSharelink struct {
 	model.Storage
@@ -97,6 +101,18 @@ func (d *OnedriveSharelink) Link(ctx context.Context, file model.Obj, args model
 	header, err := d.getValidHeaders(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	if args.Redirect {
+		directURL, err := d.resolveDirectDownloadURL(ctx, file, url, header)
+		if err != nil {
+			return nil, err
+		}
+		expiration := directLinkTTL
+		return &model.Link{
+			URL:        directURL,
+			Expiration: &expiration,
+		}, nil
 	}
 
 	return &model.Link{
@@ -192,6 +208,96 @@ func cloneHeader(header http.Header) http.Header {
 		return nil
 	}
 	return header.Clone()
+}
+
+func (d *OnedriveSharelink) resolveDirectDownloadURL(ctx context.Context, file model.Obj, rawURL string, header http.Header) (string, error) {
+	var errs []error
+	if obj, ok := unwrapObject(file); ok {
+		if obj.SPItemURL != "" {
+			directURL, err := d.resolveSPItemDownloadURL(ctx, obj.SPItemURL, header)
+			if err == nil {
+				return directURL, nil
+			}
+			errs = append(errs, err)
+		}
+		if obj.ContentDownloadURL != "" {
+			return obj.ContentDownloadURL, nil
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header = cloneHeader(header)
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
+
+	resp, err := NewNoRedirectCLient().Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		errs = append(errs, fmt.Errorf("download.aspx returned no redirect location, status code: %d", resp.StatusCode))
+		return "", fmt.Errorf("onedrive_sharelink: direct download URL unavailable: %v", errs)
+	}
+	u, err := req.URL.Parse(location)
+	if err != nil {
+		return "", err
+	}
+	return u.String(), nil
+}
+
+type spItemDownloadResp struct {
+	ContentDownloadURL string `json:"@content.downloadUrl"`
+}
+
+func unwrapObject(obj model.Obj) (*Object, bool) {
+	for {
+		switch o := obj.(type) {
+		case *Object:
+			return o, true
+		case model.ObjUnwrap:
+			obj = o.Unwrap()
+		default:
+			return nil, false
+		}
+	}
+}
+
+func (d *OnedriveSharelink) resolveSPItemDownloadURL(ctx context.Context, spItemURL string, header http.Header) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, spItemURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header = cloneHeader(header)
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
+	req.Header.Set("Accept", "application/json;odata.metadata=minimal")
+
+	resp, err := NewNoRedirectCLient().Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("sp item metadata request failed, status code: %d", resp.StatusCode)
+	}
+
+	var data spItemDownloadResp
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", err
+	}
+	if data.ContentDownloadURL == "" {
+		return "", fmt.Errorf("sp item metadata response missing @content.downloadUrl")
+	}
+	return data.ContentDownloadURL, nil
 }
 
 func (d *OnedriveSharelink) headerSnapshot() http.Header {

--- a/drivers/onedrive_sharelink/meta.go
+++ b/drivers/onedrive_sharelink/meta.go
@@ -19,7 +19,6 @@ type Addition struct {
 
 var config = driver.Config{
 	Name:        "Onedrive Sharelink",
-	OnlyProxy:   true,
 	NoUpload:    true,
 	DefaultRoot: "/",
 }

--- a/drivers/onedrive_sharelink/types.go
+++ b/drivers/onedrive_sharelink/types.go
@@ -23,30 +23,42 @@ type FolderResp struct {
 
 // Item represents an individual item in the folder.
 type Item struct {
-	ObjType      string    `json:"FSObjType"`       // ObjType indicates if the item is a file or folder.
-	Name         string    `json:"FileLeafRef"`     // Name is the name of the item.
-	ModifiedTime time.Time `json:"Modified."`       // ModifiedTime is the last modified time of the item.
-	Size         string    `json:"File_x0020_Size"` // Size is the size of the item in string format.
-	Id           string    `json:"UniqueId"`        // Id is the unique identifier of the item.
+	ObjType            string    `json:"FSObjType"`            // ObjType indicates if the item is a file or folder.
+	Name               string    `json:"FileLeafRef"`          // Name is the name of the item.
+	ModifiedTime       time.Time `json:"Modified."`            // ModifiedTime is the last modified time of the item.
+	Size               string    `json:"File_x0020_Size"`      // Size is the size of the item in string format.
+	Id                 string    `json:"UniqueId"`             // Id is the unique identifier of the item.
+	SPItemURL          string    `json:".spItemUrl"`           // SPItemURL points to the SharePoint item metadata API.
+	ContentDownloadURL string    `json:"@content.downloadUrl"` // ContentDownloadURL is a temporary cookie-free download URL.
 }
 
-// fileToObj converts an Item to an ObjThumb.
-func fileToObj(f Item) *model.ObjThumb {
+type Object struct {
+	model.ObjThumb
+	SPItemURL          string
+	ContentDownloadURL string
+}
+
+// fileToObj converts an Item to an Object.
+func fileToObj(f Item) *Object {
 	// Convert Size from string to int64.
 	size, _ := strconv.ParseInt(f.Size, 10, 64)
 	// Convert ObjType from string to int.
 	objtype, _ := strconv.Atoi(f.ObjType)
 
 	// Create a new ObjThumb with the converted values.
-	file := &model.ObjThumb{
-		Object: model.Object{
-			Name:     f.Name,
-			Modified: f.ModifiedTime,
-			Size:     size,
-			IsFolder: objtype == 1, // Check if the item is a folder.
-			ID:       f.Id,
+	file := &Object{
+		ObjThumb: model.ObjThumb{
+			Object: model.Object{
+				Name:     f.Name,
+				Modified: f.ModifiedTime,
+				Size:     size,
+				IsFolder: objtype == 1, // Check if the item is a folder.
+				ID:       f.Id,
+			},
+			Thumbnail: model.Thumbnail{},
 		},
-		Thumbnail: model.Thumbnail{},
+		SPItemURL:          f.SPItemURL,
+		ContentDownloadURL: f.ContentDownloadURL,
 	}
 	return file
 }


### PR DESCRIPTION
## Summary / 摘要

- Enable the Onedrive Sharelink driver to return redirect download links by resolving SharePoint item metadata and using `@content.downloadUrl`.
- Preserve proxy/range-reader behavior for non-redirect link requests.
- Remove `OnlyProxy` from the driver config so direct redirect downloads can be used.
- Set a short local link cache TTL for temporary SharePoint `tempauth` URLs.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: N/A
- OpenList-Docs: N/A

## Testing / 测试

- [ ] `go test ./...`
- [x] `go test ./drivers/onedrive_sharelink ./server/handles`
- [x] Manual test / 手动测试:
  - Mounted a OneDrive ShareLink storage at `/1`.
  - Verified `/d/1/01.mp4` returns `302 Found` with a SharePoint `download.aspx?...tempauth=...` location instead of falling back to OpenList proxy.
  - Verified following the redirect with a range request returns `206 Partial Content` directly from SharePoint.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的 AI 辅助内容。