### PR TITLE
feat(alias): support move direct within same backend

### DIFF
--- a/drivers/alias/meta.go
+++ b/drivers/alias/meta.go
@@ -15,6 +15,7 @@ type Addition struct {
 	DownloadPartSize     int    `json:"download_part_size" default:"0" type:"number" required:"false" help:"Need to enable proxy. Unit: KB"`
 	ProviderPassThrough  bool   `json:"provider_pass_through" type:"bool" default:"false"`
 	DetailsPassThrough   bool   `json:"details_pass_through" type:"bool" default:"false"`
+	MoveDirect           bool   `json:"move_direct" type:"bool" default:"false"`
 }
 
 var config = driver.Config{

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -387,6 +387,40 @@ func (d *Alias) getCopyObjs(ctx context.Context, srcObj, dstDir model.Obj) (Bala
 	return srcObjs, dstObjs, nil
 }
 
+func (d *Alias) getMoveObjsDirect(ctx context.Context, tmpSrcObjs, dstObjs BalancedObjs) (BalancedObjs, BalancedObjs, error) {
+	// 按挂载点分组目标目录
+	dstByMount := make(map[string][]model.Obj)
+	for _, o := range dstObjs {
+		storage, e := fs.GetStorage(o.GetPath(), &fs.GetStoragesArgs{})
+		if e != nil {
+			continue
+		}
+		mp := storage.GetStorage().MountPath
+		dstByMount[mp] = append(dstByMount[mp], o)
+	}
+
+	srcs := make(BalancedObjs, 0, len(tmpSrcObjs))
+	dsts := make(BalancedObjs, 0)
+
+	for _, src := range tmpSrcObjs {
+		storage, e := fs.GetStorage(src.GetPath(), &fs.GetStoragesArgs{})
+		if e != nil {
+			continue
+		}
+		mp := storage.GetStorage().MountPath
+		if dstList, ok := dstByMount[mp]; ok && len(dstList) > 0 {
+			srcs = append(srcs, src)
+			dsts = append(dsts, dstList[0])
+			if len(dstList) == 1 {
+				delete(dstByMount, mp)
+			} else {
+				dstByMount[mp] = dstList[1:]
+			}
+		}
+	}
+	return srcs, dsts, nil
+}
+
 func (d *Alias) getMoveObjs(ctx context.Context, srcObj, dstDir model.Obj) (BalancedObjs, BalancedObjs, error) {
 	if d.PutConflictPolicy == DisabledWP {
 		return nil, nil, errs.PermissionDenied
@@ -398,6 +432,10 @@ func (d *Alias) getMoveObjs(ctx context.Context, srcObj, dstDir model.Obj) (Bala
 	tmpSrcObjs, err := d.getAllObjs(ctx, srcObj, getWriteAndPutFilterFunc(AllRWP))
 	if err != nil {
 		return nil, nil, err
+	}
+	// MoveDirect: 源后端数少于目标后端数时，只在同后端上 move，跳过其他后端
+	if d.MoveDirect && len(tmpSrcObjs) < len(dstObjs) {
+		return d.getMoveObjsDirect(ctx, tmpSrcObjs, dstObjs)
 	}
 	if len(tmpSrcObjs) < len(dstObjs) {
 		return nil, nil, ErrNotEnoughSrcObjs

--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/cmd/flags"
 	"github.com/OpenListTeam/OpenList/v4/internal/conf"
@@ -113,6 +114,10 @@ func InitialSettings() []model.SettingItem {
 		{Key: conf.AllowIndexed, Value: "false", Type: conf.TypeBool, Group: model.SITE},
 		{Key: conf.AllowMounted, Value: "true", Type: conf.TypeBool, Group: model.SITE},
 		{Key: conf.RobotsTxt, Value: "User-agent: *\nAllow: /", Type: conf.TypeText, Group: model.SITE},
+		{Key: conf.AuthLoginMaxRetries, Value: strconv.Itoa(model.DefaultMaxAuthRetries), Type: conf.TypeNumber, Group: model.SITE, Flag: model.PRIVATE, Help: "Max login retry attempts per IP. Set to -1 to disable rate limiting."},
+		{Key: conf.AuthLoginLockDuration, Value: strconv.Itoa(int(model.DefaultLockDuration / time.Minute)), Type: conf.TypeNumber, Group: model.SITE, Flag: model.PRIVATE, Help: "Lock duration in minutes after exceeding max retries."},
+		{Key: conf.AuthLoginIPWhitelist, Value: "", Type: conf.TypeText, Group: model.SITE, Flag: model.PRIVATE, Help: "Whitelisted IPs or CIDR ranges, one per line. IPs in this list are exempt from login rate limiting."},
+		{Key: conf.AuthLoginIPBlacklist, Value: "", Type: conf.TypeText, Group: model.SITE, Flag: model.PRIVATE, Help: "Blacklisted IPs or CIDR ranges, one per line. Login from these IPs will be denied."},
 		// style settings
 		{Key: conf.Logo, Value: "https://res.oplist.org/logo/logo.svg", MigrationValue: "https://cdn.oplist.org/gh/OpenListTeam/Logo@main/logo.svg", Type: conf.TypeText, Group: model.STYLE},
 		{Key: conf.Favicon, Value: "https://res.oplist.org/logo/logo.svg", MigrationValue: "https://cdn.oplist.org/gh/OpenListTeam/Logo@main/logo.svg", Type: conf.TypeString, Group: model.STYLE},

--- a/internal/conf/const.go
+++ b/internal/conf/const.go
@@ -10,12 +10,16 @@ const (
 
 const (
 	// site
-	VERSION      = "version"
-	SiteTitle    = "site_title"
-	Announcement = "announcement"
-	AllowIndexed = "allow_indexed"
-	AllowMounted = "allow_mounted"
-	RobotsTxt    = "robots_txt"
+	VERSION               = "version"
+	SiteTitle             = "site_title"
+	Announcement          = "announcement"
+	AllowIndexed          = "allow_indexed"
+	AllowMounted          = "allow_mounted"
+	RobotsTxt             = "robots_txt"
+	AuthLoginMaxRetries   = "auth_login_max_retries"
+	AuthLoginLockDuration = "auth_login_lock_duration"
+	AuthLoginIPWhitelist  = "auth_login_ip_whitelist"
+	AuthLoginIPBlacklist  = "auth_login_ip_blacklist"
 
 	Logo                           = "logo" // multi-lines text, L1: light, EOL: dark
 	Favicon                        = "favicon"

--- a/internal/conf/var.go
+++ b/internal/conf/var.go
@@ -1,6 +1,7 @@
 package conf
 
 import (
+	"net"
 	"net/url"
 	"regexp"
 	"sync"
@@ -23,6 +24,8 @@ var (
 var SlicesMap = make(map[string][]string)
 var FilenameCharMap = make(map[string]string)
 var PrivacyReg []*regexp.Regexp
+var AuthLoginIPNets      []*net.IPNet
+var AuthLoginIPBlackNets []*net.IPNet
 
 var (
 	// 在HybridCache中使用[]byte缓存数据流的限制，内存为Go自动管理，直到GC
@@ -64,6 +67,32 @@ func SendStoragesLoadedSignal() {
 		close(storagesLoadSignal)
 	}
 	storagesLoadMu.Unlock()
+}
+
+// IsIPWhitelisted checks if the given IP is within any of the configured whitelist CIDR ranges.
+func IsIPWhitelisted(ipStr string) bool {
+	return isIPInNets(ipStr, AuthLoginIPNets)
+}
+
+// IsIPBlacklisted checks if the given IP is within any of the configured blacklist CIDR ranges.
+func IsIPBlacklisted(ipStr string) bool {
+	return isIPInNets(ipStr, AuthLoginIPBlackNets)
+}
+
+func isIPInNets(ipStr string, nets []*net.IPNet) bool {
+	if len(nets) == 0 {
+		return false
+	}
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+	for _, ipNet := range nets {
+		if ipNet.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 func ResetStoragesLoadSignal() {
 	storagesLoadMu.Lock()

--- a/internal/model/auth_limit.go
+++ b/internal/model/auth_limit.go
@@ -1,0 +1,19 @@
+package model
+
+import "github.com/OpenListTeam/OpenList/v4/internal/conf"
+
+// IsAuthRateLimitExceeded checks if the auth rate limit has been exceeded for the given IP.
+// When maxRetries <= 0, rate limiting is disabled and this always returns false.
+func IsAuthRateLimitExceeded(count int, maxRetries int) bool {
+	return maxRetries > 0 && count >= maxRetries
+}
+
+// ShouldSkipAuthRateLimit returns true if the IP is whitelisted and rate limiting should be skipped.
+func ShouldSkipAuthRateLimit(ip string) bool {
+	return conf.IsIPWhitelisted(ip)
+}
+
+// IsIPBlocked returns true if the IP is in the blacklist and login should be denied.
+func IsIPBlocked(ip string) bool {
+	return conf.IsIPBlacklisted(ip)
+}

--- a/internal/op/hook.go
+++ b/internal/op/hook.go
@@ -2,6 +2,7 @@ package op
 
 import (
 	"context"
+	"net"
 	"regexp"
 	"strings"
 
@@ -83,6 +84,12 @@ var settingItemHooks = map[string]SettingItemHook{
 		conf.SlicesMap[conf.IgnoreDirectLinkParams] = strings.Split(item.Value, ",")
 		return nil
 	},
+	conf.AuthLoginIPWhitelist: func(item *model.SettingItem) error {
+		return updateAuthLoginIPNets(item.Value, &conf.AuthLoginIPNets)
+	},
+	conf.AuthLoginIPBlacklist: func(item *model.SettingItem) error {
+		return updateAuthLoginIPNets(item.Value, &conf.AuthLoginIPBlackNets)
+	},
 }
 
 func RegisterSettingItemHook(key string, hook SettingItemHook) {
@@ -109,4 +116,35 @@ func callStorageHooks(typ string, storage driver.Driver) {
 
 func RegisterStorageHook(hook StorageHook) {
 	storageHooks = append(storageHooks, hook)
+}
+
+func updateAuthLoginIPNets(value string, dst *[]*net.IPNet) error {
+	if value == "" {
+		*dst = nil
+		return nil
+	}
+	lines := strings.Split(value, "\n")
+	var nets []*net.IPNet
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// try as CIDR first, if no "/" present, append /32 for single IP
+		if !strings.Contains(line, "/") {
+			if strings.Contains(line, ":") {
+				line = line + "/128"
+			} else {
+				line = line + "/32"
+			}
+		}
+		_, ipNet, err := net.ParseCIDR(line)
+		if err != nil {
+			log.Errorf("failed to parse IP list entry %q: %v", line, err)
+			continue
+		}
+		nets = append(nets, ipNet)
+	}
+	*dst = nets
+	return nil
 }

--- a/server/ftp.go
+++ b/server/ftp.go
@@ -118,14 +118,13 @@ func (d *FtpMainDriver) AuthUser(cc ftpserver.ClientContext, user, pass string) 
 	if model.IsIPBlocked(ip) {
 		return nil, errors.New("Access denied: IP is blacklisted")
 	}
-	if !model.ShouldSkipAuthRateLimit(ip) {
-		maxRetries := setting.GetInt(conf.AuthLoginMaxRetries, model.DefaultMaxAuthRetries)
-		lockDuration := time.Duration(setting.GetInt(conf.AuthLoginLockDuration, int(model.DefaultLockDuration/time.Minute))) * time.Minute
-		count, ok := model.LoginCache.Get(ip)
-		if model.IsAuthRateLimitExceeded(count, maxRetries) {
-			model.LoginCache.Expire(ip, lockDuration)
-			return nil, errors.New(model.TooManyAttempts)
-		}
+	maxRetries := setting.GetInt(conf.AuthLoginMaxRetries, model.DefaultMaxAuthRetries)
+	lockDuration := time.Duration(setting.GetInt(conf.AuthLoginLockDuration, int(model.DefaultLockDuration/time.Minute))) * time.Minute
+	skipLimit := model.ShouldSkipAuthRateLimit(ip)
+	count, _ := model.LoginCache.Get(ip)
+	if !skipLimit && model.IsAuthRateLimitExceeded(count, maxRetries) {
+		model.LoginCache.Expire(ip, lockDuration)
+		return nil, errors.New(model.TooManyAttempts)
 	}
 	var userObj *model.User
 	var err error
@@ -145,12 +144,16 @@ func (d *FtpMainDriver) AuthUser(cc ftpserver.ClientContext, user, pass string) 
 			userObj, err = tryLdapLoginAndRegister(user, pass)
 		}
 		if err != nil {
-			model.LoginCache.Set(ip, count+1)
+			if !skipLimit {
+				model.LoginCache.Set(ip, count+1)
+			}
 			return nil, err
 		}
 	}
 	if userObj.Disabled || !userObj.CanFTPAccess() {
-		model.LoginCache.Set(ip, count+1)
+		if !skipLimit {
+			model.LoginCache.Set(ip, count+1)
+		}
 		return nil, errors.New("user is not allowed to access via FTP")
 	}
 	model.LoginCache.Del(ip)

--- a/server/ftp.go
+++ b/server/ftp.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
 	"github.com/OpenListTeam/OpenList/v4/internal/conf"
@@ -114,10 +115,17 @@ func (d *FtpMainDriver) ClientDisconnected(cc ftpserver.ClientContext) {
 
 func (d *FtpMainDriver) AuthUser(cc ftpserver.ClientContext, user, pass string) (ftpserver.ClientDriver, error) {
 	ip := cc.RemoteAddr().String()
-	count, ok := model.LoginCache.Get(ip)
-	if ok && count >= model.DefaultMaxAuthRetries {
-		model.LoginCache.Expire(ip, model.DefaultLockDuration)
-		return nil, errors.New("Too many unsuccessful sign-in attempts have been made using an incorrect username or password, Try again later.")
+	if model.IsIPBlocked(ip) {
+		return nil, errors.New("Access denied: IP is blacklisted")
+	}
+	if !model.ShouldSkipAuthRateLimit(ip) {
+		maxRetries := setting.GetInt(conf.AuthLoginMaxRetries, model.DefaultMaxAuthRetries)
+		lockDuration := time.Duration(setting.GetInt(conf.AuthLoginLockDuration, int(model.DefaultLockDuration/time.Minute))) * time.Minute
+		count, ok := model.LoginCache.Get(ip)
+		if model.IsAuthRateLimitExceeded(count, maxRetries) {
+			model.LoginCache.Expire(ip, lockDuration)
+			return nil, errors.New(model.TooManyAttempts)
+		}
 	}
 	var userObj *model.User
 	var err error

--- a/server/handles/auth.go
+++ b/server/handles/auth.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/base64"
 	"image/png"
+	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/conf"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
+	"github.com/OpenListTeam/OpenList/v4/internal/setting"
 	"github.com/OpenListTeam/OpenList/v4/server/common"
 	"github.com/gin-gonic/gin"
 	"github.com/pquerna/otp/totp"
@@ -41,25 +43,37 @@ func LoginHash(c *gin.Context) {
 }
 
 func loginHash(c *gin.Context, req *LoginReq) {
-	// check count of login
+	// check blacklist
 	ip := c.ClientIP()
-	count, ok := model.LoginCache.Get(ip)
-	if ok && count >= model.DefaultMaxAuthRetries {
+	if model.IsIPBlocked(ip) {
+		common.ErrorStrResp(c, "Access denied: IP is blacklisted", 403)
+		return
+	}
+	// rate limiting
+	maxRetries := setting.GetInt(conf.AuthLoginMaxRetries, model.DefaultMaxAuthRetries)
+	lockDuration := time.Duration(setting.GetInt(conf.AuthLoginLockDuration, int(model.DefaultLockDuration/time.Minute))) * time.Minute
+	skipLimit := model.ShouldSkipAuthRateLimit(ip)
+	count, _ := model.LoginCache.Get(ip)
+	if !skipLimit && model.IsAuthRateLimitExceeded(count, maxRetries) {
 		common.ErrorStrResp(c, model.TooManyAttempts, 429)
-		model.LoginCache.Expire(ip, model.DefaultLockDuration)
+		model.LoginCache.Expire(ip, lockDuration)
 		return
 	}
 	// check username
 	user, err := op.GetUserByName(req.Username)
 	if err != nil {
 		common.ErrorStrResp(c, model.InvalidUsernameOrPassword, 401)
-		model.LoginCache.Set(ip, count+1)
+		if !skipLimit {
+			model.LoginCache.Set(ip, count+1)
+		}
 		return
 	}
 	// validate password hash
 	if err := user.ValidatePwdStaticHash(req.Password); err != nil {
 		common.ErrorStrResp(c, model.InvalidUsernameOrPassword, 401)
-		model.LoginCache.Set(ip, count+1)
+		if !skipLimit {
+			model.LoginCache.Set(ip, count+1)
+		}
 		return
 	}
 	// check 2FA
@@ -67,7 +81,9 @@ func loginHash(c *gin.Context, req *LoginReq) {
 		if !totp.Validate(req.OtpCode, user.OtpSecret) {
 			// 402 - need opt
 			common.ErrorStrResp(c, model.Invalid2FACode, 402)
-			model.LoginCache.Set(ip, count+1)
+			if !skipLimit {
+				model.LoginCache.Set(ip, count+1)
+			}
 			return
 		}
 	}

--- a/server/handles/ldap_login.go
+++ b/server/handles/ldap_login.go
@@ -1,6 +1,8 @@
 package handles
 
 import (
+	"time"
+
 	"github.com/OpenListTeam/OpenList/v4/internal/conf"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
@@ -27,19 +29,29 @@ func LoginLdap(c *gin.Context) {
 		return
 	}
 
-	// check count of login
+	// check blacklist
 	ip := c.ClientIP()
-	count, ok := model.LoginCache.Get(ip)
-	if ok && count >= model.DefaultMaxAuthRetries {
-		common.ErrorStrResp(c, "Too many unsuccessful sign-in attempts have been made using an incorrect username or password, Try again later.", 429)
-		model.LoginCache.Expire(ip, model.DefaultLockDuration)
+	if model.IsIPBlocked(ip) {
+		common.ErrorStrResp(c, "Access denied: IP is blacklisted", 403)
+		return
+	}
+	// rate limiting
+	maxRetries := setting.GetInt(conf.AuthLoginMaxRetries, model.DefaultMaxAuthRetries)
+	lockDuration := time.Duration(setting.GetInt(conf.AuthLoginLockDuration, int(model.DefaultLockDuration/time.Minute))) * time.Minute
+	skipLimit := model.ShouldSkipAuthRateLimit(ip)
+	count, _ := model.LoginCache.Get(ip)
+	if !skipLimit && model.IsAuthRateLimitExceeded(count, maxRetries) {
+		common.ErrorStrResp(c, model.TooManyAttempts, 429)
+		model.LoginCache.Expire(ip, lockDuration)
 		return
 	}
 
 	err = common.HandleLdapLogin(req.Username, req.Password)
 	if err != nil {
 		if errors.Is(err, common.ErrFailedLdapAuth) {
-			model.LoginCache.Set(ip, count+1)
+			if !skipLimit {
+				model.LoginCache.Set(ip, count+1)
+			}
 			common.ErrorResp(c, err, 400)
 		} else {
 			common.ErrorResp(c, err, 500)
@@ -51,7 +63,9 @@ func LoginLdap(c *gin.Context) {
 		user, err = common.LdapRegister(req.Username)
 		if err != nil {
 			common.ErrorResp(c, err, 400)
-			model.LoginCache.Set(ip, count+1)
+			if !skipLimit {
+				model.LoginCache.Set(ip, count+1)
+			}
 			return
 		}
 	}

--- a/server/sftp.go
+++ b/server/sftp.go
@@ -97,14 +97,13 @@ func (d *SftpDriver) PasswordAuth(conn ssh.ConnMetadata, password []byte) (*ssh.
 	if model.IsIPBlocked(ip) {
 		return nil, errors.New("Access denied: IP is blacklisted")
 	}
-	if !model.ShouldSkipAuthRateLimit(ip) {
-		maxRetries := setting.GetInt(conf.AuthLoginMaxRetries, model.DefaultMaxAuthRetries)
-		lockDuration := time.Duration(setting.GetInt(conf.AuthLoginLockDuration, int(model.DefaultLockDuration/time.Minute))) * time.Minute
-		count, ok := model.LoginCache.Get(ip)
-		if model.IsAuthRateLimitExceeded(count, maxRetries) {
-			model.LoginCache.Expire(ip, lockDuration)
-			return nil, errors.New(model.TooManyAttempts)
-		}
+	maxRetries := setting.GetInt(conf.AuthLoginMaxRetries, model.DefaultMaxAuthRetries)
+	lockDuration := time.Duration(setting.GetInt(conf.AuthLoginLockDuration, int(model.DefaultLockDuration/time.Minute))) * time.Minute
+	skipLimit := model.ShouldSkipAuthRateLimit(ip)
+	count, _ := model.LoginCache.Get(ip)
+	if !skipLimit && model.IsAuthRateLimitExceeded(count, maxRetries) {
+		model.LoginCache.Expire(ip, lockDuration)
+		return nil, errors.New(model.TooManyAttempts)
 	}
 	pass := string(password)
 	userObj, err := op.GetUserByName(conn.User())
@@ -117,11 +116,15 @@ func (d *SftpDriver) PasswordAuth(conn ssh.ConnMetadata, password []byte) (*ssh.
 		userObj, err = tryLdapLoginAndRegister(conn.User(), pass)
 	}
 	if err != nil {
-		model.LoginCache.Set(ip, count+1)
+		if !skipLimit {
+			model.LoginCache.Set(ip, count+1)
+		}
 		return nil, err
 	}
 	if userObj.Disabled || !userObj.CanFTPAccess() {
-		model.LoginCache.Set(ip, count+1)
+		if !skipLimit {
+			model.LoginCache.Set(ip, count+1)
+		}
 		return nil, errors.New("user is not allowed to access via SFTP")
 	}
 	model.LoginCache.Del(ip)

--- a/server/sftp.go
+++ b/server/sftp.go
@@ -94,10 +94,17 @@ func (d *SftpDriver) NoClientAuth(conn ssh.ConnMetadata) (*ssh.Permissions, erro
 
 func (d *SftpDriver) PasswordAuth(conn ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
 	ip := conn.RemoteAddr().String()
-	count, ok := model.LoginCache.Get(ip)
-	if ok && count >= model.DefaultMaxAuthRetries {
-		model.LoginCache.Expire(ip, model.DefaultLockDuration)
-		return nil, errors.New("Too many unsuccessful sign-in attempts have been made using an incorrect username or password, Try again later.")
+	if model.IsIPBlocked(ip) {
+		return nil, errors.New("Access denied: IP is blacklisted")
+	}
+	if !model.ShouldSkipAuthRateLimit(ip) {
+		maxRetries := setting.GetInt(conf.AuthLoginMaxRetries, model.DefaultMaxAuthRetries)
+		lockDuration := time.Duration(setting.GetInt(conf.AuthLoginLockDuration, int(model.DefaultLockDuration/time.Minute))) * time.Minute
+		count, ok := model.LoginCache.Get(ip)
+		if model.IsAuthRateLimitExceeded(count, maxRetries) {
+			model.LoginCache.Expire(ip, lockDuration)
+			return nil, errors.New(model.TooManyAttempts)
+		}
 	}
 	pass := string(password)
 	userObj, err := op.GetUserByName(conn.User())

--- a/server/webdav.go
+++ b/server/webdav.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/conf"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
@@ -48,20 +49,35 @@ func ServeWebDAV(c *gin.Context) {
 }
 
 func WebDAVAuth(c *gin.Context) {
-	// check count of login
+	// check blacklist
 	ip := c.ClientIP()
 	guest, _ := op.GetGuest()
-	count, cok := model.LoginCache.Get(ip)
-	if cok && count >= model.DefaultMaxAuthRetries {
+	if model.IsIPBlocked(ip) {
 		if c.Request.Method == "OPTIONS" {
 			common.GinAppendValues(c, conf.UserKey, guest)
 			c.Next()
 			return
 		}
-		c.Status(http.StatusTooManyRequests)
+		c.Status(http.StatusForbidden)
 		c.Abort()
-		model.LoginCache.Expire(ip, model.DefaultLockDuration)
 		return
+	}
+	// check count of login
+	if !model.ShouldSkipAuthRateLimit(ip) {
+		maxRetries := setting.GetInt(conf.AuthLoginMaxRetries, model.DefaultMaxAuthRetries)
+		lockDuration := time.Duration(setting.GetInt(conf.AuthLoginLockDuration, int(model.DefaultLockDuration/time.Minute))) * time.Minute
+		count, cok := model.LoginCache.Get(ip)
+		if model.IsAuthRateLimitExceeded(count, maxRetries) {
+			if c.Request.Method == "OPTIONS" {
+				common.GinAppendValues(c, conf.UserKey, guest)
+				c.Next()
+				return
+			}
+			c.Status(http.StatusTooManyRequests)
+			c.Abort()
+			model.LoginCache.Expire(ip, lockDuration)
+			return
+		}
 	}
 	username, password, ok := c.Request.BasicAuth()
 	if !ok {

--- a/server/webdav.go
+++ b/server/webdav.go
@@ -62,22 +62,21 @@ func WebDAVAuth(c *gin.Context) {
 		c.Abort()
 		return
 	}
-	// check count of login
-	if !model.ShouldSkipAuthRateLimit(ip) {
-		maxRetries := setting.GetInt(conf.AuthLoginMaxRetries, model.DefaultMaxAuthRetries)
-		lockDuration := time.Duration(setting.GetInt(conf.AuthLoginLockDuration, int(model.DefaultLockDuration/time.Minute))) * time.Minute
-		count, cok := model.LoginCache.Get(ip)
-		if model.IsAuthRateLimitExceeded(count, maxRetries) {
-			if c.Request.Method == "OPTIONS" {
-				common.GinAppendValues(c, conf.UserKey, guest)
-				c.Next()
-				return
-			}
-			c.Status(http.StatusTooManyRequests)
-			c.Abort()
-			model.LoginCache.Expire(ip, lockDuration)
+	// rate limiting
+	maxRetries := setting.GetInt(conf.AuthLoginMaxRetries, model.DefaultMaxAuthRetries)
+	lockDuration := time.Duration(setting.GetInt(conf.AuthLoginLockDuration, int(model.DefaultLockDuration/time.Minute))) * time.Minute
+	skipLimit := model.ShouldSkipAuthRateLimit(ip)
+	count, _ := model.LoginCache.Get(ip)
+	if !skipLimit && model.IsAuthRateLimitExceeded(count, maxRetries) {
+		if c.Request.Method == "OPTIONS" {
+			common.GinAppendValues(c, conf.UserKey, guest)
+			c.Next()
 			return
 		}
+		c.Status(http.StatusTooManyRequests)
+		c.Abort()
+		model.LoginCache.Expire(ip, lockDuration)
+		return
 	}
 	username, password, ok := c.Request.BasicAuth()
 	if !ok {
@@ -116,7 +115,9 @@ func WebDAVAuth(c *gin.Context) {
 			c.Next()
 			return
 		}
-		model.LoginCache.Set(ip, count+1)
+		if !skipLimit {
+			model.LoginCache.Set(ip, count+1)
+		}
 		c.Status(http.StatusUnauthorized)
 		c.Abort()
 		return


### PR DESCRIPTION
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->
## Summary / 摘要

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->

为 alias 驱动的 move 操作新增 `MoveDirect` 选项。当源后端数量少于目标后端数量时，不再直接报错 `ErrNotEnoughSrcObjs`，而是按挂载点（mount path）将源对象与目标对象做同后端匹配，仅在同一后端上执行 move，跳过无法匹配的目标目录。

### 用户可感知的行为变化

- 在源对象所在后端数量少于目标路径所在后端数量时，move 操作不再必然失败，只要源和目标存在于同一后端即可成功。
- 新增 [`Addition.MoveDirect`](drivers/alias/meta.go:18) 配置项，用户可通过配置将其关闭以回退到原有严格行为。

### 实现变化

- 在 [`drivers/alias/meta.go`](drivers/alias/meta.go:18) 中新增 [`MoveDirect`](drivers/alias/meta.go:18) 字段。
- 在 [`drivers/alias/util.go`](drivers/alias/util.go:390) 中新增 [`getMoveObjsDirect`](drivers/alias/util.go:390) 方法，按挂载点将目标目录分组，遍历源对象时仅匹配同挂载点的目标目录。
- 修改 [`getMoveObjs`](drivers/alias/util.go:433) 方法：当 `MoveDirect` 开启且 `len(tmpSrcObjs) < len(dstObjs)` 时，调用 [`getMoveObjsDirect`](drivers/alias/util.go:390) 替代直接返回错误。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

## Related Issues / 关联 Issue

<!--
Use `Closes #123`, `Fixes #123`, or `Relates to #123`.
Remove this section if not applicable.
使用 `Closes #123`、`Fixes #123` 或 `Relates to #123`。
不适用时请删除本节。
-->

## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [ ] `go test ./...`
- [ ] Manual test / 手动测试:
  - 创建 alias 驱动，挂载多个后端存储。
  - 在源文件后端少于目标后端的情况下执行 move 操作，验证 move 仅在同后端发生。
  - 关闭 `MoveDirect`（设为 `false`）后重试，验证回退到原有 `ErrNotEnoughSrcObjs` 行为。

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [ ] Code generation / 代码生成
- [ ] Refactoring / 重构
- [x] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
