### PR TITLE
fix(local): remove thumbnail cache on delete

### DIFF
--- a/drivers/local/driver.go
+++ b/drivers/local/driver.go
@@ -389,6 +389,9 @@ func (d *Local) Remove(ctx context.Context, obj model.Obj) error {
 	if err != nil {
 		return err
 	}
+	if !obj.IsDir() {
+		d.removeThumbCache(obj.GetPath())
+	}
 	if obj.IsDir() {
 		if d.directoryMap.Has(obj.GetPath()) {
 			d.directoryMap.DeleteDirNode(obj.GetPath())

--- a/drivers/local/remove_test.go
+++ b/drivers/local/remove_test.go
@@ -1,0 +1,44 @@
+package local
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+)
+
+func TestRemoveDeletesThumbCache(t *testing.T) {
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, "thumbs")
+	if err := os.Mkdir(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	filePath := filepath.Join(root, "photo.jpg")
+	if err := os.WriteFile(filePath, []byte("image"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	driver := &Local{
+		Addition: Addition{
+			ThumbCacheFolder: cacheDir,
+		},
+	}
+	thumbPath := driver.thumbCachePath(filePath)
+	if err := os.WriteFile(thumbPath, []byte("thumb"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	err := driver.Remove(context.Background(), &model.Object{
+		Path: filePath,
+		Name: filepath.Base(filePath),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = os.Stat(thumbPath); !os.IsNotExist(err) {
+		t.Fatalf("expected thumb cache to be removed, got %v", err)
+	}
+}

--- a/drivers/local/util.go
+++ b/drivers/local/util.go
@@ -24,6 +24,8 @@ import (
 	ffmpeg "github.com/u2takey/ffmpeg-go"
 )
 
+const thumbPrefix = "openlist_thumb_"
+
 func isSymlinkDir(f fs.FileInfo, path string) bool {
 	if f.Mode()&os.ModeSymlink == os.ModeSymlink ||
 		(runtime.GOOS == "windows" && f.Mode()&os.ModeIrregular == os.ModeIrregular) { // os.ModeIrregular is Junction bit in Windows
@@ -110,16 +112,29 @@ func readDir(dirname string) ([]fs.FileInfo, error) {
 	return list, nil
 }
 
+func (d *Local) thumbCachePath(fullPath string) string {
+	if d.ThumbCacheFolder == "" {
+		return ""
+	}
+	return filepath.Join(d.ThumbCacheFolder, thumbPrefix+utils.GetMD5EncodeStr(fullPath)+".png")
+}
+
+func (d *Local) removeThumbCache(fullPath string) {
+	thumbPath := d.thumbCachePath(fullPath)
+	if thumbPath == "" {
+		return
+	}
+	_ = os.Remove(thumbPath)
+}
+
 func (d *Local) getThumb(file model.Obj) (*bytes.Buffer, *string, error) {
 	fullPath := file.GetPath()
-	thumbPrefix := "openlist_thumb_"
-	thumbName := thumbPrefix + utils.GetMD5EncodeStr(fullPath) + ".png"
 	if d.ThumbCacheFolder != "" {
 		// skip if the file is a thumbnail
 		if strings.HasPrefix(file.GetName(), thumbPrefix) {
 			return nil, &fullPath, nil
 		}
-		thumbPath := filepath.Join(d.ThumbCacheFolder, thumbName)
+		thumbPath := d.thumbCachePath(fullPath)
 		if utils.Exists(thumbPath) {
 			return nil, &thumbPath, nil
 		}
@@ -151,7 +166,7 @@ func (d *Local) getThumb(file model.Obj) (*bytes.Buffer, *string, error) {
 		return nil, nil, err
 	}
 	if d.ThumbCacheFolder != "" {
-		err = os.WriteFile(filepath.Join(d.ThumbCacheFolder, thumbName), buf.Bytes(), 0o666)
+		err = os.WriteFile(d.thumbCachePath(fullPath), buf.Bytes(), 0o666)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
## Summary / 摘要

- 删除本地存储文件成功后，同步清理该文件路径对应的缩略图缓存。
- 将本地缩略图缓存路径生成逻辑复用到生成和清理流程，避免规则不一致。
- 增加本地文件删除时清理缩略图缓存的单元测试。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Related Issues / 关联 Issue

Fixes #1393

## Testing / 测试

- [ ] `go test ./...`
- [x] `go test ./drivers/local`
- [ ] Manual test / 手动测试:

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。