### PR TITLE
fix(s3): only skip direct redirect for true sub-resource queries

### DIFF
--- a/server/s3/redirect.go
+++ b/server/s3/redirect.go
@@ -4,7 +4,6 @@ package s3
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"path"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/internal/fs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"github.com/OpenListTeam/OpenList/v4/server/common"
 	"github.com/itsHenry35/gofakes3/signature"
 )
@@ -20,11 +20,14 @@ import (
 func redirectHandler(next http.Handler, authPairs map[string]string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if u, ok := directObjectURL(r, authPairs); ok {
+			w.Header().Set("Referrer-Policy", "no-referrer")
+			w.Header().Set("Cache-Control", "max-age=0, no-cache, no-store, must-revalidate")
 			w.Header().Set("Location", u)
 			w.WriteHeader(http.StatusFound)
 			return
 		}
 		if u, ok := directUploadURL(r, authPairs); ok {
+			w.Header().Set("Referrer-Policy", "no-referrer")
 			w.Header().Set("Location", u)
 			w.Header().Set("Cache-Control", "no-store")
 			w.WriteHeader(http.StatusTemporaryRedirect)
@@ -57,7 +60,7 @@ func directObjectURL(r *http.Request, authPairs map[string]string) (string, bool
 		return "", false
 	}
 	link, file, err := fs.Link(ctx, reqPath, model.LinkArgs{
-		IP:       clientIP(r),
+		IP:       utils.ClientIP(r),
 		Header:   r.Header,
 		Redirect: true,
 	})
@@ -133,17 +136,20 @@ func parseObjectPath(rawPath string) (bucket, object string, ok bool) {
 	return parts[0], parts[1], true
 }
 
+// hasNonObjectQuery reports whether the request carries a query parameter that
+// makes gofakes3 route it to a sub-resource handler instead of plain object
+// download (see gofakes3 routing.go). Only those keys force server-side
+// handling; every other query parameter (response-content-disposition,
+// response-content-type, etc.) is irrelevant to route selection and must not
+// block a direct redirect.
 func hasNonObjectQuery(r *http.Request) bool {
 	query := r.URL.Query()
-	for key := range query {
-		lower := strings.ToLower(key)
-		if strings.HasPrefix(lower, "x-amz-") ||
-			lower == "awsaccesskeyid" ||
-			lower == "signature" ||
-			lower == "expires" ||
-			lower == "x-id" {
-			continue
+	for _, key := range []string{"uploadId", "uploads", "versioning", "versions", "location"} {
+		if _, ok := query[key]; ok {
+			return true
 		}
+	}
+	if versionID := query.Get("versionId"); versionID != "" && versionID != "null" {
 		return true
 	}
 	return false
@@ -158,12 +164,4 @@ func s3RequestAuthorized(r *http.Request, authPairs map[string]string) bool {
 		result = signature.V2SignVerify(r)
 	}
 	return result == signature.ErrNone
-}
-
-func clientIP(r *http.Request) string {
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
 }

--- a/server/s3/redirect_test.go
+++ b/server/s3/redirect_test.go
@@ -42,7 +42,20 @@ func TestHasNonObjectQuery(t *testing.T) {
 		{name: "aws auth query", raw: "/bucket/object?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc", want: false},
 		{name: "legacy auth query", raw: "/bucket/object?AWSAccessKeyId=ak&Signature=sig&Expires=1", want: false},
 		{name: "sdk operation marker", raw: "/bucket/object?x-id=GetObject", want: false},
-		{name: "list query", raw: "/bucket/object?list-type=2", want: true},
+		{name: "response content disposition", raw: "/bucket/object?response-content-disposition=attachment%3Bfilename%3Dx", want: false},
+		{name: "response content type", raw: "/bucket/object?response-content-type=text%2Fplain", want: false},
+		// list-type is not a routing key in gofakes3: a path with an object
+		// segment is dispatched to getObject regardless, so it must not block
+		// a direct redirect.
+		{name: "list query", raw: "/bucket/object?list-type=2", want: false},
+		{name: "multipart uploads", raw: "/bucket/object?uploads", want: true},
+		{name: "multipart upload id", raw: "/bucket/object?uploadId=123", want: true},
+		{name: "versioning", raw: "/bucket/object?versioning", want: true},
+		{name: "versions", raw: "/bucket/object?versions", want: true},
+		{name: "bucket location", raw: "/bucket/object?location", want: true},
+		{name: "version id", raw: "/bucket/object?versionId=abc", want: true},
+		{name: "version id null", raw: "/bucket/object?versionId=null", want: false},
+		{name: "version id empty", raw: "/bucket/object?versionId=", want: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary / 摘要

Follow-up fix for #2598 (`feat(s3): support direct transfer redirects`).

After #2598 shipped, S3 `GET Object` requests that carried standard
`response-*` override parameters (most commonly `response-content-disposition`,
which clients add to set the download filename) were incorrectly forced through
the gofakes3 server-side streaming path instead of being redirected to the
upstream direct link.

Root cause: `hasNonObjectQuery` used an **allow-list** — it let through only the
SigV4 signing parameters (`x-amz-*`, `awsaccesskeyid`, `signature`, `expires`,
`x-id`) and treated *every other* query parameter as a "non-object" request,
disabling the redirect. Any client that appended `response-content-disposition`
(or any other unanticipated parameter) silently lost direct-download.

This affects **every direct-link-capable driver**, not a specific one: the
allow-list runs before storage/driver selection, so the regression is generic.

### Changes

- Reverse `hasNonObjectQuery` from an allow-list to a **block-list**: only the
  query keys that make gofakes3 route a request to a sub-resource handler
  (`uploadId`, `uploads`, `versioning`, `versions`, `location`, and a non-null
  `versionId`) disable the direct redirect. This list is derived directly from
  gofakes3 `routing.go` `routeBase`/`routeBucket`, so `response-*` and all other
  download-irrelevant parameters now correctly allow a `302`.
- Align the download redirect with the native `handles.redirect` path by setting
  `Referrer-Policy: no-referrer` (avoid leaking the signed upstream URL via
  Referer) and `Cache-Control: max-age=0, no-cache, no-store, must-revalidate`
  (avoid caching short-lived signed links). Also set `Referrer-Policy` on the
  upload redirect branch for consistency.
- Use the shared `utils.ClientIP(r)` (X-Forwarded-For / X-Real-Ip aware) instead
  of a local `RemoteAddr`-only helper, so drivers that bind direct links to the
  client IP receive the real client IP when running behind a reverse proxy.

No public API, config, or storage format changes. Upload-path logic from #2598
is untouched.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Related Issues / 关联 Issue

Relates to #2598

## Testing / 测试

- [x] `go build ./...`
- [x] `gofmt` clean on changed file
- [x] Manual test / 手动测试:

Built from source with S3 enabled on port 5246 behind an openresty reverse
proxy, and exercised three direct-link-capable drivers via signed SigV4
presigned `GET` requests. Each was tested both with and without
`response-content-disposition`.

| Bucket | Driver | Cloud | GET (plain) | GET (with `response-content-disposition`) |
|--------|--------|-------|-------------|--------------------------------------------|
| cu | 139Yun | China Mobile | `302` direct | `302` direct |
| ct | 189CloudPC | China Telecom | `302` direct | `302` direct |
| cm | WoPan | China Unicom | `302` direct | `302` direct |

Before the fix, the `response-content-disposition` variant returned `304/200`
(server-side proxy); after the fix it returns `302` to the upstream direct link.

Verified the new response headers are present on every `302`:

```
HTTP/1.1 302 Found
Cache-Control: max-age=0, no-cache, no-store, must-revalidate
Referrer-Policy: no-referrer
Location: https://<upstream-direct-link>...
```

Verified `X-Forwarded-For` handling: requests carrying
`X-Forwarded-For: 1.2.3.4` still redirect correctly, confirming the client-IP
change does not break the link flow.

Verified the block-list against gofakes3 `routing.go`: sub-resource requests
(`?uploads`, `?uploadId=`, `?versioning`, `?versions`, `?location`,
`?versionId=`) still fall back to the gofakes3 server-side path; plain object
downloads (including `?x-id=GetObject` and `?response-content-disposition=...`)
are redirected.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
