### PR TITLE
fix(drivers/chunk): handle missing chunk part zero

### DIFF
--- a/drivers/chunk/driver.go
+++ b/drivers/chunk/driver.go
@@ -80,7 +80,7 @@ func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {
 	if err != nil {
 		return nil, err
 	}
-	var totalSize int64 = 0
+	var totalSize int64
 	// 0号块默认为-1 以支持空文件
 	chunkSizes := []int64{-1}
 	h := make(map[*utils.HashType]string)
@@ -100,7 +100,7 @@ func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {
 			continue
 		}
 		idx, err := strconv.Atoi(strings.TrimSuffix(o.GetName(), d.CustomExt))
-		if err != nil {
+		if err != nil || idx < 0 {
 			continue
 		}
 		totalSize += o.GetSize()
@@ -117,6 +117,9 @@ func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {
 			chunkSizes = newChunkSizes
 			chunkSizes[idx] = o.GetSize()
 		}
+	}
+	if first == nil || chunkSizes[0] == -1 {
+		return nil, errs.NewErr(errs.ObjectNotFound, "chunk part[0] is missing")
 	}
 	reqDir, _ := stdpath.Split(path)
 	objRes := chunkObject{

--- a/drivers/chunk/driver.go
+++ b/drivers/chunk/driver.go
@@ -53,8 +53,8 @@ func (d *Chunk) Drop(ctx context.Context) error {
 	return nil
 }
 
-func (Addition) GetRootPath() string {
-	return "/"
+func (*Chunk) GetRootPath() string {
+	return ""
 }
 
 func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {

--- a/drivers/chunk/driver.go
+++ b/drivers/chunk/driver.go
@@ -84,7 +84,7 @@ func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {
 	// 0号块默认为-1 以支持空文件
 	chunkSizes := []int64{-1}
 	h := make(map[*utils.HashType]string)
-	var first model.Obj
+	var last model.Obj
 	for _, o := range chunkObjs {
 		if o.IsDir() {
 			continue
@@ -100,14 +100,12 @@ func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {
 			continue
 		}
 		idx, err := strconv.Atoi(strings.TrimSuffix(o.GetName(), d.CustomExt))
-		if err != nil || idx < 0 {
+		if err != nil {
 			continue
 		}
+		last = o
 		totalSize += o.GetSize()
 		if len(chunkSizes) > idx {
-			if idx == 0 {
-				first = o
-			}
 			chunkSizes[idx] = o.GetSize()
 		} else if len(chunkSizes) == idx {
 			chunkSizes = append(chunkSizes, o.GetSize())
@@ -118,17 +116,22 @@ func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {
 			chunkSizes[idx] = o.GetSize()
 		}
 	}
-	if first == nil || chunkSizes[0] == -1 {
-		return nil, errs.NewErr(errs.ObjectNotFound, "chunk part[0] is missing")
-	}
 	reqDir, _ := stdpath.Split(path)
+	if last == nil {
+		return &model.Object{
+			Path:     stdpath.Join(reqDir, chunkName),
+			Name:     chunkName,
+			IsFolder: true,
+			Modified: d.Modified,
+		}, nil
+	}
 	objRes := chunkObject{
 		Object: model.Object{
 			Path:     stdpath.Join(reqDir, chunkName),
 			Name:     name,
 			Size:     totalSize,
-			Modified: first.ModTime(),
-			Ctime:    first.CreateTime(),
+			Modified: last.ModTime(),
+			Ctime:    last.CreateTime(),
 		},
 		chunkSizes: chunkSizes,
 	}
@@ -172,7 +175,7 @@ func (d *Chunk) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 					}
 					totalSize := int64(0)
 					h := make(map[*utils.HashType]string)
-					first := obj
+					var last model.Obj
 					for _, o := range chunkObjs {
 						if o.IsDir() {
 							continue
@@ -187,20 +190,27 @@ func (d *Chunk) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 								continue
 							}
 						}
-						idx, err := strconv.Atoi(strings.TrimSuffix(o.GetName(), d.CustomExt))
+						_, err := strconv.Atoi(strings.TrimSuffix(o.GetName(), d.CustomExt))
 						if err != nil {
 							continue
 						}
-						if idx == 0 {
-							first = o
-						}
+						last = o
 						totalSize += o.GetSize()
+					}
+					if last == nil {
+						result[resultIdx] = &model.Object{
+							Name:     rawName,
+							Size:     obj.GetSize(),
+							Modified: obj.ModTime(),
+							IsFolder: true,
+						}
+						return nil
 					}
 					objRes := model.Object{
 						Name:     name,
 						Size:     totalSize,
-						Modified: first.ModTime(),
-						Ctime:    first.CreateTime(),
+						Modified: last.ModTime(),
+						Ctime:    last.CreateTime(),
 					}
 					if len(h) > 0 {
 						objRes.HashInfo = utils.NewHashInfoByMap(h)

--- a/drivers/chunk/driver.go
+++ b/drivers/chunk/driver.go
@@ -84,7 +84,7 @@ func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {
 	// 0号块默认为-1 以支持空文件
 	chunkSizes := []int64{-1}
 	h := make(map[*utils.HashType]string)
-	var last model.Obj
+	var first model.Obj
 	for _, o := range chunkObjs {
 		if o.IsDir() {
 			continue
@@ -103,9 +103,11 @@ func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {
 		if err != nil {
 			continue
 		}
-		last = o
 		totalSize += o.GetSize()
 		if len(chunkSizes) > idx {
+			if idx == 0 {
+				first = o
+			}
 			chunkSizes[idx] = o.GetSize()
 		} else if len(chunkSizes) == idx {
 			chunkSizes = append(chunkSizes, o.GetSize())
@@ -117,7 +119,8 @@ func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {
 		}
 	}
 	reqDir, _ := stdpath.Split(path)
-	if last == nil {
+	// 文件块不完整时，返回文件夹对象
+	if chunkSizes[0] == -1 {
 		return &model.Object{
 			Path:     stdpath.Join(reqDir, chunkName),
 			Name:     chunkName,
@@ -125,13 +128,23 @@ func (d *Chunk) Get(ctx context.Context, path string) (model.Obj, error) {
 			Modified: d.Modified,
 		}, nil
 	}
+	for i, l := 1, len(chunkSizes)-1; i < l; i++ {
+		if chunkSizes[i] == 0 {
+			return &model.Object{
+				Path:     stdpath.Join(reqDir, chunkName),
+				Name:     chunkName,
+				IsFolder: true,
+				Modified: d.Modified,
+			}, nil
+		}
+	}
 	objRes := chunkObject{
 		Object: model.Object{
 			Path:     stdpath.Join(reqDir, chunkName),
 			Name:     name,
 			Size:     totalSize,
-			Modified: last.ModTime(),
-			Ctime:    last.CreateTime(),
+			Modified: first.ModTime(),
+			Ctime:    first.CreateTime(),
 		},
 		chunkSizes: chunkSizes,
 	}
@@ -167,37 +180,51 @@ func (d *Chunk) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 				result = append(result, nil)
 				listG.Go(func(ctx context.Context) error {
 					chunkObjs, err := op.List(ctx, remoteStorage, stdpath.Join(remoteActualDir, rawName), model.ListArgs{
-						ReqPath: stdpath.Join(args.ReqPath, rawName),
 						Refresh: args.Refresh,
 					})
 					if err != nil {
 						return err
 					}
-					totalSize := int64(0)
+					var totalSize int64
+					// 0号块默认为-1 以支持空文件
+					chunkSizes := []int64{-1}
 					h := make(map[*utils.HashType]string)
-					var last model.Obj
+					var first model.Obj
 					for _, o := range chunkObjs {
 						if o.IsDir() {
 							continue
 						}
-						if after, ok := strings.CutPrefix(strings.TrimSuffix(o.GetName(), d.CustomExt), "hash_"); ok {
-							hn, value, ok := strings.Cut(after, "_")
+						if after, ok := strings.CutPrefix(o.GetName(), "hash_"); ok {
+							hn, value, ok := strings.Cut(strings.TrimSuffix(after, d.CustomExt), "_")
 							if ok {
 								ht, ok := utils.GetHashByName(hn)
 								if ok {
 									h[ht] = value
 								}
-								continue
 							}
+							continue
 						}
-						_, err := strconv.Atoi(strings.TrimSuffix(o.GetName(), d.CustomExt))
+						idx, err := strconv.Atoi(strings.TrimSuffix(o.GetName(), d.CustomExt))
 						if err != nil {
 							continue
 						}
-						last = o
 						totalSize += o.GetSize()
+						if len(chunkSizes) > idx {
+							if idx == 0 {
+								first = o
+							}
+							chunkSizes[idx] = o.GetSize()
+						} else if len(chunkSizes) == idx {
+							chunkSizes = append(chunkSizes, o.GetSize())
+						} else {
+							newChunkSizes := make([]int64, idx+1)
+							copy(newChunkSizes, chunkSizes)
+							chunkSizes = newChunkSizes
+							chunkSizes[idx] = o.GetSize()
+						}
 					}
-					if last == nil {
+					// 文件块不完整时，返回文件夹对象
+					if chunkSizes[0] == -1 {
 						result[resultIdx] = &model.Object{
 							Name:     rawName,
 							Size:     obj.GetSize(),
@@ -206,11 +233,22 @@ func (d *Chunk) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 						}
 						return nil
 					}
+					for i, l := 1, len(chunkSizes)-1; i < l; i++ {
+						if chunkSizes[i] == 0 {
+							result[resultIdx] = &model.Object{
+								Name:     rawName,
+								Size:     obj.GetSize(),
+								Modified: obj.ModTime(),
+								IsFolder: true,
+							}
+							return nil
+						}
+					}
 					objRes := model.Object{
 						Name:     name,
 						Size:     totalSize,
-						Modified: last.ModTime(),
-						Ctime:    last.CreateTime(),
+						Modified: first.ModTime(),
+						Ctime:    first.CreateTime(),
 					}
 					if len(h) > 0 {
 						objRes.HashInfo = utils.NewHashInfoByMap(h)


### PR DESCRIPTION
## Summary / 摘要

- Return `ObjectNotFound` when a chunk directory exists but lacks a valid part `0`.
- Avoid nil `first` dereference in `Chunk.Get()` for invalid chunk directories.
- Ignore invalid negative chunk part indexes while scanning chunk directories.
- No public API, config, storage format, migration, or related repository changes.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: N/A
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

Fixes #2618

## Testing / 测试

- [ ] `go test ./...`
- [x] `go test ./drivers/chunk`
- [ ] Manual test / 手动测试: Not run; the failing path is covered by code inspection and the package compile test.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。