### PR TITLE
feat(s3): support direct transfer redirects

### DIFF
--- a/drivers/onedrive_sharelink/driver.go
+++ b/drivers/onedrive_sharelink/driver.go
@@ -33,6 +33,7 @@ const (
 	headerTTL          = 25 * time.Minute
 	driveTokenTTL      = 20 * time.Minute
 	directLinkTTL      = 20 * time.Minute
+	simpleUploadLimit  = 250 * 1024 * 1024
 	uploadSessionChunk = 10 * 1024 * 1024
 )
 
@@ -302,7 +303,7 @@ func (d *OnedriveSharelink) createUploadInfo(ctx context.Context, path string, f
 	if err != nil {
 		return nil, err
 	}
-	if fileSize == 0 {
+	if fileSize >= 0 && fileSize <= simpleUploadLimit {
 		return &model.HttpDirectUploadInfo{
 			UploadURL: injectAccessToken(d.drivePathAPIURL(path)+"/content", token),
 			Method:    http.MethodPut,

--- a/server/s3/redirect.go
+++ b/server/s3/redirect.go
@@ -1,0 +1,169 @@
+// Credits: https://pkg.go.dev/github.com/rclone/rclone@v1.65.2/cmd/serve/s3
+// Package s3 implements a fake s3 server for openlist
+package s3
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/conf"
+	"github.com/OpenListTeam/OpenList/v4/internal/fs"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/internal/op"
+	"github.com/OpenListTeam/OpenList/v4/server/common"
+	"github.com/itsHenry35/gofakes3/signature"
+)
+
+func redirectHandler(next http.Handler, authPairs map[string]string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if u, ok := directObjectURL(r, authPairs); ok {
+			w.Header().Set("Location", u)
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		if u, ok := directUploadURL(r, authPairs); ok {
+			w.Header().Set("Location", u)
+			w.Header().Set("Cache-Control", "no-store")
+			w.WriteHeader(http.StatusTemporaryRedirect)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func directObjectURL(r *http.Request, authPairs map[string]string) (string, bool) {
+	if r.Method != http.MethodGet {
+		return "", false
+	}
+	if hasNonObjectQuery(r) || !s3RequestAuthorized(r, authPairs) {
+		return "", false
+	}
+	bucketName, objectName, ok := parseObjectPath(r.URL.Path)
+	if !ok {
+		return "", false
+	}
+	bucket, err := getBucketByName(bucketName)
+	if err != nil {
+		return "", false
+	}
+	reqPath := path.Join(bucket.Path, objectName)
+	meta, _ := op.GetNearestMeta(reqPath)
+	ctx := context.WithValue(r.Context(), conf.MetaKey, meta)
+	storage, err := fs.GetStorage(reqPath, &fs.GetStoragesArgs{})
+	if err != nil || common.ShouldProxy(storage, path.Base(reqPath)) {
+		return "", false
+	}
+	link, file, err := fs.Link(ctx, reqPath, model.LinkArgs{
+		IP:       clientIP(r),
+		Header:   r.Header,
+		Redirect: true,
+	})
+	if err != nil {
+		return "", false
+	}
+	defer link.Close()
+	if file == nil || file.IsDir() || link.URL == "" || link.RangeReader != nil {
+		return "", false
+	}
+	return link.URL, true
+}
+
+func directUploadURL(r *http.Request, authPairs map[string]string) (string, bool) {
+	if r.Method != http.MethodPut || r.ContentLength < 0 {
+		return "", false
+	}
+	if hasNonObjectQuery(r) || !s3RequestAuthorized(r, authPairs) {
+		return "", false
+	}
+	if r.Header.Get("X-Amz-Copy-Source") != "" ||
+		r.Header.Get("X-Amz-Content-Sha256") == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD" {
+		return "", false
+	}
+	bucketName, objectName, ok := parseObjectPath(r.URL.Path)
+	if !ok || strings.HasSuffix(objectName, "/") {
+		return "", false
+	}
+	bucket, err := getBucketByName(bucketName)
+	if err != nil {
+		return "", false
+	}
+	reqPath := path.Join(bucket.Path, objectName)
+	storage, dstDirActualPath, err := op.GetStorageAndActualPath(path.Dir(reqPath))
+	if err != nil || storage.Config().NoUpload {
+		return "", false
+	}
+	info, err := op.GetDirectUploadInfo(r.Context(), "HttpDirect", storage, dstDirActualPath, path.Base(reqPath), r.ContentLength)
+	if err != nil {
+		return "", false
+	}
+	httpInfo, ok := asHTTPDirectUploadInfo(info)
+	if !ok {
+		return "", false
+	}
+	method := httpInfo.Method
+	if method == "" {
+		method = http.MethodPut
+	}
+	if !strings.EqualFold(method, http.MethodPut) || httpInfo.UploadURL == "" ||
+		httpInfo.ChunkSize > 0 || len(httpInfo.Headers) > 0 {
+		return "", false
+	}
+	return httpInfo.UploadURL, true
+}
+
+func asHTTPDirectUploadInfo(info any) (*model.HttpDirectUploadInfo, bool) {
+	switch v := info.(type) {
+	case *model.HttpDirectUploadInfo:
+		return v, v != nil
+	case model.HttpDirectUploadInfo:
+		return &v, true
+	default:
+		return nil, false
+	}
+}
+
+func parseObjectPath(rawPath string) (bucket, object string, ok bool) {
+	parts := strings.SplitN(strings.TrimPrefix(rawPath, "/"), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func hasNonObjectQuery(r *http.Request) bool {
+	query := r.URL.Query()
+	for key := range query {
+		lower := strings.ToLower(key)
+		if strings.HasPrefix(lower, "x-amz-") ||
+			lower == "awsaccesskeyid" ||
+			lower == "signature" ||
+			lower == "expires" ||
+			lower == "x-id" {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func s3RequestAuthorized(r *http.Request, authPairs map[string]string) bool {
+	if len(authPairs) == 0 {
+		return true
+	}
+	result := signature.V4SignVerify(r)
+	if result == signature.ErrUnsupportAlgorithm {
+		result = signature.V2SignVerify(r)
+	}
+	return result == signature.ErrNone
+}
+
+func clientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/server/s3/redirect_test.go
+++ b/server/s3/redirect_test.go
@@ -1,0 +1,74 @@
+package s3
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+)
+
+func TestParseObjectPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		wantBucket string
+		wantObject string
+		wantOK     bool
+	}{
+		{name: "object", path: "/bucket/path/to/file.txt", wantBucket: "bucket", wantObject: "path/to/file.txt", wantOK: true},
+		{name: "missing object", path: "/bucket", wantOK: false},
+		{name: "empty bucket", path: "//file.txt", wantOK: false},
+		{name: "empty object", path: "/bucket/", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bucket, object, ok := parseObjectPath(tt.path)
+			if ok != tt.wantOK || bucket != tt.wantBucket || object != tt.wantObject {
+				t.Fatalf("parseObjectPath(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tt.path, bucket, object, ok, tt.wantBucket, tt.wantObject, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestHasNonObjectQuery(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "no query", raw: "/bucket/object", want: false},
+		{name: "aws auth query", raw: "/bucket/object?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc", want: false},
+		{name: "legacy auth query", raw: "/bucket/object?AWSAccessKeyId=ak&Signature=sig&Expires=1", want: false},
+		{name: "sdk operation marker", raw: "/bucket/object?x-id=GetObject", want: false},
+		{name: "list query", raw: "/bucket/object?list-type=2", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.raw, nil)
+			if got := hasNonObjectQuery(req); got != tt.want {
+				t.Fatalf("hasNonObjectQuery(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAsHTTPDirectUploadInfo(t *testing.T) {
+	info := model.HttpDirectUploadInfo{UploadURL: "https://example.com/upload"}
+	got, ok := asHTTPDirectUploadInfo(info)
+	if !ok || got == nil || got.UploadURL != info.UploadURL {
+		t.Fatalf("asHTTPDirectUploadInfo(value) = (%v, %v), want upload info", got, ok)
+	}
+
+	got, ok = asHTTPDirectUploadInfo(&info)
+	if !ok || got == nil || got.UploadURL != info.UploadURL {
+		t.Fatalf("asHTTPDirectUploadInfo(pointer) = (%v, %v), want upload info", got, ok)
+	}
+
+	got, ok = asHTTPDirectUploadInfo(struct{}{})
+	if ok || got != nil {
+		t.Fatalf("asHTTPDirectUploadInfo(unsupported) = (%v, %v), want nil false", got, ok)
+	}
+}

--- a/server/s3/server.go
+++ b/server/s3/server.go
@@ -13,15 +13,16 @@ import (
 // Make a new S3 Server to serve the remote
 func NewServer(ctx context.Context) (h http.Handler, err error) {
 	var newLogger logger
+	authPairs := authlistResolver()
 	faker := gofakes3.New(
 		newBackend(),
 		// gofakes3.WithHostBucket(!opt.pathBucketMode),
 		gofakes3.WithLogger(newLogger),
 		gofakes3.WithRequestID(rand.Uint64()),
 		gofakes3.WithoutVersioning(),
-		gofakes3.WithV4Auth(authlistResolver()),
+		gofakes3.WithV4Auth(authPairs),
 		gofakes3.WithIntegrityCheck(true), // Check Content-MD5 if supplied
 	)
 
-	return faker.Server(), nil
+	return redirectHandler(faker.Server(), authPairs), nil
 }


### PR DESCRIPTION
## Summary / 摘要

- Add an S3 HTTP wrapper that returns `302 Found` for eligible `GET Object` requests when the mapped OpenList storage can provide a direct download URL and proxying is not required.
- Add `307 Temporary Redirect` support for eligible `PUT Object` requests when the mapped storage supports `HttpDirect` single-request `PUT` uploads.
- Keep the existing gofakes3 streaming path as the fallback for unsupported cases, including multipart upload, copy requests, streaming SigV4 payloads, drivers without direct upload, forced proxy rules, chunked direct-upload sessions, and direct-upload info requiring extra headers.
- Allow OneDrive Sharelink direct-upload info to use Microsoft Graph simple `/content` upload URLs for files within the 250 MiB single-upload limit, so S3 `PUT Object` can be redirected safely for those files.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Testing / 测试

- [ ] `go test ./...`
- [x] `go test ./server/s3 ./server/handles ./drivers/onedrive_sharelink`
- [x] Manual test / 手动测试:
  - Started OpenList from source with S3 enabled on port 5246.
  - Verified unsigned S3 object requests are still rejected with `403 InvalidAccessKeyId`.
  - Verified signed S3 `GET Object` returns `302 Found` with a direct OneDrive Sharelink download URL.
  - Verified signed S3 `GET Object?x-id=GetObject` also returns `302 Found`.
  - Verified signed S3 `PUT Object` to OneDrive Sharelink returns `307 Temporary Redirect` with a direct Graph `/content` upload URL for a small file.
  - Verified signed S3 `PUT Object` to 189CloudPC falls back to the existing server-side upload path and succeeds with `200 OK`.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
