### PR TITLE
fix(webdav): Normalize WebDAV error

### DIFF
--- a/drivers/webdav/driver.go
+++ b/drivers/webdav/driver.go
@@ -52,7 +52,7 @@ func (d *WebDav) Drop(ctx context.Context) error {
 func (d *WebDav) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]model.Obj, error) {
 	files, err := d.client.ReadDir(dir.GetPath())
 	if err != nil {
-		return nil, err
+		return nil, normalizeError(err)
 	}
 	return utils.SliceConvert(files, func(src os.FileInfo) (model.Obj, error) {
 		return &model.Object{
@@ -68,7 +68,7 @@ func (d *WebDav) List(ctx context.Context, dir model.Obj, args model.ListArgs) (
 func (d *WebDav) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	url, header, err := d.client.Link(file.GetPath())
 	if err != nil {
-		return nil, err
+		return nil, normalizeError(err)
 	}
 	if args.Redirect {
 		// get the url after redirect
@@ -93,23 +93,23 @@ func (d *WebDav) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 }
 
 func (d *WebDav) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {
-	return d.client.MkdirAll(path.Join(parentDir.GetPath(), dirName), 0644)
+	return normalizeError(d.client.MkdirAll(path.Join(parentDir.GetPath(), dirName), 0644))
 }
 
 func (d *WebDav) Move(ctx context.Context, srcObj, dstDir model.Obj) error {
-	return d.client.Rename(getPath(srcObj), path.Join(dstDir.GetPath(), srcObj.GetName()), true)
+	return normalizeError(d.client.Rename(getPath(srcObj), path.Join(dstDir.GetPath(), srcObj.GetName()), true))
 }
 
 func (d *WebDav) Rename(ctx context.Context, srcObj model.Obj, newName string) error {
-	return d.client.Rename(getPath(srcObj), path.Join(path.Dir(srcObj.GetPath()), newName), true)
+	return normalizeError(d.client.Rename(getPath(srcObj), path.Join(path.Dir(srcObj.GetPath()), newName), true))
 }
 
 func (d *WebDav) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
-	return d.client.Copy(getPath(srcObj), path.Join(dstDir.GetPath(), srcObj.GetName()), true)
+	return normalizeError(d.client.Copy(getPath(srcObj), path.Join(dstDir.GetPath(), srcObj.GetName()), true))
 }
 
 func (d *WebDav) Remove(ctx context.Context, obj model.Obj) error {
-	return d.client.RemoveAll(getPath(obj))
+	return normalizeError(d.client.RemoveAll(getPath(obj)))
 }
 
 func (d *WebDav) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, up driver.UpdateProgress) error {
@@ -122,7 +122,7 @@ func (d *WebDav) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer
 		UpdateProgress: up,
 	})
 	err := d.client.WriteStream(path.Join(dstDir.GetPath(), s.GetName()), reader, 0644, callback)
-	return err
+	return normalizeError(err)
 }
 
 // implements driver.Getter interface
@@ -130,7 +130,7 @@ func (d *WebDav) Get(ctx context.Context, _path string) (model.Obj, error) {
 	_path = path.Join(d.GetRootPath(), _path)
 	info, err := d.client.Stat(_path)
 	if err != nil {
-		return nil, err
+		return nil, normalizeError(err)
 	}
 
 	return &model.Object{

--- a/drivers/webdav/driver_test.go
+++ b/drivers/webdav/driver_test.go
@@ -1,0 +1,50 @@
+package webdav
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
+	"github.com/OpenListTeam/OpenList/v4/internal/op"
+	"github.com/OpenListTeam/OpenList/v4/pkg/gowebdav"
+)
+
+func TestGetMapsPropfindNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PROPFIND" {
+			t.Fatalf("expected PROPFIND request, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	d := &WebDav{
+		client: gowebdav.NewClient(server.URL, "", ""),
+	}
+
+	_, err := d.Get(context.Background(), "/missing")
+	if !errs.IsObjectNotFound(err) {
+		t.Fatalf("expected object not found, got %v", err)
+	}
+}
+
+func TestOpGetRecognizesPropfindNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PROPFIND" {
+			t.Fatalf("expected PROPFIND request, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	d := &WebDav{
+		client: gowebdav.NewClient(server.URL, "", ""),
+	}
+
+	_, err := op.Get(context.Background(), d, "/missing")
+	if !errs.IsObjectNotFound(err) {
+		t.Fatalf("expected object not found, got %v", err)
+	}
+}

--- a/drivers/webdav/util.go
+++ b/drivers/webdav/util.go
@@ -6,6 +6,7 @@ import (
 	"net/http/cookiejar"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/webdav/odrvcookie"
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/pkg/gowebdav"
 )
@@ -49,4 +50,14 @@ func getPath(obj model.Obj) string {
 		return obj.GetPath() + "/"
 	}
 	return obj.GetPath()
+}
+
+func normalizeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if gowebdav.IsErrNotFound(err) {
+		return errs.ObjectNotFound
+	}
+	return err
 }


### PR DESCRIPTION
## Summary / 摘要

Normalize error from gowebdav to OpenList's internal error. In this PR only handles ObjectNotFound so internal/op.MakeDir can continue past the existence check and call the actual mkdir API. 

Fixes https://github.com/OpenListTeam/OpenList/issues/2564

No user visible change.

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->

<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

## Related Issues / 关联 Issue

<!--
Use `Closes #123`, `Fixes #123`, or `Relates to #123`.
Remove this section if not applicable.
使用 `Closes #123`、`Fixes #123` 或 `Relates to #123`。
不适用时请删除本节。
-->

## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [x] `go test ./...`
- [x] Manual test / 手动测试:
+ Run locally and add WebDAV storage. 
+ Without this PR, when add new folder, errors out with 404
+ With this PR, can add new folder successfully.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [ ] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
