### PR TITLE
fix(drivers/ftp): add cwd_list option and filter path-separated entries

### DIFF
--- a/drivers/ftp/driver.go
+++ b/drivers/ftp/driver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	stdpath "path"
+	"strings"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/errs"
@@ -51,13 +52,35 @@ func (d *FTP) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([]m
 	if err := d.login(); err != nil {
 		return nil, err
 	}
-	entries, err := d.conn.List(encode(dir.GetPath(), d.Encoding))
+
+	path := encode(dir.GetPath(), d.Encoding)
+
+	var entries []*ftp.Entry
+	var err error
+
+	if d.CwdList {
+		origDir, cwdErr := d.conn.CurrentDir()
+		if cwdErr != nil {
+			return nil, cwdErr
+		}
+		if cwdErr = d.conn.ChangeDir(path); cwdErr != nil {
+			return nil, cwdErr
+		}
+		entries, err = d.conn.List("")
+		if restoreErr := d.conn.ChangeDir(origDir); restoreErr != nil {
+			d.conn = nil
+		}
+	} else {
+		entries, err = d.conn.List(path)
+	}
+
 	if err != nil {
 		return nil, err
 	}
+
 	res := make([]model.Obj, 0)
 	for _, entry := range entries {
-		if entry.Name == "." || entry.Name == ".." {
+		if entry.Name == "." || entry.Name == ".." || strings.Contains(entry.Name, "/") {
 			continue
 		}
 		name := decode(entry.Name, d.Encoding)

--- a/drivers/ftp/meta.go
+++ b/drivers/ftp/meta.go
@@ -27,6 +27,7 @@ type Addition struct {
 	Encoding string `json:"encoding" required:"true"`
 	Username string `json:"username" required:"true"`
 	Password string `json:"password" required:"true"`
+	CwdList  bool   `json:"cwd_list" type:"bool" default:"false" help:"enter directory before listing"`
 	driver.RootPath
 }
 


### PR DESCRIPTION
<!--
PR title / PR 标题:
Use Conventional Commits: `type(scope): summary`
-->
<!-- 建议使用已生成的标题： -->
<!-- fix(ftp): add cwd_list option and filter path-separated entries -->

## Summary / 摘要

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->

修复 GBK 编码 FTP 服务器（常见于学校/老旧中文环境）的两个兼容性问题：

1. **新增 `cwd_list` 选项**：启用后改用 `CWD` 进入目标目录再 `LIST ""` 列出内容，代替原有的 `LIST <path>` 方式。解决非 UTF-8 编码路径在 LIST 命令中无法正确解析，导致列表只显示一个与当前目录同名假文件夹的问题。

2. **过滤含 `/` 的文件名**：部分 FTP 服务器返回的列表包含 `type=cdir`（当前目录标记）等特殊条目，其 Name 字段为完整路径格式（含 `/`）。由于 FTP 协议中合法文件名不可能包含路径分隔符，借此安全过滤此类条目。

<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

### 用户可感知的变化
- FTP 存储添加页面新增 `cwd_list` 开关（默认关闭）
- 部分 FTP 服务器不再显示 `|路径|路径` 格式的假文件夹条目

### 实现变化
- `drivers/ftp/meta.go`：Addition 结构体新增 `CwdList bool` 字段
- `drivers/ftp/driver.go`：List 方法根据 `CwdList` 选项切换列目录策略；新增 `strings.Contains(entry.Name, "/")` 过滤

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs: https://github.com/OpenListTeam/OpenList-Docs/pull/339

## Related Issues / 关联 Issue

<!--
Use `Closes #123`, `Fixes #123`, or `Relates to #123`.
Remove this section if not applicable.
使用 `Closes #123`、`Fixes #123` 或 `Relates to #123`。
不适用时请删除本节。
-->

（如有相关 Issue 请填写，否则删除本节）

## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [ ] `go test ./...`
- [x] Manual test / 手动测试:

手动测试环境：
- FTP 服务器：学校 GBK 编码 FTP 服务器
- 测试场景 1（`cwd_list` 关闭，默认行为）：行为与修复前一致，UTF-8 服务器正常工作
- 测试场景 2（`cwd_list` 开启，GBK 服务器）：原本只显示一个假文件夹的目录现在正确列出所有文件和子目录，可正常进入子目录
- 测试场景 3（`cdir` 条目过滤）：原本显示 `|路径|路径` 的假文件夹不再出现

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）：

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
