### PR TITLE
fix(drivers/thunder): handle missing token errors

### DIFF
--- a/drivers/thunder/driver.go
+++ b/drivers/thunder/driver.go
@@ -88,6 +88,9 @@ func (x *Thunder) Init(ctx context.Context) (err error) {
 					// 清空 信任密钥
 					x.Addition.CreditKey = ""
 				}
+				if token == nil {
+					return err
+				}
 				x.SetTokenResp(token)
 				return err
 			},
@@ -521,6 +524,9 @@ func (xc *XunLeiCommon) SetCoreTokenResp(tr *CoreLoginResp) {
 
 // 携带Authorization和CaptchaToken的请求
 func (xc *XunLeiCommon) Request(url string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
+	if xc.TokenResp == nil {
+		return nil, errs.EmptyToken
+	}
 	data, err := xc.Common.Request(url, method, func(req *resty.Request) {
 		req.SetHeaders(map[string]string{
 			"Authorization":   xc.Token(),

--- a/drivers/thunder/driver_test.go
+++ b/drivers/thunder/driver_test.go
@@ -1,0 +1,18 @@
+package thunder
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
+)
+
+func TestRequestReturnsErrorWhenTokenIsMissing(t *testing.T) {
+	xc := &XunLeiCommon{}
+
+	_, err := xc.Request(API_URL+"/about", http.MethodGet, nil, nil)
+	if !errors.Is(err, errs.EmptyToken) {
+		t.Fatalf("expected EmptyToken, got %v", err)
+	}
+}

--- a/drivers/thunder_browser/driver.go
+++ b/drivers/thunder_browser/driver.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
 	streamPkg "github.com/OpenListTeam/OpenList/v4/internal/stream"
@@ -86,6 +87,9 @@ func (x *ThunderBrowser) Init(ctx context.Context) (err error) {
 					}
 					// 清空 信任密钥
 					x.Addition.CreditKey = ""
+				}
+				if token == nil {
+					return err
 				}
 				x.SetTokenResp(token)
 				return err
@@ -639,6 +643,9 @@ func (xc *XunLeiBrowserCommon) SetSpaceTokenResp(spaceToken string) {
 
 // Request 携带Authorization和CaptchaToken的请求
 func (xc *XunLeiBrowserCommon) Request(url string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
+	if xc.TokenResp == nil {
+		return nil, errs.EmptyToken
+	}
 	data, err := xc.Common.Request(url, method, func(req *resty.Request) {
 		req.SetHeaders(map[string]string{
 			"Authorization":         xc.GetToken(),

--- a/drivers/thunder_browser/driver_test.go
+++ b/drivers/thunder_browser/driver_test.go
@@ -1,0 +1,18 @@
+package thunder_browser
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
+)
+
+func TestRequestReturnsErrorWhenTokenIsMissing(t *testing.T) {
+	xc := &XunLeiBrowserCommon{}
+
+	_, err := xc.Request(API_URL+"/about", http.MethodGet, nil, nil)
+	if !errors.Is(err, errs.EmptyToken) {
+		t.Fatalf("expected EmptyToken, got %v", err)
+	}
+}

--- a/drivers/thunderx/driver.go
+++ b/drivers/thunderx/driver.go
@@ -69,12 +69,15 @@ func (x *ThunderX) Init(ctx context.Context) (err error) {
 					token, err = x.Login(x.Username, x.Password)
 					if err != nil {
 						x.GetStorage().SetStatus(fmt.Sprintf("%+v", err.Error()))
-						if token.UserID != "" {
+						if token != nil && token.UserID != "" {
 							x.SetUserID(token.UserID)
 							x.UserAgent = BuildCustomUserAgent(utils.GetMD5EncodeStr(x.Username+x.Password), ClientID, PackageName, SdkVersion, ClientVersion, PackageName, token.UserID)
 						}
 						op.MustSaveDriverStorage(x)
 					}
+				}
+				if token == nil {
+					return err
 				}
 				x.SetTokenResp(token)
 				return err
@@ -496,6 +499,9 @@ func (xc *XunLeiXCommon) SetTokenResp(tr *TokenResp) {
 
 // Request 携带Authorization和CaptchaToken的请求
 func (xc *XunLeiXCommon) Request(url string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
+	if xc.TokenResp == nil {
+		return nil, errs.EmptyToken
+	}
 	data, err := xc.Common.Request(url, method, func(req *resty.Request) {
 		req.SetHeaders(map[string]string{
 			"Authorization":   xc.Token(),

--- a/drivers/thunderx/driver_test.go
+++ b/drivers/thunderx/driver_test.go
@@ -1,0 +1,18 @@
+package thunderx
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
+)
+
+func TestRequestReturnsErrorWhenTokenIsMissing(t *testing.T) {
+	xc := &XunLeiXCommon{}
+
+	_, err := xc.Request(API_URL+"/about", http.MethodGet, nil, nil)
+	if !errors.Is(err, errs.EmptyToken) {
+		t.Fatalf("expected EmptyToken, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary / 摘要

- 修复 Thunder 相关驱动在 token 缺失或刷新失败后触发空指针 panic 的问题。
- 将空 token 请求转为 `errs.EmptyToken` 普通错误，让存储加载按现有失败状态处理并继续加载其他驱动。
- 避免刷新或重新登录失败后写入 `nil` token，并补充 Thunder、ThunderX、Thunder Browser 的回归测试。

⚠️ 本组织、仓库、相关维护者，不对破解驱动作出任何修复、维护，本次修复，旨在允许驱动失败时，进程免于崩溃。并未修复驱动本身的问题。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Related Issues / 关联 Issue

Fixes #2467
Fixes #2571
Fixes #2567 

## Testing / 测试

- [x] `go test ./...`
- [ ] Manual test / 手动测试:

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的 AI 辅助内容。