### PR TITLE
feat(alias): add optional listing cache

### DIFF
--- a/drivers/alias/cache.go
+++ b/drivers/alias/cache.go
@@ -1,0 +1,252 @@
+package alias
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
+)
+
+type aliasListCacheEntry struct {
+	objs    []model.Obj
+	expires time.Time
+}
+
+type aliasResolveCacheEntry struct {
+	resolved aliasResolved
+	expires  time.Time
+}
+
+type aliasResolved struct {
+	paths   []string
+	skipped bool
+	obj     model.Object
+	hasObj  bool
+}
+
+type aliasCache struct {
+	mu       sync.RWMutex
+	lists    map[string]aliasListCacheEntry
+	resolved map[string]aliasResolveCacheEntry
+}
+
+func (c *aliasCache) init() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lists = make(map[string]aliasListCacheEntry)
+	c.resolved = make(map[string]aliasResolveCacheEntry)
+}
+
+func (c *aliasCache) clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lists = make(map[string]aliasListCacheEntry)
+	c.resolved = make(map[string]aliasResolveCacheEntry)
+}
+
+func (d *Alias) cacheTTL() time.Duration {
+	if !d.AliasCacheEnabled {
+		return 0
+	}
+	expiration := d.AliasCacheExpiration
+	if expiration <= 0 {
+		expiration = 30
+	}
+	return time.Minute * time.Duration(expiration)
+}
+
+func (d *Alias) cacheMaxEntries() int {
+	if !d.AliasCacheEnabled || d.AliasCacheMaxEntries <= 0 {
+		return 0
+	}
+	return d.AliasCacheMaxEntries
+}
+
+func (c *aliasCache) listKey(dirPaths []string, withDetails bool) string {
+	parts := make([]string, 0, len(dirPaths))
+	for _, dirPath := range dirPaths {
+		if dirPath == "" {
+			continue
+		}
+		parts = append(parts, utils.FixAndCleanPath(dirPath))
+	}
+	key := "backend:" + strings.Join(parts, "\x00")
+	if withDetails {
+		return key + "\x00details"
+	}
+	return key
+}
+
+func (c *aliasCache) getList(key string, ttl time.Duration) ([]model.Obj, bool) {
+	if ttl <= 0 {
+		return nil, false
+	}
+	c.mu.RLock()
+	entry, ok := c.lists[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expires) {
+		c.deleteList(key)
+		return nil, false
+	}
+	return cloneObjs(entry.objs), true
+}
+
+func (c *aliasCache) setList(key string, objs []model.Obj, ttl time.Duration, maxEntries int) {
+	if ttl <= 0 {
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pruneExpiredLocked(now)
+	c.lists[key] = aliasListCacheEntry{
+		objs:    cloneObjs(objs),
+		expires: now.Add(ttl),
+	}
+	c.enforceMaxEntriesLocked(maxEntries)
+}
+
+func (c *aliasCache) deleteList(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.lists, key)
+}
+
+func (c *aliasCache) getResolved(path string, ttl time.Duration) (aliasResolved, bool) {
+	if ttl <= 0 {
+		return aliasResolved{}, false
+	}
+	path = utils.FixAndCleanPath(path)
+	c.mu.RLock()
+	entry, ok := c.resolved[path]
+	c.mu.RUnlock()
+	if !ok {
+		return aliasResolved{}, false
+	}
+	if time.Now().After(entry.expires) {
+		c.deleteResolved(path)
+		return aliasResolved{}, false
+	}
+	return cloneResolved(entry.resolved), true
+}
+
+func (c *aliasCache) setResolved(path string, resolved aliasResolved, ttl time.Duration, maxEntries int) {
+	if ttl <= 0 || len(resolved.paths) == 0 {
+		return
+	}
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pruneExpiredLocked(now)
+	c.resolved[utils.FixAndCleanPath(path)] = aliasResolveCacheEntry{
+		resolved: cloneResolved(resolved),
+		expires:  now.Add(ttl),
+	}
+	c.enforceMaxEntriesLocked(maxEntries)
+}
+
+func (c *aliasCache) deleteResolved(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.resolved, utils.FixAndCleanPath(path))
+}
+
+func (c *aliasCache) deleteResolvedPrefix(prefix string) {
+	prefix = utils.FixAndCleanPath(prefix)
+	if prefix == "/" {
+		c.clear()
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key := range c.resolved {
+		if key == prefix || strings.HasPrefix(key, prefix+"/") {
+			delete(c.resolved, key)
+		}
+	}
+}
+
+func (c *aliasCache) pruneExpiredLocked(now time.Time) {
+	for key, entry := range c.lists {
+		if now.After(entry.expires) {
+			delete(c.lists, key)
+		}
+	}
+	for key, entry := range c.resolved {
+		if now.After(entry.expires) {
+			delete(c.resolved, key)
+		}
+	}
+}
+
+func (c *aliasCache) enforceMaxEntriesLocked(maxEntries int) {
+	if maxEntries <= 0 {
+		return
+	}
+	for len(c.lists)+len(c.resolved) > maxEntries {
+		if c.deleteOldestLocked() {
+			continue
+		}
+		return
+	}
+}
+
+func (c *aliasCache) deleteOldestLocked() bool {
+	var oldestKey string
+	var oldestList bool
+	var oldestExpires time.Time
+	found := false
+	for key, entry := range c.lists {
+		if !found || entry.expires.Before(oldestExpires) {
+			oldestKey = key
+			oldestList = true
+			oldestExpires = entry.expires
+			found = true
+		}
+	}
+	for key, entry := range c.resolved {
+		if !found || entry.expires.Before(oldestExpires) {
+			oldestKey = key
+			oldestList = false
+			oldestExpires = entry.expires
+			found = true
+		}
+	}
+	if !found {
+		return false
+	}
+	if oldestList {
+		delete(c.lists, oldestKey)
+	} else {
+		delete(c.resolved, oldestKey)
+	}
+	return true
+}
+
+func cloneObjs(objs []model.Obj) []model.Obj {
+	if len(objs) == 0 {
+		return nil
+	}
+	cloned := make([]model.Obj, len(objs))
+	copy(cloned, objs)
+	return cloned
+}
+
+func cloneStrings(items []string) []string {
+	if len(items) == 0 {
+		return nil
+	}
+	cloned := make([]string, len(items))
+	copy(cloned, items)
+	return cloned
+}
+
+func cloneResolved(resolved aliasResolved) aliasResolved {
+	resolved.paths = cloneStrings(resolved.paths)
+	return resolved
+}

--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	stdpath "path"
 	"strings"
+	"sync"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/errs"
@@ -28,6 +29,7 @@ type Alias struct {
 	rootOrder []string
 	pathMap   map[string][]string
 	root      model.Obj
+	cache     aliasCache
 }
 
 func (d *Alias) Config() driver.Config {
@@ -39,6 +41,7 @@ func (d *Alias) GetAddition() driver.Additional {
 }
 
 func (d *Alias) Init(ctx context.Context) error {
+	d.cache.init()
 	paths := strings.Split(d.Paths, "\n")
 	d.rootOrder = make([]string, 0, len(paths))
 	d.pathMap = make(map[string][]string)
@@ -100,6 +103,7 @@ func (d *Alias) Drop(ctx context.Context) error {
 	d.rootOrder = nil
 	d.pathMap = nil
 	d.root = nil
+	d.cache.clear()
 	return nil
 }
 
@@ -116,55 +120,30 @@ func (d *Alias) Get(ctx context.Context, path string) (model.Obj, error) {
 	if len(roots) == 0 {
 		return nil, errs.ObjectNotFound
 	}
+	ttl := d.cacheTTL()
+	if cached, ok := d.cache.getResolved(path, ttl); ok {
+		if cached.hasObj {
+			return d.buildBalancedObj(ctx, sub, cached.paths[0], &cached.obj, cached.paths[1:], cached.skipped), nil
+		}
+		obj, err := d.getFromResolvedPaths(ctx, sub, cached)
+		if err == nil {
+			return obj, nil
+		}
+		d.cache.deleteResolved(path)
+	}
 	for idx, root := range roots {
 		rawPath := stdpath.Join(root, sub)
 		obj, err := fs.Get(ctx, rawPath, &fs.GetArgs{NoLog: true})
 		if err != nil {
 			continue
 		}
-		mask := model.GetObjMask(obj) &^ model.Temp
-		if sub == "" {
-			// 根目录
-			mask |= model.Locked | model.Virtual
+		resolvedPaths := make([]string, 0, len(roots)-idx)
+		for _, root := range roots[idx:] {
+			resolvedPaths = append(resolvedPaths, stdpath.Join(root, sub))
 		}
-		ret := model.Object{
-			Path:     rawPath,
-			Name:     obj.GetName(),
-			Size:     obj.GetSize(),
-			Modified: obj.ModTime(),
-			IsFolder: obj.IsDir(),
-			HashInfo: obj.GetHash(),
-			Mask:     mask,
-		}
-		obj = &ret
-		if d.ProviderPassThrough && !obj.IsDir() {
-			if storage, err := fs.GetStorage(rawPath, &fs.GetStoragesArgs{}); err == nil {
-				obj = &model.ObjectProvider{
-					Object: ret,
-					Provider: model.Provider{
-						Provider: storage.Config().Name,
-					},
-				}
-			}
-		}
-
-		roots = roots[idx+1:]
-		var objs BalancedObjs
-		if idx > 0 {
-			objs = make(BalancedObjs, 0, len(roots)+2)
-		} else {
-			objs = make(BalancedObjs, 0, len(roots)+1)
-		}
-		objs = append(objs, obj)
-		if idx > 0 {
-			objs = append(objs, nil)
-		}
-		for _, d := range roots {
-			objs = append(objs, &tempObj{model.Object{
-				Path: stdpath.Join(d, sub),
-			}})
-		}
-		return objs, nil
+		resolved := newAliasResolved(resolvedPaths, idx > 0, obj)
+		d.cache.setResolved(path, resolved, ttl, d.cacheMaxEntries())
+		return d.buildBalancedObj(ctx, sub, rawPath, obj, resolved.paths[1:], resolved.skipped), nil
 	}
 	return nil, errs.ObjectNotFound
 }
@@ -174,25 +153,46 @@ func (d *Alias) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 	if !ok {
 		return d.listRoot(ctx, args.WithStorageDetails && d.DetailsPassThrough, args.Refresh), nil
 	}
-
-	// 因为alias是NoCache且Get方法不会返回NotSupport或NotImplement错误
-	// 所以这里对象不会传回到alias，也就不需要返回BalancedObjs了
-	objMap := make(map[string]model.Obj)
+	withDetails := args.WithStorageDetails && d.DetailsPassThrough
+	dirPaths := make([]string, 0, len(dirs))
 	for _, dir := range dirs {
 		if dir == nil {
 			continue
 		}
-		dirPath := dir.GetPath()
-		tmp, err := fs.List(ctx, dirPath, &fs.ListArgs{
-			NoLog:              true,
-			Refresh:            args.Refresh,
-			WithStorageDetails: args.WithStorageDetails && d.DetailsPassThrough,
-		})
-		if err != nil {
+		dirPaths = append(dirPaths, dir.GetPath())
+	}
+	ttl := d.cacheTTL()
+	cacheKey := d.cache.listKey(dirPaths, withDetails)
+	if !args.Refresh {
+		if objs, ok := d.cache.getList(cacheKey, ttl); ok {
+			return objs, nil
+		}
+	} else {
+		d.cache.deleteList(cacheKey)
+		if prefix := d.aliasInternalPath(args.ReqPath); prefix != "" {
+			d.cache.deleteResolvedPrefix(prefix)
+		}
+	}
+
+	// 因为alias是NoCache且Get方法不会返回NotSupport或NotImplement错误
+	// 所以这里对象不会传回到alias，也就不需要返回BalancedObjs了
+	objMap := make(map[string]model.Obj)
+	resolveMap := make(map[string]aliasResolved)
+	listResults, cacheable := d.listBackendDirs(ctx, dirPaths, args)
+	for dirIndex, tmp := range listResults {
+		if tmp == nil {
 			continue
 		}
+		dirPath := dirPaths[dirIndex]
 		for _, obj := range tmp {
 			name := obj.GetName()
+			if _, exists := resolveMap[name]; !exists {
+				paths := make([]string, 0, len(dirPaths)-dirIndex)
+				for _, path := range dirPaths[dirIndex:] {
+					paths = append(paths, stdpath.Join(path, name))
+				}
+				resolveMap[name] = newAliasResolved(paths, dirIndex > 0, obj)
+			}
 			if _, exists := objMap[name]; exists {
 				continue
 			}
@@ -203,6 +203,7 @@ func (d *Alias) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 				Size:     obj.GetSize(),
 				Modified: obj.ModTime(),
 				IsFolder: obj.IsDir(),
+				HashInfo: obj.GetHash(),
 				Mask:     mask,
 			}
 			var objRet model.Obj
@@ -238,7 +239,72 @@ func (d *Alias) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 			model.ExtractFolder(objs, sort.ExtractFolder)
 		}
 	}
+	if cacheable {
+		d.cache.setList(cacheKey, objs, ttl, d.cacheMaxEntries())
+		d.cacheResolvedChildren(args.ReqPath, resolveMap)
+	}
 	return objs, nil
+}
+
+func (d *Alias) listBackendDirs(ctx context.Context, dirPaths []string, args model.ListArgs) ([][]model.Obj, bool) {
+	results := make([][]model.Obj, len(dirPaths))
+	cacheable := true
+	concurrency := d.listConcurrency(len(dirPaths))
+	if concurrency <= 1 {
+		for i, dirPath := range dirPaths {
+			tmp, err := fs.List(ctx, dirPath, &fs.ListArgs{
+				NoLog:              true,
+				Refresh:            args.Refresh,
+				WithStorageDetails: args.WithStorageDetails && d.DetailsPassThrough,
+			})
+			if err == nil {
+				results[i] = tmp
+			} else if !errs.IsObjectNotFound(err) {
+				cacheable = false
+			}
+		}
+		return results, cacheable
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	sem := make(chan struct{}, concurrency)
+	for i, dirPath := range dirPaths {
+		wg.Add(1)
+		go func(i int, dirPath string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			tmp, err := fs.List(ctx, dirPath, &fs.ListArgs{
+				NoLog:              true,
+				Refresh:            args.Refresh,
+				WithStorageDetails: args.WithStorageDetails && d.DetailsPassThrough,
+			})
+			if err == nil {
+				results[i] = tmp
+			} else if !errs.IsObjectNotFound(err) {
+				mu.Lock()
+				cacheable = false
+				mu.Unlock()
+			}
+		}(i, dirPath)
+	}
+	wg.Wait()
+	return results, cacheable
+}
+
+func (d *Alias) listConcurrency(total int) int {
+	if total <= 1 {
+		return 1
+	}
+	concurrency := d.AliasListConcurrency
+	if concurrency <= 1 {
+		return 1
+	}
+	if concurrency > total {
+		return total
+	}
+	return concurrency
 }
 
 func (d *Alias) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
@@ -348,6 +414,7 @@ func (d *Alias) Other(ctx context.Context, args model.OtherArgs) (interface{}, e
 }
 
 func (d *Alias) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {
+	defer d.cache.clear()
 	objs, err := d.getWriteObjs(ctx, parentDir)
 	if err == nil {
 		for _, obj := range objs {
@@ -358,6 +425,7 @@ func (d *Alias) MakeDir(ctx context.Context, parentDir model.Obj, dirName string
 }
 
 func (d *Alias) Move(ctx context.Context, srcObj, dstDir model.Obj) error {
+	defer d.cache.clear()
 	srcs, dsts, err := d.getMoveObjs(ctx, srcObj, dstDir)
 	if err == nil {
 		for i, dst := range dsts {
@@ -375,6 +443,7 @@ func (d *Alias) Move(ctx context.Context, srcObj, dstDir model.Obj) error {
 }
 
 func (d *Alias) Rename(ctx context.Context, srcObj model.Obj, newName string) error {
+	defer d.cache.clear()
 	objs, err := d.getWriteObjs(ctx, srcObj)
 	if err == nil {
 		for _, obj := range objs {
@@ -385,6 +454,7 @@ func (d *Alias) Rename(ctx context.Context, srcObj model.Obj, newName string) er
 }
 
 func (d *Alias) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
+	defer d.cache.clear()
 	srcs, dsts, err := d.getCopyObjs(ctx, srcObj, dstDir)
 	if err == nil {
 		for i, src := range srcs {
@@ -397,6 +467,7 @@ func (d *Alias) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
 }
 
 func (d *Alias) Remove(ctx context.Context, obj model.Obj) error {
+	defer d.cache.clear()
 	objs, err := d.getWriteObjs(ctx, obj)
 	if err == nil {
 		for _, obj := range objs {
@@ -407,6 +478,7 @@ func (d *Alias) Remove(ctx context.Context, obj model.Obj) error {
 }
 
 func (d *Alias) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer, up driver.UpdateProgress) error {
+	defer d.cache.clear()
 	objs, err := d.getPutObjs(ctx, dstDir)
 	if err == nil {
 		if len(objs) == 1 {
@@ -445,6 +517,7 @@ func (d *Alias) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer,
 }
 
 func (d *Alias) PutURL(ctx context.Context, dstDir model.Obj, name, url string) error {
+	defer d.cache.clear()
 	objs, err := d.getPutObjs(ctx, dstDir)
 	if err == nil {
 		for _, obj := range objs {
@@ -507,6 +580,7 @@ func (d *Alias) Extract(ctx context.Context, obj model.Obj, args model.ArchiveIn
 }
 
 func (d *Alias) ArchiveDecompress(ctx context.Context, srcObj, dstDir model.Obj, args model.ArchiveDecompressArgs) error {
+	defer d.cache.clear()
 	srcs, dsts, err := d.getCopyObjs(ctx, srcObj, dstDir)
 	if err == nil {
 		for i, src := range srcs {

--- a/drivers/alias/meta.go
+++ b/drivers/alias/meta.go
@@ -15,6 +15,10 @@ type Addition struct {
 	DownloadPartSize     int    `json:"download_part_size" default:"0" type:"number" required:"false" help:"Need to enable proxy. Unit: KB"`
 	ProviderPassThrough  bool   `json:"provider_pass_through" type:"bool" default:"false"`
 	DetailsPassThrough   bool   `json:"details_pass_through" type:"bool" default:"false"`
+	AliasCacheEnabled    bool   `json:"alias_cache_enabled" type:"bool" default:"false" help:"Cache aggregated Alias directory listings and resolved backend paths"`
+	AliasCacheExpiration int    `json:"alias_cache_expiration" default:"30" required:"false" type:"number" help:"Alias cache expiration in minutes"`
+	AliasCacheMaxEntries int    `json:"alias_cache_max_entries" default:"0" required:"false" type:"number" help:"Maximum Alias cache entries. 0 means unlimited"`
+	AliasListConcurrency int    `json:"alias_list_concurrency" default:"1" required:"false" type:"number" help:"Maximum number of backend folders to list concurrently. 1 or less means serial listing"`
 }
 
 var config = driver.Config{

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -12,6 +12,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/internal/fs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"github.com/OpenListTeam/OpenList/v4/server/common"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -94,6 +95,113 @@ func (d *Alias) getRootsAndPath(path string) (roots []string, sub string) {
 		return d.pathMap[path], ""
 	}
 	return d.pathMap[before], after
+}
+
+func (d *Alias) aliasInternalPath(reqPath string) string {
+	if reqPath == "" {
+		return ""
+	}
+	reqPath = utils.FixAndCleanPath(reqPath)
+	mountPath := utils.GetActualMountPath(d.MountPath)
+	if reqPath == mountPath {
+		return "/"
+	}
+	if strings.HasPrefix(reqPath, mountPath+"/") {
+		return strings.TrimPrefix(reqPath, mountPath)
+	}
+	return reqPath
+}
+
+func (d *Alias) cacheResolvedChildren(reqPath string, children map[string]aliasResolved) {
+	ttl := d.cacheTTL()
+	if ttl <= 0 || reqPath == "" || len(children) == 0 {
+		return
+	}
+	parent := d.aliasInternalPath(reqPath)
+	if parent == "" {
+		return
+	}
+	maxEntries := d.cacheMaxEntries()
+	for name, resolved := range children {
+		d.cache.setResolved(stdpath.Join(parent, name), resolved, ttl, maxEntries)
+	}
+}
+
+func (d *Alias) getFromResolvedPaths(ctx context.Context, sub string, resolved aliasResolved) (model.Obj, error) {
+	for idx, rawPath := range resolved.paths {
+		obj, err := fs.Get(ctx, rawPath, &fs.GetArgs{NoLog: true})
+		if err != nil {
+			continue
+		}
+		return d.buildBalancedObj(ctx, sub, rawPath, obj, resolved.paths[idx+1:], resolved.skipped || idx > 0), nil
+	}
+	return nil, errs.ObjectNotFound
+}
+
+func newAliasResolved(paths []string, skipped bool, obj model.Obj) aliasResolved {
+	resolved := aliasResolved{
+		paths:   paths,
+		skipped: skipped,
+	}
+	if obj != nil {
+		resolved.obj = model.Object{
+			ID:       obj.GetID(),
+			Path:     obj.GetPath(),
+			Name:     obj.GetName(),
+			Size:     obj.GetSize(),
+			Modified: obj.ModTime(),
+			Ctime:    obj.CreateTime(),
+			IsFolder: obj.IsDir(),
+			HashInfo: obj.GetHash(),
+			Mask:     model.GetObjMask(obj),
+		}
+		resolved.hasObj = true
+	}
+	return resolved
+}
+
+func (d *Alias) buildBalancedObj(ctx context.Context, sub, rawPath string, obj model.Obj, remainingPaths []string, skipped bool) BalancedObjs {
+	mask := model.GetObjMask(obj) &^ model.Temp
+	if sub == "" {
+		// root directory
+		mask |= model.Locked | model.Virtual
+	}
+	ret := model.Object{
+		Path:     rawPath,
+		Name:     obj.GetName(),
+		Size:     obj.GetSize(),
+		Modified: obj.ModTime(),
+		IsFolder: obj.IsDir(),
+		HashInfo: obj.GetHash(),
+		Mask:     mask,
+	}
+	var first model.Obj = &ret
+	if d.ProviderPassThrough && !obj.IsDir() {
+		if storage, err := fs.GetStorage(rawPath, &fs.GetStoragesArgs{}); err == nil {
+			first = &model.ObjectProvider{
+				Object: ret,
+				Provider: model.Provider{
+					Provider: storage.Config().Name,
+				},
+			}
+		}
+	}
+
+	capacity := len(remainingPaths) + 1
+	if skipped {
+		capacity++
+	}
+	objs := make(BalancedObjs, 0, capacity)
+	objs = append(objs, first)
+	if skipped {
+		objs = append(objs, nil)
+	}
+	for _, path := range remainingPaths {
+		objs = append(objs, &tempObj{model.Object{
+			Path: path,
+		}})
+	}
+	return objs
 }
 
 func (d *Alias) link(ctx context.Context, reqPath string, args model.LinkArgs) (*model.Link, model.Obj, error) {


### PR DESCRIPTION
## Summary / 摘要

Adds opt-in caching for the Alias driver to reduce repeated backend polling when listing aggregated directories and resolving virtual Alias paths to their backend paths.

- Adds `alias_cache_enabled`, `alias_cache_expiration`, `alias_cache_max_entries`, and `alias_list_concurrency` Alias options.
- Caches aggregated Alias directory listings and resolved backend paths when enabled.
- Uses backend directory paths as the list cache key so internal `op.List(..., model.ListArgs{})` calls without `ReqPath` do not collide.
- Avoids caching partial list results when any backend returns a non-`ObjectNotFound` error.
- Clears the Alias cache on write-like operations and invalidates refreshed list/resolved entries when `refresh` is requested.
- Keeps the feature disabled by default. `alias_cache_max_entries=0` means unlimited entries.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: N/A. The existing driver metadata form renders these options dynamically.
- OpenList-Docs: N/A.

## Related Issues / 关联 Issue

N/A

## Testing / 测试

- [ ] `go test ./...`
  - Not run locally because this environment was restricted to source-mode runtime validation and did not allow generating compiled test artifacts.
- [x] Manual test / 手动测试:
  - Source-mode run: `go run . --config /tmp/openlist-config-with-s3.json server --log-std`
  - Formatting: `gofmt -w drivers/alias/driver.go drivers/alias/cache.go drivers/alias/meta.go drivers/alias/util.go`
  - Diff check: `git diff --check -- drivers/alias/driver.go drivers/alias/cache.go drivers/alias/meta.go drivers/alias/util.go`

### Source-mode runtime validation

Local restored dataset, Alias mount `/videos`, Alias list concurrency `8`, cache expiration `30` minutes unless noted.

Directory list cache behavior:

| Request | Mode | Result | Time |
| --- | --- | ---: | ---: |
| `/videos/电视剧` | `refresh=true` | 200, 9 items | 10.485506s |
| `/videos/电视剧` | warm request 1 | 200, 9 items | 0.001217s |
| `/videos/电视剧` | warm request 2 | 200, 9 items | 0.001104s |
| `/videos/电视剧` | warm request 3 | 200, 9 items | 0.000969s |
| `/videos/电视剧/欧美剧` | `refresh=true` | 200, 218 items | 4.052087s |
| `/videos/电视剧/欧美剧` | warm request 1 | 200, 218 items | 0.002297s |
| `/videos/电视剧/欧美剧` | warm request 2 | 200, 218 items | 0.002446s |
| `/videos/电视剧/欧美剧/3体 (2024)` | `refresh=true` | 200, 12 items | 0.581298s |
| `/videos/电视剧/欧美剧/3体 (2024)` | warm request 1 | 200, 12 items | 0.001222s |
| `/videos/电视剧/欧美剧/3体 (2024)` | warm request 2 | 200, 12 items | 0.001270s |

Resolved child cache behavior after listing parent directory:

| Request | Result | Time |
| --- | ---: | ---: |
| `/api/fs/get /videos/电视剧/欧美剧/3体 (2024)` | 200, directory | 0.002172s |
| repeat `/api/fs/get /videos/电视剧/欧美剧/3体 (2024)` | 200, directory | 0.001977s |

Direct-link HEAD behavior for a deep media file:

| Scenario | Result | Time |
| --- | ---: | ---: |
| restart, empty Alias cache, first `HEAD /d/...S01E01.mkv` | 302 | 3.987208s |
| same file repeat `HEAD` | 302 | 0.000920s |
| same file repeat `HEAD` again | 302 | 0.000562s |
| Alias cache temporarily disabled, first `HEAD /d/...S01E02.mkv` | 302 | 3.694040s |
| Alias cache disabled, first `HEAD /d/...S01E03.mkv` | 302 | 0.237525s |
| Alias cache disabled, first `HEAD /d/...S01E04.mkv` | 302 | 0.242099s |
| Alias cache restored, parent list prewarmed, first `HEAD /d/...S01E05.mkv` | 302 | 0.246256s |
| same E05 repeat `HEAD` | 302 | 0.000660s |

Interpretation: the Alias cache removes the slow virtual-path-to-backend-path probing. The first real direct-link fetch can still have backend/provider link latency, while repeated HEAD requests can also benefit from the existing link/provider cache layer.

### Longer memory / latency comparison

Dataset: recursive list paths discovered under `/videos`: 4074 directories.

Cache-on measurement used a temporary 180-minute TTL during prewarm so entries would not expire before the 30-minute measurement. Local config was restored to 30 minutes after the test.

Full prewarm with cache enabled:

```text
samples=4074
avg_rss=618.2MB
max_rss=1650.0MB
max_time=113.950s
slow_path=/videos/电影/外语电影/第一滴血3 (1988)
prewarm_errors=0
```

30-minute cache-on measurement after full prewarm and 5-minute stabilization:

```text
finished_at=2026-06-13 02:36:59 +0800
stabilize_samples=60
stabilize_avg_mb=1362.0
stabilize_min_mb=1030.3
stabilize_max_mb=1573.7
measure_rss_samples=360
measure_avg_mb=1258.4
measure_min_mb=197.1
measure_max_mb=1725.9
requests=3224
request_avg_time_s=0.0009
request_min_time_s=0.0004
request_max_time_s=0.0172
request_errors=0
```

30-minute cache-off measurement after restart and 5-minute stabilization:

```text
finished_at=2026-06-13 03:18:02 +0800
stabilize_samples=60
stabilize_avg_mb=77.1
stabilize_min_mb=64.9
stabilize_max_mb=80.5
measure_rss_samples=295
measure_avg_mb=106.2
measure_min_mb=66.3
measure_max_mb=124.9
requests=1360
request_avg_time_s=1.2767
request_min_time_s=0.0020
request_max_time_s=34.8874
request_errors=0
```

Quick comparison:

| Mode | Stabilize RSS avg | Measure RSS avg | Measure RSS max | Requests / 30 min | Avg list latency | Max list latency | Errors |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Alias cache on | 1362.0 MB | 1258.4 MB | 1725.9 MB | 3224 | 0.0009s | 0.0172s | 0 |
| Alias cache off | 77.1 MB | 106.2 MB | 124.9 MB | 1360 | 1.2767s | 34.8874s | 0 |

Notes:

- RSS was sampled from the OpenList child process created by `go run`, not the parent `go run` process.
- macOS RSS fluctuated due to runtime/OS memory return behavior.
- Local Strm `SaveStrmToLocal` emitted `mkdir /Strm: read-only file system` warnings during list traversal; both cache-on and cache-off tests used the same restored local data/environment.
- The memory cost is why the feature is opt-in and has an optional `alias_cache_max_entries` limit.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [x] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。