### PR TITLE
refactor(drivers/139): update path handling, put for family/group

### DIFF
--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -734,7 +734,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 				if err != nil {
 					return err
 				}
-				err = d.uploadPersonalParts(ctx, partInfos, moreresp.Data.PartInfos, ss, p)
+				err = d.uploadPersonalParts(ctx, batchPartInfos, moreresp.Data.PartInfos, ss, p)
 				if err != nil {
 					return err
 				}

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -703,7 +703,11 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 				return fmt.Errorf("cloud_id is required for group/family upload")
 			}
 			data["groupId"] = d.CloudID
-			data["groupType"] = 1
+			if d.isGroup() {
+				data["groupType"] = 2
+			} else if d.isFamily() {
+				data["groupType"] = 1
+			}
 			data["catalogType"] = 3
 			data["seqNo"] = random.String(32)
 		}
@@ -772,6 +776,10 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 				"contentHashAlgorithm": "SHA256",
 				"fileId":               resp.Data.FileId,
 				"uploadId":             resp.Data.UploadId,
+			}
+			// 家庭盘和小组盘需要额外的参数
+			if d.isGroup() || d.isFamily() {
+				data["groupId"] = d.CloudID
 			}
 			_, err = d.newPost(completePath, data, nil)
 			if err != nil {

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -88,7 +88,7 @@ func (d *Yun139) Init(ctx context.Context) error {
 		if len(d.PersonalCloudHost) == 0 {
 			return fmt.Errorf("PersonalCloudHost is empty")
 		}
-		if d.Addition.Type == MetaGroup || d.Addition.Type == MetaFamily {
+		if d.isGroup() || d.isFamily() {
 			if len(d.GroupCloudHost) == 0 {
 				return fmt.Errorf("GroupCloudHost is empty")
 			}

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -32,7 +32,6 @@ type Yun139 struct {
 	PersonalCloudHost string
 	FamilyCloudHost   string
 	GroupCloudHost    string
-	RootPath          string
 }
 
 func (d *Yun139) Config() driver.Config {
@@ -226,7 +225,7 @@ func (d *Yun139) MakeDir(ctx context.Context, parentDir model.Obj, dirName strin
 				"accountType": 1,
 			},
 			"docLibName": dirName,
-			"path":       path.Join(parentDir.GetPath(), parentDir.GetID()),
+			"path":       d.dirPath(parentDir),
 		}
 		pathname := "/orchestration/familyCloud-rebuild/cloudCatalog/v1.0/createCloudDoc"
 		_, err = d.post(pathname, data, nil)
@@ -239,7 +238,7 @@ func (d *Yun139) MakeDir(ctx context.Context, parentDir model.Obj, dirName strin
 			},
 			"groupID":      d.CloudID,
 			"parentFileId": parentDir.GetID(),
-			"path":         path.Join(parentDir.GetPath(), parentDir.GetID()),
+			"path":         d.dirPath(parentDir),
 		}
 		pathname := "/orchestration/group-rebuild/catalog/v1.0/createGroupCatalog"
 		_, err = d.post(pathname, data, nil)
@@ -324,9 +323,9 @@ func (d *Yun139) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj,
 		var contentList []string
 		var catalogList []string
 		if srcObj.IsDir() {
-			catalogList = append(catalogList, path.Join(srcObj.GetPath(), srcObj.GetID()))
+			catalogList = append(catalogList, d.dirPath(srcObj))
 		} else {
-			contentList = append(contentList, path.Join(srcObj.GetPath(), srcObj.GetID()))
+			contentList = append(contentList, d.dirPath(srcObj))
 		}
 
 		body := base.Json{
@@ -338,7 +337,7 @@ func (d *Yun139) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj,
 			"contentList":   contentList,
 			"destCatalogID": dstDir.GetID(),
 			"destGroupID":   d.CloudID,
-			"destPath":      path.Join(dstDir.GetPath(), dstDir.GetID()),
+			"destPath":      d.dirPath(dstDir),
 			"destType":      0,
 			"srcGroupID":    d.CloudID,
 			"srcType":       0,
@@ -439,7 +438,7 @@ func (d *Yun139) Rename(ctx context.Context, srcObj model.Obj, newName string) e
 				},
 				"docLibName":   newName,
 				"docLibraryID": srcObj.GetID(),
-				"path":         path.Join(srcObj.GetPath(), srcObj.GetID()),
+				"path":         d.dirPath(srcObj),
 			}
 			var resp ModifyCloudDocV2Resp
 			_, err = d.andAlbumRequest(pathname, data, &resp)
@@ -845,11 +844,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 		}
 		pathname := "/orchestration/personalCloud/uploadAndDownload/v1.0/pcUploadFileRequest"
 		if d.isFamily() || d.isGroup() {
-			uploadPath := path.Join(dstDir.GetPath(), dstDir.GetID())
-			// if dstDir is root folder
-			if dstDir.GetID() == d.RootFolderID {
-				uploadPath = d.RootPath
-			}
+			uploadPath := d.dirPath(dstDir)
 			data = d.newJson(base.Json{
 				"fileCount":    1,
 				"manualRename": 2,

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -703,10 +703,14 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 		if resp.Data.PartInfos != nil {
 			// Progress
 			p := driver.NewProgress(size, up)
-			rateLimited := driver.NewLimitedUploadStream(ctx, stream)
+
+			ss, err := streamPkg.NewStreamSectionReader(stream, int(partSize), &up)
+			if err != nil {
+				return err
+			}
 
 			// 先上传前100个分片
-			err = d.uploadPersonalParts(ctx, partInfos, resp.Data.PartInfos, rateLimited, p)
+			err = d.uploadPersonalParts(ctx, partInfos, resp.Data.PartInfos, ss, p)
 			if err != nil {
 				return err
 			}
@@ -730,7 +734,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 				if err != nil {
 					return err
 				}
-				err = d.uploadPersonalParts(ctx, partInfos, moreresp.Data.PartInfos, rateLimited, p)
+				err = d.uploadPersonalParts(ctx, partInfos, moreresp.Data.PartInfos, ss, p)
 				if err != nil {
 					return err
 				}

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -30,6 +30,8 @@ type Yun139 struct {
 	Account           string
 	ref               *Yun139
 	PersonalCloudHost string
+	FamilyCloudHost   string
+	GroupCloudHost    string
 	RootPath          string
 }
 
@@ -74,13 +76,23 @@ func (d *Yun139) Init(ctx context.Context) error {
 			return err
 		}
 		for _, policyItem := range resp.Data.RoutePolicyList {
-			if policyItem.ModName == "personal" {
+			switch policyItem.ModName {
+			case "personal":
 				d.PersonalCloudHost = policyItem.HttpsUrl
-				break
+			case "group":
+				d.GroupCloudHost = policyItem.HttpsUrl
+			case "family":
+				d.FamilyCloudHost = policyItem.HttpsUrl
 			}
 		}
 		if len(d.PersonalCloudHost) == 0 {
 			return fmt.Errorf("PersonalCloudHost is empty")
+		}
+		if len(d.GroupCloudHost) == 0 {
+			return fmt.Errorf("GroupCloudHost is empty")
+		}
+		if len(d.FamilyCloudHost) == 0 {
+			return fmt.Errorf("FamilyCloudHost is empty")
 		}
 
 		d.cron = cron.NewCron(time.Hour * 12)

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -87,11 +87,13 @@ func (d *Yun139) Init(ctx context.Context) error {
 		if len(d.PersonalCloudHost) == 0 {
 			return fmt.Errorf("PersonalCloudHost is empty")
 		}
-		if len(d.GroupCloudHost) == 0 {
-			return fmt.Errorf("GroupCloudHost is empty")
-		}
-		if len(d.FamilyCloudHost) == 0 {
-			return fmt.Errorf("FamilyCloudHost is empty")
+		if d.Addition.Type == MetaGroup || d.Addition.Type == MetaFamily {
+			if len(d.GroupCloudHost) == 0 {
+				return fmt.Errorf("GroupCloudHost is empty")
+			}
+			if len(d.FamilyCloudHost) == 0 {
+				return fmt.Errorf("FamilyCloudHost is empty")
+			}
 		}
 
 		d.cron = cron.NewCron(time.Hour * 12)

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -902,22 +902,19 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 			start := i * partSize
 			byteSize := min(size-start, partSize)
 
-			var rd io.ReadSeeker
+			rd, getErr := ss.GetSectionReader(start, byteSize)
+			if getErr != nil {
+				return getErr
+			}
+
 			err = retry.Do(
 				func() error {
-					var getErr error
-					rd, getErr = ss.GetSectionReader(start, byteSize)
-					if getErr != nil {
-						return getErr
-					}
 					if _, err := rd.Seek(0, io.SeekStart); err != nil {
-						ss.FreeSectionReader(rd)
 						return err
 					}
 					req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, resp.Data.UploadResult.RedirectionURL,
 						io.TeeReader(rd, p))
 					if reqErr != nil {
-						ss.FreeSectionReader(rd)
 						return reqErr
 					}
 					req.Header.Set("Content-Type", "text/plain;name="+unicode(stream.GetName()))
@@ -929,27 +926,22 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 
 					res, doErr := base.HttpClient.Do(req)
 					if doErr != nil {
-						ss.FreeSectionReader(rd)
 						return doErr
 					}
 					defer res.Body.Close()
 					bodyBytes, readErr := io.ReadAll(res.Body)
 					if readErr != nil {
-						ss.FreeSectionReader(rd)
 						return fmt.Errorf("error reading response body: %v", readErr)
 					}
 					if res.StatusCode != http.StatusOK {
-						ss.FreeSectionReader(rd)
 						return fmt.Errorf("unexpected status code: %d, body: %s", res.StatusCode, string(bodyBytes))
 					}
 					var result InterLayerUploadResult
 					xmlErr := xml.Unmarshal(bodyBytes, &result)
 					if xmlErr != nil {
-						ss.FreeSectionReader(rd)
 						return fmt.Errorf("error parsing XML: %v", xmlErr)
 					}
 					if result.ResultCode != 0 {
-						ss.FreeSectionReader(rd)
 						return fmt.Errorf("upload failed with result code: %d, message: %s", result.ResultCode, result.Msg)
 					}
 					return nil

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -910,10 +910,14 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 					if getErr != nil {
 						return getErr
 					}
-					rd.Seek(0, io.SeekStart)
+					if _, err := rd.Seek(0, io.SeekStart); err != nil {
+						ss.FreeSectionReader(rd)
+						return err
+					}
 					req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, resp.Data.UploadResult.RedirectionURL,
 						io.TeeReader(rd, p))
 					if reqErr != nil {
+						ss.FreeSectionReader(rd)
 						return reqErr
 					}
 					req.Header.Set("Content-Type", "text/plain;name="+unicode(stream.GetName()))
@@ -925,22 +929,27 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 
 					res, doErr := base.HttpClient.Do(req)
 					if doErr != nil {
+						ss.FreeSectionReader(rd)
 						return doErr
 					}
 					defer res.Body.Close()
 					bodyBytes, readErr := io.ReadAll(res.Body)
 					if readErr != nil {
+						ss.FreeSectionReader(rd)
 						return fmt.Errorf("error reading response body: %v", readErr)
 					}
 					if res.StatusCode != http.StatusOK {
+						ss.FreeSectionReader(rd)
 						return fmt.Errorf("unexpected status code: %d, body: %s", res.StatusCode, string(bodyBytes))
 					}
 					var result InterLayerUploadResult
 					xmlErr := xml.Unmarshal(bodyBytes, &result)
 					if xmlErr != nil {
+						ss.FreeSectionReader(rd)
 						return fmt.Errorf("error parsing XML: %v", xmlErr)
 					}
 					if result.ResultCode != 0 {
+						ss.FreeSectionReader(rd)
 						return fmt.Errorf("upload failed with result code: %d, message: %s", result.ResultCode, result.Msg)
 					}
 					return nil

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -697,6 +697,16 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 			"type":                 "file",
 			"fileRenameMode":       "auto_rename",
 		}
+		// 家庭盘和小组盘需要额外的参数
+		if d.isGroup() || d.isFamily() {
+			if d.CloudID == "" {
+				return fmt.Errorf("cloud_id is required for group/family upload")
+			}
+			data["groupId"] = d.CloudID
+			data["groupType"] = 1
+			data["catalogType"] = 3
+			data["seqNo"] = random.String(32)
+		}
 		var resp PersonalUploadResp
 		_, err = d.newPost(createPath, data, &resp)
 		if err != nil {

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -703,7 +703,12 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 			// Progress
 			p := driver.NewProgress(size, up)
 
-			ss, err := streamPkg.NewStreamSectionReader(stream, int(partSize), &up)
+			rateLimited := driver.NewLimitedUploadStream(ctx, stream)
+			ss, err := streamPkg.NewStreamSectionReader(&streamPkg.FileStream{
+				Ctx:    ctx,
+				Reader: rateLimited,
+				Obj:    &model.Object{Size: size},
+			}, int(partSize), &up)
 			if err != nil {
 				return err
 			}

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -883,6 +883,10 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 		pathname := "/orchestration/personalCloud/uploadAndDownload/v1.0/pcUploadFileRequest"
 		if d.isFamily() || d.isGroup() {
 			uploadPath := d.dirPath(dstDir)
+			// 共享群的根目录上传路径为 0
+			if d.isGroup() && dstDir.GetID() == d.RootFolderID {
+				uploadPath = "0"
+			}
 			data = d.newJson(base.Json{
 				"fileCount":    1,
 				"manualRename": 2,

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -122,7 +122,6 @@ func (d *Yun139) Init(ctx context.Context) error {
 	case MetaFamily:
 		if len(d.Addition.RootFolderID) == 0 {
 			// Attempt to obtain data.path as the root via a query and persist it.
-			d.RootFolderID = stripRootPath(d.RootFolderID)
 			if root, err := d.getFamilyRootPath(d.CloudID); err == nil && root != "" {
 				d.RootFolderID = root
 				op.MustSaveDriverStorage(d)

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -32,6 +32,7 @@ type Yun139 struct {
 	PersonalCloudHost string
 	FamilyCloudHost   string
 	GroupCloudHost    string
+	ProviderRoot      string
 }
 
 func (d *Yun139) Config() driver.Config {
@@ -122,9 +123,10 @@ func (d *Yun139) Init(ctx context.Context) error {
 			return err
 		}
 	case MetaFamily:
-		if len(d.Addition.RootFolderID) == 0 {
-			// Attempt to obtain data.path as the root via a query and persist it.
-			if root, err := d.getFamilyRootPath(d.CloudID); err == nil && root != "" {
+		// Attempt to obtain data.path as the root via a query and persist it.
+		if root, err := d.getFamilyRootPath(d.CloudID); err == nil && root != "" {
+			d.ProviderRoot = root
+			if len(d.Addition.RootFolderID) == 0 {
 				d.RootFolderID = root
 				op.MustSaveDriverStorage(d)
 			}

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -632,7 +632,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 		((d.isGroup() || d.isFamily()) && !d.UseOldStreamUpload) {
 		var createPath, getUploadUrlPath, completePath string
 		if d.isGroup() || d.isFamily() {
-			// 家庭盘和小组盘共用同一套新上传 API
+			// 家庭云和共享群共用同一套新上传 API
 			createPath = "/dynamic/file/create"
 			getUploadUrlPath = "/dynamic/file/getUploadUrl"
 			completePath = "/dynamic/file/complete"
@@ -697,7 +697,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 			"type":                 "file",
 			"fileRenameMode":       "auto_rename",
 		}
-		// 家庭盘和小组盘需要额外的参数
+		// 家庭云和共享群需要额外的参数
 		if d.isGroup() || d.isFamily() {
 			if d.CloudID == "" {
 				return fmt.Errorf("cloud_id is required for group/family upload")
@@ -777,7 +777,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 				"fileId":               resp.Data.FileId,
 				"uploadId":             resp.Data.UploadId,
 			}
-			// 家庭盘和小组盘需要额外的参数
+			// 家庭云和共享群需要额外的参数
 			if d.isGroup() || d.isFamily() {
 				data["groupId"] = d.CloudID
 			}

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -941,7 +941,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 					return nil
 				},
 				retry.Context(ctx),
-				retry.Attempts(10),
+				retry.Attempts(3),
 				retry.DelayType(retry.BackOffDelay),
 				retry.Delay(time.Second),
 			)

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -124,14 +124,16 @@ func (d *Yun139) Init(ctx context.Context) error {
 		}
 	case MetaFamily:
 		// Attempt to obtain data.path as the root via a query and persist it.
-		if root, err := d.getFamilyRootPath(d.CloudID); err == nil && root != "" {
-			d.ProviderRoot = root
-			if len(d.Addition.RootFolderID) == 0 {
-				d.RootFolderID = root
-				op.MustSaveDriverStorage(d)
-			}
+		root, err := d.getFamilyRootPath(d.CloudID)
+		if err != nil || root == "" {
+			return fmt.Errorf("failed to get family root path: %w", err)
 		}
-		_, err := d.familyGetFiles(d.RootFolderID)
+		d.ProviderRoot = root
+		if len(d.Addition.RootFolderID) == 0 {
+			d.RootFolderID = root
+			op.MustSaveDriverStorage(d)
+		}
+		_, err = d.familyGetFiles(d.RootFolderID)
 		if err != nil {
 			return err
 		}

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -123,6 +123,7 @@ func (d *Yun139) Init(ctx context.Context) error {
 	case MetaFamily:
 		if len(d.Addition.RootFolderID) == 0 {
 			// Attempt to obtain data.path as the root via a query and persist it.
+			d.RootFolderID = stripRootPath(d.RootFolderID)
 			if root, err := d.getFamilyRootPath(d.CloudID); err == nil && root != "" {
 				d.RootFolderID = root
 				op.MustSaveDriverStorage(d)
@@ -843,7 +844,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 			},
 		}
 		pathname := "/orchestration/personalCloud/uploadAndDownload/v1.0/pcUploadFileRequest"
-		if d.isFamily() || d.Addition.Type == MetaGroup {
+		if d.isFamily() || d.isGroup() {
 			uploadPath := path.Join(dstDir.GetPath(), dstDir.GetID())
 			// if dstDir is root folder
 			if dstDir.GetID() == d.RootFolderID {

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -627,8 +627,22 @@ func (d *Yun139) getPartSize(size int64) int64 {
 }
 
 func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) error {
-	switch d.Addition.Type {
-	case MetaPersonalNew:
+	// PersonalNew 以及 Group/Family 在非旧流模式时走新上传路径
+	if d.Addition.Type == MetaPersonalNew ||
+		((d.isGroup() || d.isFamily()) && !d.UseOldStreamUpload) {
+		var createPath, getUploadUrlPath, completePath string
+		if d.isGroup() || d.isFamily() {
+			// 家庭盘和小组盘共用同一套新上传 API
+			createPath = "/dynamic/file/create"
+			getUploadUrlPath = "/dynamic/file/getUploadUrl"
+			completePath = "/dynamic/file/complete"
+		} else {
+			// MetaPersonalNew
+			createPath = "/file/create"
+			getUploadUrlPath = "/file/getUploadUrl"
+			completePath = "/file/complete"
+		}
+
 		var err error
 		fullHash := stream.GetHash().GetHash(utils.SHA256)
 		if len(fullHash) != utils.SHA256.Width {
@@ -683,9 +697,8 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 			"type":                 "file",
 			"fileRenameMode":       "auto_rename",
 		}
-		pathname := "/file/create"
 		var resp PersonalUploadResp
-		_, err = d.personalPost(pathname, data, &resp)
+		_, err = d.newPost(createPath, data, &resp)
 		if err != nil {
 			return err
 		}
@@ -732,9 +745,8 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 						"accountType": 1,
 					},
 				}
-				pathname := "/file/getUploadUrl"
 				var moreresp PersonalUploadUrlResp
-				_, err = d.personalPost(pathname, moredata, &moreresp)
+				_, err = d.newPost(getUploadUrlPath, moredata, &moreresp)
 				if err != nil {
 					return err
 				}
@@ -751,7 +763,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 				"fileId":               resp.Data.FileId,
 				"uploadId":             resp.Data.UploadId,
 			}
-			_, err = d.personalPost("/file/complete", data, nil)
+			_, err = d.newPost(completePath, data, nil)
 			if err != nil {
 				return err
 			}
@@ -796,11 +808,11 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 			}
 		}
 		return nil
-	case MetaPersonal:
-		fallthrough
-	case MetaGroup:
-		fallthrough
-	case MetaFamily:
+	}
+
+	// 旧上传路径
+	switch d.Addition.Type {
+	case MetaPersonal, MetaGroup, MetaFamily:
 		// 处理冲突
 		// 获取文件列表
 		files, err := d.List(ctx, dstDir, model.ListArgs{})

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -764,7 +764,7 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 				if err != nil {
 					return err
 				}
-				err = d.uploadPersonalParts(ctx, batchPartInfos, moreresp.Data.PartInfos, ss, p)
+				err = d.uploadPersonalParts(ctx, partInfos, moreresp.Data.PartInfos, ss, p)
 				if err != nil {
 					return err
 				}

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/pkg/cron"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils/random"
+	"github.com/avast/retry-go"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -858,55 +859,84 @@ func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStr
 		}
 
 		size := stream.GetSize()
+		partSize := d.getPartSize(size)
+
 		// Progress
 		p := driver.NewProgress(size, up)
-		partSize := d.getPartSize(size)
+		rateLimited := driver.NewLimitedUploadStream(ctx, stream)
+
+		// StreamSectionReader for per-chunk buffering and retry
+		ss, err := streamPkg.NewStreamSectionReader(&streamPkg.FileStream{
+			Ctx:    ctx,
+			Reader: rateLimited,
+			Obj:    &model.Object{Size: size},
+		}, int(partSize), &up)
+		if err != nil {
+			return err
+		}
+
 		part := int64(1)
 		if size > partSize {
 			part = (size + partSize - 1) / partSize
 		}
-		rateLimited := driver.NewLimitedUploadStream(ctx, stream)
 		for i := int64(0); i < part; i++ {
 			if utils.IsCanceled(ctx) {
 				return ctx.Err()
 			}
-
 			start := i * partSize
 			byteSize := min(size-start, partSize)
 
-			limitReader := io.LimitReader(rateLimited, byteSize)
-			// Update Progress
-			r := io.TeeReader(limitReader, p)
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, resp.Data.UploadResult.RedirectionURL, r)
-			if err != nil {
-				return err
-			}
-			req.Header.Set("Content-Type", "text/plain;name="+unicode(stream.GetName()))
-			req.Header.Set("contentSize", strconv.FormatInt(size, 10))
-			req.Header.Set("range", fmt.Sprintf("bytes=%d-%d", start, start+byteSize-1))
-			req.Header.Set("uploadtaskID", resp.Data.UploadResult.UploadTaskID)
-			req.Header.Set("rangeType", "0")
-			req.ContentLength = byteSize
+			var rd io.ReadSeeker
+			err = retry.Do(
+				func() error {
+					var getErr error
+					rd, getErr = ss.GetSectionReader(start, byteSize)
+					if getErr != nil {
+						return getErr
+					}
+					rd.Seek(0, io.SeekStart)
+					req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, resp.Data.UploadResult.RedirectionURL,
+						io.TeeReader(rd, p))
+					if reqErr != nil {
+						return reqErr
+					}
+					req.Header.Set("Content-Type", "text/plain;name="+unicode(stream.GetName()))
+					req.Header.Set("contentSize", strconv.FormatInt(size, 10))
+					req.Header.Set("range", fmt.Sprintf("bytes=%d-%d", start, start+byteSize-1))
+					req.Header.Set("uploadtaskID", resp.Data.UploadResult.UploadTaskID)
+					req.Header.Set("rangeType", "0")
+					req.ContentLength = byteSize
 
-			res, err := base.HttpClient.Do(req)
+					res, doErr := base.HttpClient.Do(req)
+					if doErr != nil {
+						return doErr
+					}
+					defer res.Body.Close()
+					bodyBytes, readErr := io.ReadAll(res.Body)
+					if readErr != nil {
+						return fmt.Errorf("error reading response body: %v", readErr)
+					}
+					if res.StatusCode != http.StatusOK {
+						return fmt.Errorf("unexpected status code: %d, body: %s", res.StatusCode, string(bodyBytes))
+					}
+					var result InterLayerUploadResult
+					xmlErr := xml.Unmarshal(bodyBytes, &result)
+					if xmlErr != nil {
+						return fmt.Errorf("error parsing XML: %v", xmlErr)
+					}
+					if result.ResultCode != 0 {
+						return fmt.Errorf("upload failed with result code: %d, message: %s", result.ResultCode, result.Msg)
+					}
+					return nil
+				},
+				retry.Context(ctx),
+				retry.Attempts(10),
+				retry.DelayType(retry.BackOffDelay),
+				retry.Delay(time.Second),
+			)
+			ss.FreeSectionReader(rd)
 			if err != nil {
 				return err
-			}
-			if res.StatusCode != http.StatusOK {
-				res.Body.Close()
-				return fmt.Errorf("unexpected status code: %d", res.StatusCode)
-			}
-			bodyBytes, err := io.ReadAll(res.Body)
-			if err != nil {
-				return fmt.Errorf("error reading response body: %v", err)
-			}
-			var result InterLayerUploadResult
-			err = xml.Unmarshal(bodyBytes, &result)
-			if err != nil {
-				return fmt.Errorf("error parsing XML: %v", err)
-			}
-			if result.ResultCode != 0 {
-				return fmt.Errorf("upload failed with result code: %d, message: %s", result.ResultCode, result.Msg)
 			}
 		}
 		return nil

--- a/drivers/139/meta.go
+++ b/drivers/139/meta.go
@@ -18,6 +18,7 @@ type Addition struct {
 	CustomUploadPartSize int64  `json:"custom_upload_part_size" type:"number" default:"0" help:"0 for auto"`
 	ReportRealSize       bool   `json:"report_real_size" type:"bool" default:"true" help:"Enable to report the real file size during upload"`
 	UseLargeThumbnail    bool   `json:"use_large_thumbnail" type:"bool" default:"false" help:"Enable to use large thumbnail for images"`
+	UseOldStreamUpload   bool   `json:"use_old_stream_upload" type:"bool" default:"false" help:"Enable to use old stream upload method (not support rapid upload)"`
 }
 
 var config = driver.Config{

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -497,8 +497,7 @@ func unicode(str string) string {
 	return textUnquoted
 }
 
-func (d *Yun139) personalRequest(pathname string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
-	url := d.getPersonalCloudHost() + pathname
+func (d *Yun139) newRequest(url string, method string, callback base.ReqCallback, resp interface{}) ([]byte, error) {
 	req := base.RestyClient.R()
 	randStr := random.String(16)
 	ts := time.Now().Format("2006-01-02 15:04:05")
@@ -560,7 +559,21 @@ func (d *Yun139) personalRequest(pathname string, method string, callback base.R
 }
 
 func (d *Yun139) personalPost(pathname string, data interface{}, resp interface{}) ([]byte, error) {
-	return d.personalRequest(pathname, http.MethodPost, func(req *resty.Request) {
+	return d.newRequest(d.getFamilyCloudHost()+pathname, http.MethodPost, func(req *resty.Request) {
+		req.SetBody(data)
+	}, resp)
+}
+
+func (d *Yun139) newPost(pathname string, data interface{}, resp interface{}) ([]byte, error) {
+	var url string
+	switch d.Type {
+	case MetaFamily, MetaGroup:
+		// this is on purpose
+		url = d.getGroupCloudHost() + pathname
+	default:
+		url = d.getPersonalCloudHost() + pathname
+	}
+	return d.newRequest(url, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(data)
 	}, resp)
 }

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -734,8 +734,12 @@ func (d *Yun139) uploadPersonalParts(ctx context.Context, partInfos []PartInfo, 
 			return getErr
 		}
 
+		// Save progress before this part so retries don't double-count bytes
+		partDoneStart := p.Done
 		err := retry.Do(
 			func() error {
+				// Reset progress to the start of this part on each attempt
+				p.Done = partDoneStart
 				if _, seekErr := rd.Seek(0, io.SeekStart); seekErr != nil {
 					return seekErr
 				}

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -41,7 +41,11 @@ const (
 
 // do others that not defined in Driver interface
 func (d *Yun139) isFamily() bool {
-	return d.Type == "family"
+	return d.Type == MetaFamily
+}
+
+func (d *Yun139) isGroup() bool {
+	return d.Type == MetaGroup
 }
 
 func encodeURIComponent(str string) string {
@@ -353,6 +357,10 @@ func (d *Yun139) familyGetFiles(catalogID string) ([]model.Obj, error) {
 		}
 		// 返回的是完整的Path: root:/<UserRootID>/<CatalogID>/.../<CatalogID>
 		path := resp.Data.Path
+		if catalogID == d.RootFolderID {
+			path = ensureRootPath(d.RootPath)
+			d.RootPath = path
+		}
 		for _, catalog := range resp.Data.CloudCatalogList {
 			f := model.Object{
 				ID:       catalog.CatalogID,
@@ -1363,8 +1371,25 @@ func (d *Yun139) getGroupRootByCloudID(cloudID string) (string, error) {
 	return "", fmt.Errorf("no root found in group response")
 }
 
+// helper to strip "root:/" or "root:" prefix
+func stripRootPath(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "root:/")
+	s = strings.TrimPrefix(s, "root:")
+	return s
+}
+
+// helper to ensure "root:/" prefix
+func ensureRootPath(s string) string {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "root:") {
+		s = "root:/" + s
+	}
+	return s
+}
+
 // getFamilyRootPath 查询 family 的上层 path（data.path）
-// 返回值为完整Path
+// 返回值已去除前缀 "root:/"（或 "root:"），直接返回纯 ID 或 path 部分，便于持久化为 RootFolderID。
 func (d *Yun139) getFamilyRootPath(cloudID string) (string, error) {
 	// 使用 v1.2 接口（代码日志中已有该请求），pageSize 取 1 足够获取 path 字段
 	pathname := "/orchestration/familyCloud-rebuild/content/v1.2/queryContentList"
@@ -1394,13 +1419,13 @@ func (d *Yun139) getFamilyRootPath(cloudID string) (string, error) {
 		return "", fmt.Errorf("invalid family response data")
 	}
 	if p, ok := dataObj["path"].(string); ok && p != "" {
-		return p, nil
+		return stripRootPath(p), nil
 	}
 	// 回退：有时 path 在 cloudCatalogList.catalogList 中
 	if cl, ok := dataObj["cloudCatalogList"].([]interface{}); ok && len(cl) > 0 {
 		if first, ok := cl[0].(map[string]interface{}); ok {
 			if p, ok := first["path"].(string); ok && p != "" {
-				return p, nil
+				return stripRootPath(p), nil
 			}
 		}
 	}

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -25,8 +25,10 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
+	streamPkg "github.com/OpenListTeam/OpenList/v4/internal/stream"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils/random"
+	"github.com/avast/retry-go"
 	"github.com/go-resty/resty/v2"
 	jsoniter "github.com/json-iterator/go"
 	log "github.com/sirupsen/logrus"
@@ -698,7 +700,7 @@ func (d *Yun139) getGroupCloudHost() string {
 	return d.GroupCloudHost
 }
 
-func (d *Yun139) uploadPersonalParts(ctx context.Context, partInfos []PartInfo, uploadPartInfos []PersonalPartInfo, rateLimited *driver.RateLimitReader, p *driver.Progress) error {
+func (d *Yun139) uploadPersonalParts(ctx context.Context, partInfos []PartInfo, uploadPartInfos []PersonalPartInfo, ss streamPkg.StreamSectionReader, p *driver.Progress) error {
 	// 确保数组以 PartNumber 从小到大排序
 	sort.Slice(uploadPartInfos, func(i, j int) bool {
 		return uploadPartInfos[i].PartNumber < uploadPartInfos[j].PartNumber
@@ -710,31 +712,53 @@ func (d *Yun139) uploadPersonalParts(ctx context.Context, partInfos []PartInfo, 
 			return fmt.Errorf("invalid PartNumber %d: index out of bounds (partInfos length: %d)", uploadPartInfo.PartNumber, len(partInfos))
 		}
 		partSize := partInfos[index].PartSize
+		offset := partInfos[index].ParallelHashCtx.PartOffset
 		log.Debugf("[139] uploading part %+v/%+v", index, len(partInfos))
-		limitReader := io.LimitReader(rateLimited, partSize)
-		r := io.TeeReader(limitReader, p)
-		req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadPartInfo.UploadUrl, r)
-		if err != nil {
-			return err
-		}
-		req.Header.Set("Content-Type", "application/octet-stream")
-		req.Header.Set("Content-Length", fmt.Sprint(partSize))
-		req.Header.Set("Origin", "https://yun.139.com")
-		req.Header.Set("Referer", "https://yun.139.com/")
-		req.ContentLength = partSize
-		err = func() error {
-			res, err := base.HttpClient.Do(req)
-			if err != nil {
-				return err
-			}
-			defer res.Body.Close()
-			log.Debugf("[139] uploaded: %+v", res)
-			if res.StatusCode != http.StatusOK {
-				body, _ := io.ReadAll(res.Body)
-				return fmt.Errorf("unexpected status code: %d, body: %s", res.StatusCode, string(body))
-			}
-			return nil
-		}()
+
+		var rd io.ReadSeeker
+		err := retry.Do(
+			func() error {
+				var getErr error
+				rd, getErr = ss.GetSectionReader(offset, partSize)
+				if getErr != nil {
+					return getErr
+				}
+				_, seekErr := rd.Seek(0, io.SeekStart)
+				if seekErr != nil {
+					ss.FreeSectionReader(rd)
+					return seekErr
+				}
+				req, reqErr := http.NewRequestWithContext(ctx, http.MethodPut, uploadPartInfo.UploadUrl, io.TeeReader(rd, p))
+				if reqErr != nil {
+					ss.FreeSectionReader(rd)
+					return reqErr
+				}
+				req.Header.Set("Content-Type", "application/octet-stream")
+				req.Header.Set("Content-Length", fmt.Sprint(partSize))
+				req.Header.Set("Origin", "https://yun.139.com")
+				req.Header.Set("Referer", "https://yun.139.com/")
+				req.ContentLength = partSize
+
+				res, doErr := base.HttpClient.Do(req)
+				if doErr != nil {
+					ss.FreeSectionReader(rd)
+					return doErr
+				}
+				defer res.Body.Close()
+				log.Debugf("[139] uploaded: %+v", res)
+				if res.StatusCode != http.StatusOK {
+					body, _ := io.ReadAll(res.Body)
+					ss.FreeSectionReader(rd)
+					return fmt.Errorf("unexpected status code: %d, body: %s", res.StatusCode, string(body))
+				}
+				return nil
+			},
+			retry.Context(ctx),
+			retry.Attempts(10),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Delay(time.Second),
+		)
+		ss.FreeSectionReader(rd)
 		if err != nil {
 			return err
 		}

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -346,9 +346,9 @@ func (d *Yun139) familyGetFiles(catalogID string) ([]model.Obj, error) {
 			"sortDirection": 1,
 		})
 		// 传入 catalogID 是文件夹的ID，而不是完整路径
-		// 当传入catalogID为根目录时，不能使用 catalogID
-		if catalogID == d.RootFolderID {
-			delete(data, "catalogID")
+		// 当传入catalogID为家庭云根目录时，直接留空
+		if catalogID == d.ProviderRoot {
+			data["catalogID"] = ""
 		}
 		var resp QueryContentListResp
 		_, err := d.post("/orchestration/familyCloud-rebuild/content/v1.2/queryContentList", data, &resp)

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -357,10 +357,6 @@ func (d *Yun139) familyGetFiles(catalogID string) ([]model.Obj, error) {
 		}
 		// 返回的是完整的Path: root:/<UserRootID>/<CatalogID>/.../<CatalogID>
 		path := resp.Data.Path
-		if catalogID == d.RootFolderID {
-			path = ensureRootPath(d.RootPath)
-			d.RootPath = path
-		}
 		for _, catalog := range resp.Data.CloudCatalogList {
 			f := model.Object{
 				ID:       catalog.CatalogID,
@@ -416,9 +412,6 @@ func (d *Yun139) groupGetFiles(catalogID string) ([]model.Obj, error) {
 			return nil, err
 		}
 		path := resp.Data.GetGroupContentResult.ParentCatalogID
-		if catalogID == d.RootFolderID {
-			d.RootPath = path
-		}
 		for _, catalog := range resp.Data.GetGroupContentResult.CatalogList {
 			f := model.Object{
 				ID:       catalog.CatalogID,
@@ -1371,20 +1364,26 @@ func (d *Yun139) getGroupRootByCloudID(cloudID string) (string, error) {
 	return "", fmt.Errorf("no root found in group response")
 }
 
+// dirPath returns the full path for a directory object.
+// For family root (Path="" from framework), needs "root:/"+id prefix.
+// Non-root objects already have their API path in GetPath() from List responses.
+func (d *Yun139) dirPath(dir model.Obj) string {
+	p := dir.GetPath()
+	id := dir.GetID()
+	if p == "" {
+		if d.isFamily() {
+			return "root:/" + id
+		}
+		return id
+	}
+	return path.Join(p, id)
+}
+
 // helper to strip "root:/" or "root:" prefix
 func stripRootPath(s string) string {
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "root:/")
 	s = strings.TrimPrefix(s, "root:")
-	return s
-}
-
-// helper to ensure "root:/" prefix
-func ensureRootPath(s string) string {
-	s = strings.TrimSpace(s)
-	if !strings.HasPrefix(s, "root:") {
-		s = "root:/" + s
-	}
 	return s
 }
 

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -559,7 +559,7 @@ func (d *Yun139) newRequest(url string, method string, callback base.ReqCallback
 }
 
 func (d *Yun139) personalPost(pathname string, data interface{}, resp interface{}) ([]byte, error) {
-	return d.newRequest(d.getFamilyCloudHost()+pathname, http.MethodPost, func(req *resty.Request) {
+	return d.newRequest(d.getPersonalCloudHost()+pathname, http.MethodPost, func(req *resty.Request) {
 		req.SetBody(data)
 	}, resp)
 }

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -684,6 +684,20 @@ func (d *Yun139) getPersonalCloudHost() string {
 	return d.PersonalCloudHost
 }
 
+func (d *Yun139) getFamilyCloudHost() string {
+	if d.ref != nil {
+		return d.ref.getFamilyCloudHost()
+	}
+	return d.FamilyCloudHost
+}
+
+func (d *Yun139) getGroupCloudHost() string {
+	if d.ref != nil {
+		return d.ref.getGroupCloudHost()
+	}
+	return d.GroupCloudHost
+}
+
 func (d *Yun139) uploadPersonalParts(ctx context.Context, partInfos []PartInfo, uploadPartInfos []PersonalPartInfo, rateLimited *driver.RateLimitReader, p *driver.Progress) error {
 	// 确保数组以 PartNumber 从小到大排序
 	sort.Slice(uploadPartInfos, func(i, j int) bool {
@@ -884,7 +898,6 @@ func (d *Yun139) step2_get_single_token(sid string) (string, error) {
 	}
 
 	exchangePassidHeaders := map[string]string{
-		"Host":            "smsrebuild1.mail.10086.cn",
 		"Cookie":          rmkey,
 		"Content-Type":    "text/xml; charset=utf-8",
 		"Accept-Encoding": "gzip",
@@ -1159,7 +1172,6 @@ func (d *Yun139) step3_third_party_login(dycpwd string) (string, error) {
 		"x-UserAgent":         "android|23116PN5BC|android15|1.2.6|||1440x3200|10246600",
 		"x-DeviceInfo":        "4|127.0.0.1|5|1.2.6|Xiaomi|23116PN5BC||02-00-00-00-00-00|android 15|1440x3200|android|||",
 		"Content-Type":        "text/plain;charset=UTF-8",
-		"Host":                "user-njs.yun.139.com",
 		"Accept-Encoding":     "gzip",
 		"User-Agent":          "okhttp/3.12.2",
 	}
@@ -1240,10 +1252,9 @@ func (d *Yun139) loginWithPassword() (string, error) {
 }
 
 func (d *Yun139) andAlbumRequest(pathname string, body interface{}, resp interface{}) ([]byte, error) {
-	url := "https://group.yun.139.com/hcy/family/adapter/andAlbum/openApi" + pathname
+	url := d.getFamilyCloudHost() + "/andAlbum/openApi" + pathname
 
 	headers := map[string]string{
-		"Host":                "group.yun.139.com",
 		"authorization":       "Basic " + d.getAuthorization(),
 		"x-svctype":           "2",
 		"hcy-cool-flag":       "1",

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -716,22 +716,18 @@ func (d *Yun139) uploadPersonalParts(ctx context.Context, partInfos []PartInfo, 
 		offset := partInfos[index].ParallelHashCtx.PartOffset
 		log.Debugf("[139] uploading part %+v/%+v", index, len(partInfos))
 
-		var rd io.ReadSeeker
+		rd, getErr := ss.GetSectionReader(offset, partSize)
+		if getErr != nil {
+			return getErr
+		}
+
 		err := retry.Do(
 			func() error {
-				var getErr error
-				rd, getErr = ss.GetSectionReader(offset, partSize)
-				if getErr != nil {
-					return getErr
-				}
-				_, seekErr := rd.Seek(0, io.SeekStart)
-				if seekErr != nil {
-					ss.FreeSectionReader(rd)
+				if _, seekErr := rd.Seek(0, io.SeekStart); seekErr != nil {
 					return seekErr
 				}
 				req, reqErr := http.NewRequestWithContext(ctx, http.MethodPut, uploadPartInfo.UploadUrl, io.TeeReader(rd, p))
 				if reqErr != nil {
-					ss.FreeSectionReader(rd)
 					return reqErr
 				}
 				req.Header.Set("Content-Type", "application/octet-stream")
@@ -742,14 +738,12 @@ func (d *Yun139) uploadPersonalParts(ctx context.Context, partInfos []PartInfo, 
 
 				res, doErr := base.HttpClient.Do(req)
 				if doErr != nil {
-					ss.FreeSectionReader(rd)
 					return doErr
 				}
 				defer res.Body.Close()
 				log.Debugf("[139] uploaded: %+v", res)
 				if res.StatusCode != http.StatusOK {
 					body, _ := io.ReadAll(res.Body)
-					ss.FreeSectionReader(rd)
 					return fmt.Errorf("unexpected status code: %d, body: %s", res.StatusCode, string(body))
 				}
 				return nil

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -1379,14 +1379,6 @@ func (d *Yun139) dirPath(dir model.Obj) string {
 	return path.Join(p, id)
 }
 
-// helper to strip "root:/" or "root:" prefix
-func stripRootPath(s string) string {
-	s = strings.TrimSpace(s)
-	s = strings.TrimPrefix(s, "root:/")
-	s = strings.TrimPrefix(s, "root:")
-	return s
-}
-
 // getFamilyRootPath 查询 family 的上层 path（data.path）
 // 返回值已去除前缀 "root:/"（或 "root:"），直接返回纯 ID 或 path 部分，便于持久化为 RootFolderID。
 func (d *Yun139) getFamilyRootPath(cloudID string) (string, error) {
@@ -1417,14 +1409,21 @@ func (d *Yun139) getFamilyRootPath(cloudID string) (string, error) {
 	if dataObj == nil {
 		return "", fmt.Errorf("invalid family response data")
 	}
+	// helper to strip "root:/" or "root:" prefix
+	stripRoot := func(s string) string {
+		s = strings.TrimSpace(s)
+		s = strings.TrimPrefix(s, "root:/")
+		s = strings.TrimPrefix(s, "root:")
+		return s
+	}
 	if p, ok := dataObj["path"].(string); ok && p != "" {
-		return stripRootPath(p), nil
+		return stripRoot(p), nil
 	}
 	// 回退：有时 path 在 cloudCatalogList.catalogList 中
 	if cl, ok := dataObj["cloudCatalogList"].([]interface{}); ok && len(cl) > 0 {
 		if first, ok := cl[0].(map[string]interface{}); ok {
 			if p, ok := first["path"].(string); ok && p != "" {
-				return stripRootPath(p), nil
+				return stripRoot(p), nil
 			}
 		}
 	}

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -755,7 +755,7 @@ func (d *Yun139) uploadPersonalParts(ctx context.Context, partInfos []PartInfo, 
 				return nil
 			},
 			retry.Context(ctx),
-			retry.Attempts(10),
+			retry.Attempts(3),
 			retry.DelayType(retry.BackOffDelay),
 			retry.Delay(time.Second),
 		)

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -339,15 +339,18 @@ func (d *Yun139) familyGetFiles(catalogID string) ([]model.Obj, error) {
 			},
 			"sortDirection": 1,
 		})
+		// 传入 catalogID 是文件夹的ID，而不是完整路径
+		// 当传入catalogID为根目录时，不能使用 catalogID
+		if catalogID == d.RootFolderID {
+			delete(data, "catalogID")
+		}
 		var resp QueryContentListResp
 		_, err := d.post("/orchestration/familyCloud-rebuild/content/v1.2/queryContentList", data, &resp)
 		if err != nil {
 			return nil, err
 		}
+		// 返回的是完整的Path: root:/<UserRootID>/<CatalogID>/.../<CatalogID>
 		path := resp.Data.Path
-		if catalogID == d.RootFolderID {
-			d.RootPath = path
-		}
 		for _, catalog := range resp.Data.CloudCatalogList {
 			f := model.Object{
 				ID:       catalog.CatalogID,
@@ -1326,7 +1329,7 @@ func (d *Yun139) getGroupRootByCloudID(cloudID string) (string, error) {
 }
 
 // getFamilyRootPath 查询 family 的上层 path（data.path）
-// 返回值已去除前缀 "root:/"（或 "root:"），直接返回纯 ID 或 path 部分，便于持久化为 RootFolderID。
+// 返回值为完整Path
 func (d *Yun139) getFamilyRootPath(cloudID string) (string, error) {
 	// 使用 v1.2 接口（代码日志中已有该请求），pageSize 取 1 足够获取 path 字段
 	pathname := "/orchestration/familyCloud-rebuild/content/v1.2/queryContentList"
@@ -1355,21 +1358,14 @@ func (d *Yun139) getFamilyRootPath(cloudID string) (string, error) {
 	if dataObj == nil {
 		return "", fmt.Errorf("invalid family response data")
 	}
-	// helper to strip "root:/" or "root:" prefix
-	stripRoot := func(s string) string {
-		s = strings.TrimSpace(s)
-		s = strings.TrimPrefix(s, "root:/")
-		s = strings.TrimPrefix(s, "root:")
-		return s
-	}
 	if p, ok := dataObj["path"].(string); ok && p != "" {
-		return stripRoot(p), nil
+		return p, nil
 	}
 	// 回退：有时 path 在 cloudCatalogList.catalogList 中
 	if cl, ok := dataObj["cloudCatalogList"].([]interface{}); ok && len(cl) > 0 {
 		if first, ok := cl[0].(map[string]interface{}); ok {
 			if p, ok := first["path"].(string); ok && p != "" {
-				return stripRoot(p), nil
+				return p, nil
 			}
 		}
 	}


### PR DESCRIPTION
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->

## Summary / 摘要

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->

1. 修复139家庭云无法新建文件夹、移动、重命名
2. 优化路径处理
3. 重构为基于StreamSectionReader的上传，支持分片重试
4. 支持家庭云、共享群秒传
5. 家庭云、共享群使用新个人云的上传方式
6. 增加「使用旧版本流式上传」选项（家庭云、共享群）

说明：

官方网页版家庭云/共享群的上传方法已经改成与（新）个人云的一致，只是域名不同，已预留API URL地址请求函数，~~但老方法仍能上传，暂未实现新方法。~~ **实测老方法上传大文件会有问题，上传速度可能不如新方法。** 故统一为新方法。新方法支持秒传，但不支持流式，因此添加开关，允许用户回退到「旧版本的流式上传」。

出现这个问题是官方家庭云改用 `root:/` 前缀，之前不会拼接 root，故产生此问题。由于相关字段中包含 ID，因此使用拼接方法，不将ID直接改为Path，降低迁移成本。

目前官方共享群未使用 `root:/` 前缀，后续如果改了，直接改 `dirPath` 函数即可。

<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs: https://github.com/OpenListTeam/OpenList-Docs/pull/346

## Related Issues / 关联 Issue

<!--
Use `Closes #123`, `Fixes #123`, or `Relates to #123`.
Remove this section if not applicable.
使用 `Closes #123`、`Fixes #123` 或 `Relates to #123`。
不适用时请删除本节。
-->

## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [x] `go test ./...`
- [x] Manual test / 手动测试:

家庭云 上传 复制 移动 删除 重命名 新建文件夹，根目录和子目录均无问题

修改到的新个人云测试上传无问题

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。



## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [x] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [ ] Code generation / 代码生成
- [x] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。