### PR TITLE
fix(drivers/webdav): normalize missing path error

### DIFF
--- a/drivers/webdav/driver.go
+++ b/drivers/webdav/driver.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/pkg/cron"
 	"github.com/OpenListTeam/OpenList/v4/pkg/gowebdav"
@@ -130,6 +131,9 @@ func (d *WebDav) Get(ctx context.Context, _path string) (model.Obj, error) {
 	_path = path.Join(d.GetRootPath(), _path)
 	info, err := d.client.Stat(_path)
 	if err != nil {
+		if gowebdav.IsErrNotFound(err) {
+			return nil, errs.ObjectNotFound
+		}
 		return nil, err
 	}
 

--- a/drivers/webdav/driver_test.go
+++ b/drivers/webdav/driver_test.go
@@ -1,0 +1,89 @@
+package webdav
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
+	"github.com/OpenListTeam/OpenList/v4/internal/op"
+)
+
+func TestGetMapsMissingPathToObjectNotFound(t *testing.T) {
+	d, cleanup := newTestDriver(t, nil)
+	defer cleanup()
+
+	_, err := d.Get(context.Background(), "/missing")
+	if !errs.IsObjectNotFound(err) {
+		t.Fatalf("expected object not found, got %v", err)
+	}
+}
+
+func TestMakeDirAfterMissingWebDAVStat(t *testing.T) {
+	var mkcolCount int32
+	d, cleanup := newTestDriver(t, func(w http.ResponseWriter, r *http.Request) bool {
+		if r.Method == "MKCOL" && (r.URL.Path == "/new" || r.URL.Path == "/new/") {
+			atomic.AddInt32(&mkcolCount, 1)
+			w.WriteHeader(http.StatusCreated)
+			return true
+		}
+		return false
+	})
+	defer cleanup()
+
+	if err := op.MakeDir(context.Background(), d, "/new"); err != nil {
+		t.Fatalf("MakeDir failed: %v", err)
+	}
+	if got := atomic.LoadInt32(&mkcolCount); got != 1 {
+		t.Fatalf("expected one MKCOL request, got %d", got)
+	}
+}
+
+func newTestDriver(t *testing.T, extra func(http.ResponseWriter, *http.Request) bool) (*WebDav, func()) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if extra != nil && extra(w, r) {
+			return
+		}
+		switch r.Method {
+		case "PROPFIND":
+			if r.URL.Path == "/" {
+				w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+				w.WriteHeader(http.StatusMultiStatus)
+				_, _ = w.Write([]byte(`<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:displayname>/</d:displayname>
+        <d:resourcetype><d:collection/></d:resourcetype>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`))
+				return
+			}
+			http.NotFound(w, r)
+		case "MKCOL":
+			w.WriteHeader(http.StatusConflict)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+
+	d := &WebDav{Addition: Addition{Address: srv.URL, RootPath: driver.RootPath{RootFolderPath: "/"}}}
+	if err := d.Init(context.Background()); err != nil {
+		srv.Close()
+		t.Fatalf("init driver: %v", err)
+	}
+	return d, func() {
+		_ = d.Drop(context.Background())
+		srv.Close()
+	}
+}


### PR DESCRIPTION
## Summary / 摘要

Normalize WebDAV 404 responses from `Stat` to `errs.ObjectNotFound`.

This fixes the mkdir pre-check path: when the target folder does not exist, `op.MakeDir` can now treat the lookup as a normal missing object and continue to issue `MKCOL` through the WebDAV driver.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Related Issues / 关联 Issue

Fixes #2564

## Testing / 测试

- [ ] `go test ./...`
- [x] `go test ./pkg/gowebdav ./drivers/webdav`
- [ ] Manual test / 手动测试:

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [x] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [ ] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
