### PR TITLE
feat(drivers/139): merge multiple share roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Thank you for your support and understanding of the OpenList project.
   - [x] [MediaFire](https://www.mediafire.com)
   - [x] [Mediatrack](https://www.mediatrack.cn)
   - [x] [ProtonDrive](https://proton.me/drive)
-  - [x] [139yun](https://yun.139.com) (Personal, Family, Group)
+  - [x] [139yun](https://yun.139.com) (Personal, Family, Group, Share)
   - [x] [YandexDisk](https://disk.yandex.com)
   - [x] [BaiduNetdisk](http://pan.baidu.com)
   - [x] [Terabox](https://www.terabox.com/main)

--- a/README/README_ar.md
+++ b/README/README_ar.md
@@ -50,7 +50,7 @@ OpenList has no official association with third-party derivative projects that u
   - [x] [MediaFire](https://www.mediafire.com)
   - [x] [Mediatrack](https://www.mediatrack.cn)
   - [x] [ProtonDrive](https://proton.me/drive)
-  - [x] [139yun](https://yun.139.com) (Personal, Family, Group)
+  - [x] [139yun](https://yun.139.com) (Personal, Family, Group, Share)
   - [x] [YandexDisk](https://disk.yandex.com)
   - [x] [BaiduNetdisk](http://pan.baidu.com)
   - [x] [Terabox](https://www.terabox.com/main)

--- a/README/README_cn.md
+++ b/README/README_cn.md
@@ -67,7 +67,7 @@ OpenList 是一个由 OpenList 团队独立维护的开源项目，遵循 AGPL-3
   - [x] [MediaFire](https://www.mediafire.com)
   - [x] [分秒帧](https://www.mediatrack.cn)
   - [x] [ProtonDrive](https://proton.me/drive)
-  - [x] [和彩云](https://yun.139.com)（个人、家庭、群组）
+  - [x] [和彩云](https://yun.139.com)（个人、家庭、群组、分享）
   - [x] [YandexDisk](https://disk.yandex.com)
   - [x] [百度网盘](http://pan.baidu.com)
   - [x] [Terabox](https://www.terabox.com/main)

--- a/README/README_de.md
+++ b/README/README_de.md
@@ -50,7 +50,7 @@ OpenList has no official association with third-party derivative projects that u
   - [x] [MediaFire](https://www.mediafire.com)
   - [x] [Mediatrack](https://www.mediatrack.cn)
   - [x] [ProtonDrive](https://proton.me/drive)
-  - [x] [139yun](https://yun.139.com) (Personal, Family, Group)
+  - [x] [139yun](https://yun.139.com) (Personal, Family, Group, Share)
   - [x] [YandexDisk](https://disk.yandex.com)
   - [x] [BaiduNetdisk](http://pan.baidu.com)
   - [x] [Terabox](https://www.terabox.com/main)

--- a/README/README_es.md
+++ b/README/README_es.md
@@ -50,7 +50,7 @@ OpenList has no official association with third-party derivative projects that u
   - [x] [MediaFire](https://www.mediafire.com)
   - [x] [Mediatrack](https://www.mediatrack.cn)
   - [x] [ProtonDrive](https://proton.me/drive)
-  - [x] [139yun](https://yun.139.com) (Personal, Family, Group)
+  - [x] [139yun](https://yun.139.com) (Personal, Family, Group, Share)
   - [x] [YandexDisk](https://disk.yandex.com)
   - [x] [BaiduNetdisk](http://pan.baidu.com)
   - [x] [Terabox](https://www.terabox.com/main)

--- a/README/README_fr.md
+++ b/README/README_fr.md
@@ -50,7 +50,7 @@ OpenList has no official association with third-party derivative projects that u
   - [x] [MediaFire](https://www.mediafire.com)
   - [x] [Mediatrack](https://www.mediatrack.cn)
   - [x] [ProtonDrive](https://proton.me/drive)
-  - [x] [139yun](https://yun.139.com) (Personal, Family, Group)
+  - [x] [139yun](https://yun.139.com) (Personal, Family, Group, Share)
   - [x] [YandexDisk](https://disk.yandex.com)
   - [x] [BaiduNetdisk](http://pan.baidu.com)
   - [x] [Terabox](https://www.terabox.com/main)

--- a/README/README_ja.md
+++ b/README/README_ja.md
@@ -66,7 +66,7 @@ OpenListプロジェクトへのご支援とご理解をありがとうござい
   - [x] Teambition([中国](https://www.teambition.com), [国際](https://us.teambition.com))
   - [x] [Mediatrack](https://www.mediatrack.cn)
   - [x] [ProtonDrive](https://proton.me/drive)
-  - [x] [139yun](https://yun.139.com)（個人、家族、グループ）
+  - [x] [139yun](https://yun.139.com)（個人、家族、グループ、共有）
   - [x] [YandexDisk](https://disk.yandex.com)
   - [x] [BaiduNetdisk](http://pan.baidu.com)
   - [x] [Terabox](https://www.terabox.com/main)

--- a/README/README_ko.md
+++ b/README/README_ko.md
@@ -50,7 +50,7 @@ OpenList has no official association with third-party derivative projects that u
   - [x] [MediaFire](https://www.mediafire.com)
   - [x] [Mediatrack](https://www.mediatrack.cn)
   - [x] [ProtonDrive](https://proton.me/drive)
-  - [x] [139yun](https://yun.139.com) (Personal, Family, Group)
+  - [x] [139yun](https://yun.139.com) (Personal, Family, Group, Share)
   - [x] [YandexDisk](https://disk.yandex.com)
   - [x] [BaiduNetdisk](http://pan.baidu.com)
   - [x] [Terabox](https://www.terabox.com/main)

--- a/README/README_nl.md
+++ b/README/README_nl.md
@@ -67,7 +67,7 @@ Dank u voor uw ondersteuning en begrip
   - [x] [MediaFire](https://www.mediafire.com)
   - [x] [Mediatrack](https://www.mediatrack.cn)
   - [x] [ProtonDrive](https://proton.me/drive)
-  - [x] [139yun](https://yun.139.com) (Persoonlijk, Familie, Groep)
+  - [x] [139yun](https://yun.139.com) (Persoonlijk, Familie, Groep, Delen)
   - [x] [YandexDisk](https://disk.yandex.com)
   - [x] [BaiduNetdisk](http://pan.baidu.com)
   - [x] [Terabox](https://www.terabox.com/main)

--- a/README/README_ru.md
+++ b/README/README_ru.md
@@ -50,7 +50,7 @@ OpenList has no official association with third-party derivative projects that u
   - [x] [MediaFire](https://www.mediafire.com)
   - [x] [Mediatrack](https://www.mediatrack.cn)
   - [x] [ProtonDrive](https://proton.me/drive)
-  - [x] [139yun](https://yun.139.com) (Personal, Family, Group)
+  - [x] [139yun](https://yun.139.com) (Personal, Family, Group, Share)
   - [x] [YandexDisk](https://disk.yandex.com)
   - [x] [BaiduNetdisk](http://pan.baidu.com)
   - [x] [Terabox](https://www.terabox.com/main)

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -2,12 +2,15 @@ package _139
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
@@ -35,6 +38,72 @@ type Yun139 struct {
 	ProviderRoot      string
 }
 
+type shareRef struct {
+	LinkID   string
+	Password string
+	NodeID   string
+}
+
+const multiShareRefPrefix = "shares:"
+
+func encodeShareRef(linkID, password, nodeID string) string {
+	return url.PathEscape(linkID) + "|" + url.PathEscape(password) + "|" + url.PathEscape(nodeID)
+}
+
+func decodeShareRef(id string) (shareRef, bool) {
+	parts := strings.SplitN(id, "|", 3)
+	if len(parts) != 3 {
+		return shareRef{}, false
+	}
+	linkID, err1 := url.PathUnescape(parts[0])
+	password, err2 := url.PathUnescape(parts[1])
+	nodeID, err3 := url.PathUnescape(parts[2])
+	if err1 != nil || err2 != nil || err3 != nil || linkID == "" {
+		return shareRef{}, false
+	}
+	return shareRef{LinkID: linkID, Password: password, NodeID: nodeID}, true
+}
+
+func encodeShareRefs(refs []shareRef) string {
+	if len(refs) == 1 {
+		ref := refs[0]
+		return encodeShareRef(ref.LinkID, ref.Password, ref.NodeID)
+	}
+	data, err := utils.Json.Marshal(refs)
+	if err != nil {
+		return ""
+	}
+	return multiShareRefPrefix + base64.RawURLEncoding.EncodeToString(data)
+}
+
+func decodeShareRefs(id string) ([]shareRef, bool) {
+	if !strings.HasPrefix(id, multiShareRefPrefix) {
+		ref, ok := decodeShareRef(id)
+		if !ok {
+			return nil, false
+		}
+		return []shareRef{ref}, true
+	}
+	data, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(id, multiShareRefPrefix))
+	if err != nil {
+		return nil, false
+	}
+	var refs []shareRef
+	if err = utils.Json.Unmarshal(data, &refs); err != nil || len(refs) == 0 {
+		return nil, false
+	}
+	return refs, true
+}
+
+func (d *Yun139) shareRootEntries() []shareRef {
+	entries := d.shareEntries()
+	refs := make([]shareRef, 0, len(entries))
+	for _, entry := range entries {
+		refs = append(refs, shareRef{LinkID: entry.LinkID, Password: entry.Password, NodeID: "root"})
+	}
+	return refs
+}
+
 func (d *Yun139) Config() driver.Config {
 	return config
 }
@@ -44,6 +113,26 @@ func (d *Yun139) GetAddition() driver.Additional {
 }
 
 func (d *Yun139) Init(ctx context.Context) error {
+	if d.Addition.Type == MetaShare {
+		if len(d.Addition.RootFolderID) == 0 {
+			d.RootFolderID = "root"
+		}
+		d.LinkID = d.Addition.LinkID
+		if d.ref == nil && (d.Authorization != "" || (d.Username != "" && d.Password != "")) {
+			if len(d.Authorization) == 0 {
+				log.Infof("139yun: authorization is empty, trying to login with password.")
+				newAuth, err := d.loginWithPassword()
+				log.Debugf("newAuth: Ok: %s", newAuth)
+				if err != nil {
+					return fmt.Errorf("login with password failed: %w", err)
+				}
+			}
+			if err := d.refreshToken(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 	if d.ref == nil {
 		if len(d.Authorization) == 0 {
 			if d.Username != "" && d.Password != "" {
@@ -122,6 +211,13 @@ func (d *Yun139) Init(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+	case MetaShare:
+		if len(d.Addition.RootFolderID) == 0 {
+			d.RootFolderID = "root"
+		}
+		if len(d.shareEntries()) == 0 {
+			return fmt.Errorf("link_id is empty")
+		}
 	case MetaFamily:
 		// Attempt to obtain data.path as the root via a query and persist it.
 		root, err := d.getFamilyRootPath(d.CloudID)
@@ -152,6 +248,45 @@ func (d *Yun139) InitReference(storage driver.Driver) error {
 	return errs.NotSupport
 }
 
+func (d *Yun139) Get(ctx context.Context, path string) (model.Obj, error) {
+	if d.Addition.Type != MetaShare {
+		return nil, errs.NotImplement
+	}
+	if path == "/" {
+		return &model.Object{ID: "root", Name: "root", IsFolder: true, Path: "/"}, nil
+	}
+	if obj, err := d.shareGetObj(path); err == nil {
+		return obj, nil
+	}
+	return nil, errs.ObjectNotFound
+}
+
+func (d *Yun139) shareEntries() []struct{ LinkID, Password string } {
+	raw := strings.TrimSpace(d.LinkID)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '\n' || r == '\r' || r == ',' || r == ';'
+	})
+	entries := make([]struct{ LinkID, Password string }, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		entry := struct{ LinkID, Password string }{LinkID: part}
+		if linkID, password, ok := strings.Cut(part, "#"); ok {
+			entry.LinkID = strings.TrimSpace(linkID)
+			entry.Password = strings.TrimSpace(password)
+		}
+		if entry.LinkID != "" {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
+
 func (d *Yun139) Drop(ctx context.Context) error {
 	if d.cron != nil {
 		d.cron.Stop()
@@ -170,12 +305,23 @@ func (d *Yun139) List(ctx context.Context, dir model.Obj, args model.ListArgs) (
 		return d.familyGetFiles(dir.GetID())
 	case MetaGroup:
 		return d.groupGetFiles(dir.GetID())
+	case MetaShare:
+		if dir.GetID() == "root" {
+			return d.shareGetMergedFiles(d.shareRootEntries())
+		}
+		if refs, ok := decodeShareRefs(dir.GetID()); ok {
+			return d.shareGetMergedFiles(refs)
+		}
+		return d.shareGetFilesWithRef(shareRef{LinkID: d.LinkID, NodeID: dir.GetID()}, dir.GetID())
 	default:
 		return nil, errs.NotImplement
 	}
 }
 
 func (d *Yun139) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
+	if file.IsDir() {
+		return nil, errs.NotFile
+	}
 	var url string
 	var err error
 	switch d.Addition.Type {
@@ -187,6 +333,11 @@ func (d *Yun139) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 		url, err = d.familyGetLink(file.GetID(), file.GetPath())
 	case MetaGroup:
 		url, err = d.groupGetLink(file.GetID(), file.GetPath())
+	case MetaShare:
+		if refs, ok := decodeShareRefs(file.GetID()); ok && len(refs) > 0 {
+			return d.shareGetLinkWithRef(refs[0], refs[0].NodeID, args.Type)
+		}
+		return d.shareGetLinkWithRef(shareRef{LinkID: d.LinkID, NodeID: "root"}, file.GetID(), args.Type)
 	default:
 		return nil, errs.NotImplement
 	}

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -2,12 +2,10 @@ package _139
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"path"
 	"strconv"
 	"strings"
@@ -36,72 +34,6 @@ type Yun139 struct {
 	FamilyCloudHost   string
 	GroupCloudHost    string
 	ProviderRoot      string
-}
-
-type shareRef struct {
-	LinkID   string
-	Password string
-	NodeID   string
-}
-
-const multiShareRefPrefix = "shares:"
-
-func encodeShareRef(linkID, password, nodeID string) string {
-	return url.PathEscape(linkID) + "|" + url.PathEscape(password) + "|" + url.PathEscape(nodeID)
-}
-
-func decodeShareRef(id string) (shareRef, bool) {
-	parts := strings.SplitN(id, "|", 3)
-	if len(parts) != 3 {
-		return shareRef{}, false
-	}
-	linkID, err1 := url.PathUnescape(parts[0])
-	password, err2 := url.PathUnescape(parts[1])
-	nodeID, err3 := url.PathUnescape(parts[2])
-	if err1 != nil || err2 != nil || err3 != nil || linkID == "" {
-		return shareRef{}, false
-	}
-	return shareRef{LinkID: linkID, Password: password, NodeID: nodeID}, true
-}
-
-func encodeShareRefs(refs []shareRef) string {
-	if len(refs) == 1 {
-		ref := refs[0]
-		return encodeShareRef(ref.LinkID, ref.Password, ref.NodeID)
-	}
-	data, err := utils.Json.Marshal(refs)
-	if err != nil {
-		return ""
-	}
-	return multiShareRefPrefix + base64.RawURLEncoding.EncodeToString(data)
-}
-
-func decodeShareRefs(id string) ([]shareRef, bool) {
-	if !strings.HasPrefix(id, multiShareRefPrefix) {
-		ref, ok := decodeShareRef(id)
-		if !ok {
-			return nil, false
-		}
-		return []shareRef{ref}, true
-	}
-	data, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(id, multiShareRefPrefix))
-	if err != nil {
-		return nil, false
-	}
-	var refs []shareRef
-	if err = utils.Json.Unmarshal(data, &refs); err != nil || len(refs) == 0 {
-		return nil, false
-	}
-	return refs, true
-}
-
-func (d *Yun139) shareRootEntries() []shareRef {
-	entries := d.shareEntries()
-	refs := make([]shareRef, 0, len(entries))
-	for _, entry := range entries {
-		refs = append(refs, shareRef{LinkID: entry.LinkID, Password: entry.Password, NodeID: "root"})
-	}
-	return refs
 }
 
 func (d *Yun139) Config() driver.Config {

--- a/drivers/139/driver.go
+++ b/drivers/139/driver.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"path"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
@@ -45,28 +44,8 @@ func (d *Yun139) GetAddition() driver.Additional {
 }
 
 func (d *Yun139) Init(ctx context.Context) error {
-	if d.Addition.Type == MetaShare {
-		if len(d.Addition.RootFolderID) == 0 {
-			d.RootFolderID = "root"
-		}
-		d.LinkID = d.Addition.LinkID
-		if d.ref == nil && (d.Authorization != "" || (d.Username != "" && d.Password != "")) {
-			if len(d.Authorization) == 0 {
-				log.Infof("139yun: authorization is empty, trying to login with password.")
-				newAuth, err := d.loginWithPassword()
-				log.Debugf("newAuth: Ok: %s", newAuth)
-				if err != nil {
-					return fmt.Errorf("login with password failed: %w", err)
-				}
-			}
-			if err := d.refreshToken(); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
 	if d.ref == nil {
-		if len(d.Authorization) == 0 {
+		if len(d.Authorization) == 0 && !d.isShare() {
 			if d.Username != "" && d.Password != "" {
 				log.Infof("139yun: authorization is empty, trying to login with password.")
 				newAuth, err := d.loginWithPassword()
@@ -78,53 +57,55 @@ func (d *Yun139) Init(ctx context.Context) error {
 				return fmt.Errorf("authorization is empty and username/password is not provided")
 			}
 		}
-		err := d.refreshToken()
-		if err != nil {
-			return err
-		}
-
-		// Query Route Policy
-		var resp QueryRoutePolicyResp
-		_, err = d.requestRoute(base.Json{
-			"userInfo": base.Json{
-				"userType":    1,
-				"accountType": 1,
-				"accountName": d.Account,
-			},
-			"modAddrType": 1,
-		}, &resp)
-		if err != nil {
-			return err
-		}
-		for _, policyItem := range resp.Data.RoutePolicyList {
-			switch policyItem.ModName {
-			case "personal":
-				d.PersonalCloudHost = policyItem.HttpsUrl
-			case "group":
-				d.GroupCloudHost = policyItem.HttpsUrl
-			case "family":
-				d.FamilyCloudHost = policyItem.HttpsUrl
-			}
-		}
-		if len(d.PersonalCloudHost) == 0 {
-			return fmt.Errorf("PersonalCloudHost is empty")
-		}
-		if d.isGroup() || d.isFamily() {
-			if len(d.GroupCloudHost) == 0 {
-				return fmt.Errorf("GroupCloudHost is empty")
-			}
-			if len(d.FamilyCloudHost) == 0 {
-				return fmt.Errorf("FamilyCloudHost is empty")
-			}
-		}
-
-		d.cron = cron.NewCron(time.Hour * 12)
-		d.cron.Do(func() {
+		if d.Authorization != "" {
 			err := d.refreshToken()
 			if err != nil {
-				log.Errorf("%+v", err)
+				return err
 			}
-		})
+
+			// Query Route Policy
+			var resp QueryRoutePolicyResp
+			_, err = d.requestRoute(base.Json{
+				"userInfo": base.Json{
+					"userType":    1,
+					"accountType": 1,
+					"accountName": d.Account,
+				},
+				"modAddrType": 1,
+			}, &resp)
+			if err != nil {
+				return err
+			}
+			for _, policyItem := range resp.Data.RoutePolicyList {
+				switch policyItem.ModName {
+				case "personal":
+					d.PersonalCloudHost = policyItem.HttpsUrl
+				case "group":
+					d.GroupCloudHost = policyItem.HttpsUrl
+				case "family":
+					d.FamilyCloudHost = policyItem.HttpsUrl
+				}
+			}
+			if len(d.PersonalCloudHost) == 0 {
+				return fmt.Errorf("PersonalCloudHost is empty")
+			}
+			if d.isGroup() || d.isFamily() {
+				if len(d.GroupCloudHost) == 0 {
+					return fmt.Errorf("GroupCloudHost is empty")
+				}
+				if len(d.FamilyCloudHost) == 0 {
+					return fmt.Errorf("FamilyCloudHost is empty")
+				}
+			}
+
+			d.cron = cron.NewCron(time.Hour * 12)
+			d.cron.Do(func() {
+				err := d.refreshToken()
+				if err != nil {
+					log.Errorf("%+v", err)
+				}
+			})
+		}
 	}
 	switch d.Addition.Type {
 	case MetaPersonalNew:
@@ -181,7 +162,7 @@ func (d *Yun139) InitReference(storage driver.Driver) error {
 }
 
 func (d *Yun139) Get(ctx context.Context, path string) (model.Obj, error) {
-	if d.Addition.Type != MetaShare {
+	if !d.isShare() {
 		return nil, errs.NotImplement
 	}
 	if path == "/" {
@@ -191,32 +172,6 @@ func (d *Yun139) Get(ctx context.Context, path string) (model.Obj, error) {
 		return obj, nil
 	}
 	return nil, errs.ObjectNotFound
-}
-
-func (d *Yun139) shareEntries() []struct{ LinkID, Password string } {
-	raw := strings.TrimSpace(d.LinkID)
-	if raw == "" {
-		return nil
-	}
-	parts := strings.FieldsFunc(raw, func(r rune) bool {
-		return r == '\n' || r == '\r' || r == ',' || r == ';'
-	})
-	entries := make([]struct{ LinkID, Password string }, 0, len(parts))
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		entry := struct{ LinkID, Password string }{LinkID: part}
-		if linkID, password, ok := strings.Cut(part, "#"); ok {
-			entry.LinkID = strings.TrimSpace(linkID)
-			entry.Password = strings.TrimSpace(password)
-		}
-		if entry.LinkID != "" {
-			entries = append(entries, entry)
-		}
-	}
-	return entries
 }
 
 func (d *Yun139) Drop(ctx context.Context) error {
@@ -269,7 +224,12 @@ func (d *Yun139) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 		if refs, ok := decodeShareRefs(file.GetID()); ok && len(refs) > 0 {
 			return d.shareGetLinkWithRef(refs[0], refs[0].NodeID, args.Type)
 		}
-		return d.shareGetLinkWithRef(shareRef{LinkID: d.LinkID, NodeID: "root"}, file.GetID(), args.Type)
+		fallbackRef := shareRef{LinkID: d.LinkID, NodeID: "root"}
+		if entries := d.shareEntries(); len(entries) > 0 {
+			fallbackRef.LinkID = entries[0].LinkID
+			fallbackRef.Password = entries[0].Password
+		}
+		return d.shareGetLinkWithRef(fallbackRef, file.GetID(), args.Type)
 	default:
 		return nil, errs.NotImplement
 	}
@@ -280,6 +240,9 @@ func (d *Yun139) Link(ctx context.Context, file model.Obj, args model.LinkArgs) 
 }
 
 func (d *Yun139) MakeDir(ctx context.Context, parentDir model.Obj, dirName string) error {
+	if d.isShare() {
+		return errs.NotImplement
+	}
 	var err error
 	switch d.Addition.Type {
 	case MetaPersonalNew:
@@ -337,6 +300,9 @@ func (d *Yun139) MakeDir(ctx context.Context, parentDir model.Obj, dirName strin
 }
 
 func (d *Yun139) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj, error) {
+	if d.isShare() {
+		return nil, errs.NotImplement
+	}
 	switch d.Addition.Type {
 	case MetaPersonalNew:
 		data := base.Json{
@@ -448,6 +414,9 @@ func (d *Yun139) Move(ctx context.Context, srcObj, dstDir model.Obj) (model.Obj,
 }
 
 func (d *Yun139) Rename(ctx context.Context, srcObj model.Obj, newName string) error {
+	if d.isShare() {
+		return errs.NotImplement
+	}
 	var err error
 	switch d.Addition.Type {
 	case MetaPersonalNew:
@@ -557,6 +526,9 @@ func (d *Yun139) Rename(ctx context.Context, srcObj model.Obj, newName string) e
 }
 
 func (d *Yun139) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
+	if d.isShare() {
+		return errs.NotImplement
+	}
 	var err error
 	switch d.Addition.Type {
 	case MetaPersonalNew:
@@ -626,6 +598,9 @@ func (d *Yun139) Copy(ctx context.Context, srcObj, dstDir model.Obj) error {
 }
 
 func (d *Yun139) Remove(ctx context.Context, obj model.Obj) error {
+	if d.isShare() {
+		return errs.NotImplement
+	}
 	switch d.Addition.Type {
 	case MetaPersonalNew:
 		data := base.Json{
@@ -716,6 +691,9 @@ func (d *Yun139) getPartSize(size int64) int64 {
 }
 
 func (d *Yun139) Put(ctx context.Context, dstDir model.Obj, stream model.FileStreamer, up driver.UpdateProgress) error {
+	if d.isShare() {
+		return errs.NotImplement
+	}
 	// PersonalNew 以及 Group/Family 在非旧流模式时走新上传路径
 	if d.Addition.Type == MetaPersonalNew ||
 		((d.isGroup() || d.isFamily()) && !d.UseOldStreamUpload) {

--- a/drivers/139/meta.go
+++ b/drivers/139/meta.go
@@ -12,7 +12,8 @@ type Addition struct {
 	Password      string `json:"password" required:"true" secret:"true"`
 	MailCookies   string `json:"mail_cookies" required:"true" type:"text" help:"Cookies from mail.139.com used for login authentication."`
 	driver.RootID
-	Type                 string `json:"type" type:"select" options:"personal_new,family,group,personal" default:"personal_new"`
+	Type                 string `json:"type" type:"select" options:"personal_new,family,group,personal,share" default:"personal_new"`
+	LinkID               string `json:"link_id" type:"text" help:"Multiple shares are separated by commas or new lines. Use link_id#password for password-protected shares."`
 	CloudID              string `json:"cloud_id"`
 	UserDomainID         string `json:"user_domain_id" help:"ud_id in Cookie, fill in to show disk usage"`
 	CustomUploadPartSize int64  `json:"custom_upload_part_size" type:"number" default:"0" help:"0 for auto"`

--- a/drivers/139/share_test.go
+++ b/drivers/139/share_test.go
@@ -1,0 +1,35 @@
+package _139
+
+import (
+	"testing"
+)
+
+func TestShareEntriesAndRefEncoding(t *testing.T) {
+	d := &Yun139{Addition: Addition{
+		Type:   MetaShare,
+		LinkID: "2w2KLTrz2Y8bd,2uR1zFho3YNcj,2w2KLzpSwt57p#f95e",
+	}}
+
+	entries := d.shareEntries()
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 share entries, got %d", len(entries))
+	}
+	if entries[2].LinkID != "2w2KLzpSwt57p" || entries[2].Password != "f95e" {
+		t.Fatalf("unexpected password share entry: %+v", entries[2])
+	}
+
+	refs := []shareRef{
+		{LinkID: entries[0].LinkID, Password: entries[0].Password, NodeID: "root-a"},
+		{LinkID: entries[2].LinkID, Password: entries[2].Password, NodeID: "root-b"},
+	}
+	encoded := encodeShareRefs(refs)
+	decoded, ok := decodeShareRefs(encoded)
+	if !ok || len(decoded) != len(refs) {
+		t.Fatalf("failed to decode merged share refs: %q", encoded)
+	}
+	for i := range refs {
+		if decoded[i] != refs[i] {
+			t.Fatalf("unexpected decoded ref at %d: %+v", i, decoded[i])
+		}
+	}
+}

--- a/drivers/139/share_test.go
+++ b/drivers/139/share_test.go
@@ -7,14 +7,14 @@ import (
 func TestShareEntriesAndRefEncoding(t *testing.T) {
 	d := &Yun139{Addition: Addition{
 		Type:   MetaShare,
-		LinkID: "2w2KLTrz2Y8bd,2uR1zFho3YNcj,2w2KLzpSwt57p#f95e",
+		LinkID: "share-a,share-b,share-c#pass",
 	}}
 
 	entries := d.shareEntries()
 	if len(entries) != 3 {
 		t.Fatalf("expected 3 share entries, got %d", len(entries))
 	}
-	if entries[2].LinkID != "2w2KLzpSwt57p" || entries[2].Password != "f95e" {
+	if entries[2].LinkID != "share-c" || entries[2].Password != "pass" {
 		t.Fatalf("unexpected password share entry: %+v", entries[2])
 	}
 

--- a/drivers/139/types.go
+++ b/drivers/139/types.go
@@ -9,6 +9,7 @@ const (
 	MetaFamily      string = "family"
 	MetaGroup       string = "group"
 	MetaPersonalNew string = "personal_new"
+	MetaShare       string = "share"
 )
 
 type BaseResp struct {
@@ -283,6 +284,56 @@ type PersonalUploadUrlResp struct {
 		UploadId  string             `json:"uploadId"`
 		PartInfos []PersonalPartInfo `json:"partInfos"`
 	}
+}
+
+type ShareCatalog struct {
+	CaID   string `json:"caId"`
+	CaName string `json:"caName"`
+	UdTime string `json:"udTime"`
+}
+
+type ShareContent struct {
+	CoID        string `json:"coId"`
+	CoName      string `json:"coName"`
+	CoSize      int64  `json:"coSize"`
+	CoType      int    `json:"coType"`
+	UdTime      string `json:"udTime"`
+	CoPath      string `json:"coPath"`
+	PresentURL  string `json:"presentURL"`
+	DownloadURL string `json:"downloadURL"`
+}
+
+type ShareListResp struct {
+	BaseResp
+	Data struct {
+		LKName string         `json:"lkName"`
+		Passwd string         `json:"password"`
+		CaLst  []ShareCatalog `json:"caLst"`
+		CoLst  []ShareContent `json:"coLst"`
+	} `json:"data"`
+}
+
+type ShareContentInfo struct {
+	PresentURL  string `json:"presentURL"`
+	DownloadURL string `json:"cdnDownLoadUrl"`
+}
+
+type ShareDownloadResp struct {
+	BaseResp
+	Data struct {
+		DownloadURL string `json:"downloadURL"`
+		RedrURL     string `json:"redrUrl"`
+		ExtInfo     struct {
+			CDNDownloadURL string `json:"cdnDownloadUrl"`
+		} `json:"extInfo"`
+	} `json:"data"`
+}
+
+type ShareContentInfoResp struct {
+	BaseResp
+	Data struct {
+		ContentInfo ShareContentInfo `json:"contentInfo"`
+	} `json:"data"`
 }
 
 type QueryRoutePolicyResp struct {

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -2,7 +2,6 @@ package _139
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
@@ -48,6 +47,10 @@ func (d *Yun139) isFamily() bool {
 
 func (d *Yun139) isGroup() bool {
 	return d.Type == MetaGroup
+}
+
+func (d *Yun139) isShare() bool {
+	return d.Type == MetaShare
 }
 
 func encodeURIComponent(str string) string {
@@ -493,15 +496,9 @@ func (d *Yun139) groupGetLink(contentId string, path string) (string, error) {
 	return jsoniter.Get(res, "data", "downloadURL").ToString(), nil
 }
 
-func (d *Yun139) sharePost(pathname string, data interface{}, resp interface{}) ([]byte, error) {
-	crypto := NewYunCrypto()
-	encryptedBody, err := crypto.Encrypt(data)
-	if err != nil {
-		return nil, err
-	}
+var shareAesKeyHex = hex.EncodeToString([]byte("PVGDwmcvfs1uV3d1"))
 
-	url := "https://share-kd-njs.yun.139.com" + pathname
-	req := base.RestyClient.R()
+func (d *Yun139) shareHeaders() map[string]string {
 	auth := d.getAuthorization()
 	if auth != "" && !strings.HasPrefix(strings.ToLower(auth), "basic ") {
 		auth = "Basic " + auth
@@ -510,7 +507,7 @@ func (d *Yun139) sharePost(pathname string, data interface{}, resp interface{}) 
 		"User-Agent":        "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0",
 		"Accept":            "application/json, text/plain, */*",
 		"Content-Type":      "application/json;charset=UTF-8",
-		"X-Deviceinfo":      "||9|12.27.0|firefox|140.0|12b780037221ab547c682223327dc9cd||linux unknow|1920X526|zh-CN|||",
+		"X-Deviceinfo":      "||9|12.27.0|firefox|140.0|||linux unknow|1920X526|zh-CN|||",
 		"hcy-cool-flag":     "1",
 		"CMS-DEVICE":        "default",
 		"x-m4c-caller":      "PC",
@@ -521,30 +518,12 @@ func (d *Yun139) sharePost(pathname string, data interface{}, resp interface{}) 
 	if auth != "" {
 		headers["Authorization"] = auth
 	}
-	req.SetHeaders(headers)
-	req.SetBody(encryptedBody)
-
-	res, err := req.Post(url)
-	if err != nil {
-		return nil, err
-	}
-
-	decryptedText, err := crypto.Decrypt(res.String())
-	if err != nil {
-		log.Errorf("[139Share] Decryption failed, raw response: %s", res.String())
-		return nil, fmt.Errorf("decryption failed: %v, raw: %s", err, res.String())
-	}
-
-	if resp != nil {
-		if err = utils.Json.Unmarshal([]byte(decryptedText), resp); err != nil {
-			return nil, err
-		}
-	}
-	return []byte(decryptedText), nil
+	return headers
 }
 
-func (d *Yun139) shareGetFiles(pCaID string) ([]model.Obj, error) {
-	return d.shareGetFilesWithRef(shareRef{LinkID: d.Addition.LinkID, NodeID: pCaID}, pCaID)
+func (d *Yun139) sharePost(pathname string, data interface{}, resp interface{}) ([]byte, error) {
+	url := "https://share-kd-njs.yun.139.com/yun-share" + pathname
+	return d.yun139EncryptedRequest(url, data, d.shareHeaders(), shareAesKeyHex, resp)
 }
 
 type shareRef struct {
@@ -604,6 +583,32 @@ func decodeShareRefs(id string) ([]shareRef, bool) {
 	return refs, true
 }
 
+func (d *Yun139) shareEntries() []struct{ LinkID, Password string } {
+	raw := strings.TrimSpace(d.LinkID)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '\n' || r == '\r' || r == ',' || r == ';'
+	})
+	entries := make([]struct{ LinkID, Password string }, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		entry := struct{ LinkID, Password string }{LinkID: part}
+		if linkID, password, ok := strings.Cut(part, "#"); ok {
+			entry.LinkID = strings.TrimSpace(linkID)
+			entry.Password = strings.TrimSpace(password)
+		}
+		if entry.LinkID != "" {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
+
 func (d *Yun139) shareRootEntries() []shareRef {
 	entries := d.shareEntries()
 	refs := make([]shareRef, 0, len(entries))
@@ -629,7 +634,7 @@ func (d *Yun139) shareGetFilesWithRef(ref shareRef, pCaID string) ([]model.Obj, 
 		},
 	}
 	var resp ShareListResp
-	_, err := d.sharePost("/yun-share/richlifeApp/devapp/IOutLink/getOutLinkInfoV6", data, &resp)
+	_, err := d.sharePost("/richlifeApp/devapp/IOutLink/getOutLinkInfoV6", data, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -749,10 +754,6 @@ func (d *Yun139) shareGetObj(reqPath string) (model.Obj, error) {
 	return currentObj, nil
 }
 
-func (d *Yun139) shareGetLink(coID string, linkType string) (*model.Link, error) {
-	return d.shareGetLinkWithRef(shareRef{LinkID: d.Addition.LinkID, NodeID: "root"}, coID, linkType)
-}
-
 func (d *Yun139) shareGetLinkWithRef(ref shareRef, coID string, linkType string) (*model.Link, error) {
 	data := base.Json{
 		"getContentInfoFromOutLinkReq": base.Json{
@@ -763,7 +764,7 @@ func (d *Yun139) shareGetLinkWithRef(ref shareRef, coID string, linkType string)
 		},
 	}
 	var resp ShareContentInfoResp
-	body, err := d.sharePost("/yun-share/richlifeApp/devapp/IOutLink/getContentInfoFromOutLink", data, &resp)
+	body, err := d.sharePost("/richlifeApp/devapp/IOutLink/getContentInfoFromOutLink", data, &resp)
 	if err != nil {
 		return nil, err
 	}
@@ -794,7 +795,7 @@ func (d *Yun139) shareGetLinkWithRef(ref shareRef, coID string, linkType string)
 		},
 	}
 	var downloadResp ShareDownloadResp
-	downloadBody, err := d.sharePost("/yun-share/richlifeApp/devapp/IOutLink/dlFromOutLinkV3", downloadReq, &downloadResp)
+	downloadBody, err := d.sharePost("/richlifeApp/devapp/IOutLink/dlFromOutLinkV3", downloadReq, &downloadResp)
 	if err != nil {
 		return nil, err
 	}
@@ -1367,71 +1368,6 @@ func aesCbcDecrypt(ciphertext []byte, key []byte, iv []byte) ([]byte, error) {
 	mode := cipher.NewCBCDecrypter(block, iv)
 	mode.CryptBlocks(decrypted, ciphertext)
 	return pkcs7_unpad(decrypted)
-}
-
-type YunCrypto struct {
-	Key       []byte
-	BlockSize int
-}
-
-func NewYunCrypto() *YunCrypto {
-	return &YunCrypto{
-		Key:       []byte("PVGDwmcvfs1uV3d1"),
-		BlockSize: aes.BlockSize,
-	}
-}
-
-func (y *YunCrypto) Encrypt(data interface{}) (string, error) {
-	jsonData, err := utils.Json.Marshal(data)
-	if err != nil {
-		return "", err
-	}
-	iv := make([]byte, y.BlockSize)
-	if _, err := io.ReadFull(crypto_rand.Reader, iv); err != nil {
-		return "", err
-	}
-	ciphertext, err := aesCbcEncrypt(jsonData, y.Key, iv)
-	if err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(append(iv, ciphertext...)), nil
-}
-
-func (y *YunCrypto) Decrypt(b64Data string) (string, error) {
-	b64Data = strings.Join(strings.Fields(b64Data), "")
-	raw, err := base64.StdEncoding.DecodeString(b64Data)
-	if err != nil {
-		return "", err
-	}
-	if len(raw) < y.BlockSize {
-		return "", errors.New("data too short")
-	}
-	iv := raw[:y.BlockSize]
-	ciphertext := raw[y.BlockSize:]
-	decrypted, err := aesCbcDecrypt(ciphertext, y.Key, iv)
-	if err != nil {
-		if len(ciphertext)%aes.BlockSize != 0 {
-			return "", err
-		}
-		block, blockErr := aes.NewCipher(y.Key)
-		if blockErr != nil {
-			return "", blockErr
-		}
-		decrypted = make([]byte, len(ciphertext))
-		cipher.NewCBCDecrypter(block, iv).CryptBlocks(decrypted, ciphertext)
-		decrypted = []byte(strings.TrimSpace(string(decrypted)))
-	}
-	if len(decrypted) > 2 && decrypted[0] == 0x1f && decrypted[1] == 0x8b {
-		reader, err := gzip.NewReader(bytes.NewReader(decrypted))
-		if err == nil {
-			defer reader.Close()
-			unzipped, err := io.ReadAll(reader)
-			if err == nil {
-				return string(unzipped), nil
-			}
-		}
-	}
-	return string(decrypted), nil
 }
 
 // sortedJsonStringify 对 JSON 对象进行排序并字符串化。

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -547,6 +547,72 @@ func (d *Yun139) shareGetFiles(pCaID string) ([]model.Obj, error) {
 	return d.shareGetFilesWithRef(shareRef{LinkID: d.Addition.LinkID, NodeID: pCaID}, pCaID)
 }
 
+type shareRef struct {
+	LinkID   string
+	Password string
+	NodeID   string
+}
+
+const multiShareRefPrefix = "shares:"
+
+func encodeShareRef(linkID, password, nodeID string) string {
+	return url.PathEscape(linkID) + "|" + url.PathEscape(password) + "|" + url.PathEscape(nodeID)
+}
+
+func decodeShareRef(id string) (shareRef, bool) {
+	parts := strings.SplitN(id, "|", 3)
+	if len(parts) != 3 {
+		return shareRef{}, false
+	}
+	linkID, err1 := url.PathUnescape(parts[0])
+	password, err2 := url.PathUnescape(parts[1])
+	nodeID, err3 := url.PathUnescape(parts[2])
+	if err1 != nil || err2 != nil || err3 != nil || linkID == "" {
+		return shareRef{}, false
+	}
+	return shareRef{LinkID: linkID, Password: password, NodeID: nodeID}, true
+}
+
+func encodeShareRefs(refs []shareRef) string {
+	if len(refs) == 1 {
+		ref := refs[0]
+		return encodeShareRef(ref.LinkID, ref.Password, ref.NodeID)
+	}
+	data, err := utils.Json.Marshal(refs)
+	if err != nil {
+		return ""
+	}
+	return multiShareRefPrefix + base64.RawURLEncoding.EncodeToString(data)
+}
+
+func decodeShareRefs(id string) ([]shareRef, bool) {
+	if !strings.HasPrefix(id, multiShareRefPrefix) {
+		ref, ok := decodeShareRef(id)
+		if !ok {
+			return nil, false
+		}
+		return []shareRef{ref}, true
+	}
+	data, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(id, multiShareRefPrefix))
+	if err != nil {
+		return nil, false
+	}
+	var refs []shareRef
+	if err = utils.Json.Unmarshal(data, &refs); err != nil || len(refs) == 0 {
+		return nil, false
+	}
+	return refs, true
+}
+
+func (d *Yun139) shareRootEntries() []shareRef {
+	entries := d.shareEntries()
+	refs := make([]shareRef, 0, len(entries))
+	for _, entry := range entries {
+		refs = append(refs, shareRef{LinkID: entry.LinkID, Password: entry.Password, NodeID: "root"})
+	}
+	return refs
+}
+
 func (d *Yun139) shareGetFilesWithRef(ref shareRef, pCaID string) ([]model.Obj, error) {
 	if ref.NodeID == "" {
 		ref.NodeID = "root"

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -2,6 +2,7 @@ package _139
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
 	streamPkg "github.com/OpenListTeam/OpenList/v4/internal/stream"
@@ -489,6 +491,257 @@ func (d *Yun139) groupGetLink(contentId string, path string) (string, error) {
 		return "", err
 	}
 	return jsoniter.Get(res, "data", "downloadURL").ToString(), nil
+}
+
+func (d *Yun139) sharePost(pathname string, data interface{}, resp interface{}) ([]byte, error) {
+	crypto := NewYunCrypto()
+	encryptedBody, err := crypto.Encrypt(data)
+	if err != nil {
+		return nil, err
+	}
+
+	url := "https://share-kd-njs.yun.139.com" + pathname
+	req := base.RestyClient.R()
+	auth := d.getAuthorization()
+	if auth != "" && !strings.HasPrefix(strings.ToLower(auth), "basic ") {
+		auth = "Basic " + auth
+	}
+	headers := map[string]string{
+		"User-Agent":        "Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0",
+		"Accept":            "application/json, text/plain, */*",
+		"Content-Type":      "application/json;charset=UTF-8",
+		"X-Deviceinfo":      "||9|12.27.0|firefox|140.0|12b780037221ab547c682223327dc9cd||linux unknow|1920X526|zh-CN|||",
+		"hcy-cool-flag":     "1",
+		"CMS-DEVICE":        "default",
+		"x-m4c-caller":      "PC",
+		"X-Yun-Api-Version": "v1",
+		"Origin":            "https://yun.139.com",
+		"Referer":           "https://yun.139.com/",
+	}
+	if auth != "" {
+		headers["Authorization"] = auth
+	}
+	req.SetHeaders(headers)
+	req.SetBody(encryptedBody)
+
+	res, err := req.Post(url)
+	if err != nil {
+		return nil, err
+	}
+
+	decryptedText, err := crypto.Decrypt(res.String())
+	if err != nil {
+		log.Errorf("[139Share] Decryption failed, raw response: %s", res.String())
+		return nil, fmt.Errorf("decryption failed: %v, raw: %s", err, res.String())
+	}
+
+	if resp != nil {
+		if err = utils.Json.Unmarshal([]byte(decryptedText), resp); err != nil {
+			return nil, err
+		}
+	}
+	return []byte(decryptedText), nil
+}
+
+func (d *Yun139) shareGetFiles(pCaID string) ([]model.Obj, error) {
+	return d.shareGetFilesWithRef(shareRef{LinkID: d.Addition.LinkID, NodeID: pCaID}, pCaID)
+}
+
+func (d *Yun139) shareGetFilesWithRef(ref shareRef, pCaID string) ([]model.Obj, error) {
+	if ref.NodeID == "" {
+		ref.NodeID = "root"
+	}
+	if pCaID == "" {
+		pCaID = ref.NodeID
+	}
+	data := base.Json{
+		"getOutLinkInfoReq": base.Json{
+			"account": d.getAccount(),
+			"linkID":  ref.LinkID,
+			"passwd":  ref.Password,
+			"pCaID":   pCaID,
+		},
+	}
+	var resp ShareListResp
+	_, err := d.sharePost("/yun-share/richlifeApp/devapp/IOutLink/getOutLinkInfoV6", data, &resp)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]model.Obj, 0)
+	for _, catalog := range resp.Data.CaLst {
+		modTime, _ := time.ParseInLocation("20060102150405", catalog.UdTime, utils.CNLoc)
+		f := model.Object{
+			ID:       encodeShareRef(ref.LinkID, ref.Password, catalog.CaID),
+			Name:     catalog.CaName,
+			Modified: modTime,
+			IsFolder: true,
+		}
+		files = append(files, &f)
+	}
+	for _, content := range resp.Data.CoLst {
+		name := content.CoName
+		size := content.CoSize
+		modTime, _ := time.ParseInLocation("20060102150405", content.UdTime, utils.CNLoc)
+		f := model.Object{
+			ID:       encodeShareRef(ref.LinkID, ref.Password, content.CoID),
+			Name:     name,
+			Size:     size,
+			Modified: modTime,
+		}
+		files = append(files, &f)
+	}
+
+	return files, nil
+}
+
+func (d *Yun139) shareGetMergedFiles(refs []shareRef) ([]model.Obj, error) {
+	files := make([]model.Obj, 0)
+	indices := make(map[string]int)
+	var firstErr error
+	for _, ref := range refs {
+		items, err := d.shareGetFilesWithRef(ref, ref.NodeID)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		for _, item := range items {
+			idx, exists := indices[item.GetName()]
+			if !exists {
+				indices[item.GetName()] = len(files)
+				files = append(files, item)
+				continue
+			}
+			if !files[idx].IsDir() || !item.IsDir() {
+				continue
+			}
+			existingRefs, ok1 := decodeShareRefs(files[idx].GetID())
+			itemRefs, ok2 := decodeShareRefs(item.GetID())
+			if !ok1 || !ok2 {
+				continue
+			}
+			mergedRefs := append(existingRefs, itemRefs...)
+			files[idx] = &model.Object{
+				ID:       encodeShareRefs(mergedRefs),
+				Name:     item.GetName(),
+				Modified: item.ModTime(),
+				IsFolder: true,
+			}
+		}
+	}
+	if len(files) == 0 && firstErr != nil {
+		return nil, firstErr
+	}
+	return files, nil
+}
+
+func (d *Yun139) shareGetObj(reqPath string) (model.Obj, error) {
+	reqPath = utils.FixAndCleanPath(reqPath)
+	if reqPath == "/" {
+		return &model.Object{ID: "root", Name: "root", IsFolder: true, Path: "/"}, nil
+	}
+	parts := strings.Split(strings.Trim(reqPath, "/"), "/")
+	currentRefs := d.shareRootEntries()
+	currentPath := ""
+	var currentObj model.Obj
+	for idx, part := range parts {
+		items, err := d.shareGetMergedFiles(currentRefs)
+		if err != nil {
+			return nil, err
+		}
+		matched := false
+		for _, item := range items {
+			if item.GetName() != part {
+				continue
+			}
+			matched = true
+			currentObj = item
+			currentPath = path.Join(currentPath, item.GetName())
+			if item.IsDir() {
+				itemRefs, ok := decodeShareRefs(item.GetID())
+				if !ok {
+					return nil, errs.ObjectNotFound
+				}
+				currentRefs = itemRefs
+				break
+			}
+			if idx != len(parts)-1 {
+				return nil, errs.ObjectNotFound
+			}
+		}
+		if !matched {
+			return nil, errs.ObjectNotFound
+		}
+	}
+	if currentObj == nil {
+		return nil, errs.ObjectNotFound
+	}
+	if setter, ok := currentObj.(model.SetPath); ok {
+		setter.SetPath(currentPath)
+	}
+	return currentObj, nil
+}
+
+func (d *Yun139) shareGetLink(coID string, linkType string) (*model.Link, error) {
+	return d.shareGetLinkWithRef(shareRef{LinkID: d.Addition.LinkID, NodeID: "root"}, coID, linkType)
+}
+
+func (d *Yun139) shareGetLinkWithRef(ref shareRef, coID string, linkType string) (*model.Link, error) {
+	data := base.Json{
+		"getContentInfoFromOutLinkReq": base.Json{
+			"contentId": coID,
+			"linkID":    ref.LinkID,
+			"passwd":    ref.Password,
+			"account":   d.getAccount(),
+		},
+	}
+	var resp ShareContentInfoResp
+	body, err := d.sharePost("/yun-share/richlifeApp/devapp/IOutLink/getContentInfoFromOutLink", data, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	res := resp.Data.ContentInfo
+	if linkType == "video_preview" || linkType == "preview" || linkType == "thumb" {
+		if res.PresentURL == "" {
+			return nil, fmt.Errorf("failed to get preview link")
+		}
+		return &model.Link{URL: res.PresentURL}, nil
+	}
+
+	if d.getAccount() == "" {
+		return nil, fmt.Errorf("139 share download requires account authentication")
+	}
+
+	downloadReq := base.Json{
+		"dlFromOutLinkReqV3": base.Json{
+			"account": d.getAccount(),
+			"linkID":  ref.LinkID,
+			"passwd":  ref.Password,
+			"coIDLst": base.Json{
+				"item": []string{coID},
+			},
+		},
+	}
+	var downloadResp ShareDownloadResp
+	downloadBody, err := d.sharePost("/yun-share/richlifeApp/devapp/IOutLink/dlFromOutLinkV3", downloadReq, &downloadResp)
+	if err != nil {
+		return nil, err
+	}
+	if downloadResp.Data.ExtInfo.CDNDownloadURL != "" {
+		return &model.Link{URL: downloadResp.Data.ExtInfo.CDNDownloadURL}, nil
+	}
+	if downloadResp.Data.RedrURL != "" {
+		return &model.Link{URL: downloadResp.Data.RedrURL}, nil
+	}
+	if downloadResp.Data.DownloadURL != "" {
+		return &model.Link{URL: downloadResp.Data.DownloadURL}, nil
+	}
+
+	log.Debugf("[139Share] content info without embedded download url: %s", string(body))
+	log.Debugf("[139Share] download response without direct url: %s", string(downloadBody))
+	return nil, fmt.Errorf("failed to get link")
 }
 
 func unicode(str string) string {
@@ -1045,6 +1298,71 @@ func aesCbcDecrypt(ciphertext []byte, key []byte, iv []byte) ([]byte, error) {
 	mode := cipher.NewCBCDecrypter(block, iv)
 	mode.CryptBlocks(decrypted, ciphertext)
 	return pkcs7_unpad(decrypted)
+}
+
+type YunCrypto struct {
+	Key       []byte
+	BlockSize int
+}
+
+func NewYunCrypto() *YunCrypto {
+	return &YunCrypto{
+		Key:       []byte("PVGDwmcvfs1uV3d1"),
+		BlockSize: aes.BlockSize,
+	}
+}
+
+func (y *YunCrypto) Encrypt(data interface{}) (string, error) {
+	jsonData, err := utils.Json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	iv := make([]byte, y.BlockSize)
+	if _, err := io.ReadFull(crypto_rand.Reader, iv); err != nil {
+		return "", err
+	}
+	ciphertext, err := aesCbcEncrypt(jsonData, y.Key, iv)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(append(iv, ciphertext...)), nil
+}
+
+func (y *YunCrypto) Decrypt(b64Data string) (string, error) {
+	b64Data = strings.Join(strings.Fields(b64Data), "")
+	raw, err := base64.StdEncoding.DecodeString(b64Data)
+	if err != nil {
+		return "", err
+	}
+	if len(raw) < y.BlockSize {
+		return "", errors.New("data too short")
+	}
+	iv := raw[:y.BlockSize]
+	ciphertext := raw[y.BlockSize:]
+	decrypted, err := aesCbcDecrypt(ciphertext, y.Key, iv)
+	if err != nil {
+		if len(ciphertext)%aes.BlockSize != 0 {
+			return "", err
+		}
+		block, blockErr := aes.NewCipher(y.Key)
+		if blockErr != nil {
+			return "", blockErr
+		}
+		decrypted = make([]byte, len(ciphertext))
+		cipher.NewCBCDecrypter(block, iv).CryptBlocks(decrypted, ciphertext)
+		decrypted = []byte(strings.TrimSpace(string(decrypted)))
+	}
+	if len(decrypted) > 2 && decrypted[0] == 0x1f && decrypted[1] == 0x8b {
+		reader, err := gzip.NewReader(bytes.NewReader(decrypted))
+		if err == nil {
+			defer reader.Close()
+			unzipped, err := io.ReadAll(reader)
+			if err == nil {
+				return string(unzipped), nil
+			}
+		}
+	}
+	return string(decrypted), nil
 }
 
 // sortedJsonStringify 对 JSON 对象进行排序并字符串化。

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -711,6 +711,9 @@ func (d *Yun139) shareGetLinkWithRef(ref shareRef, coID string, linkType string)
 	}
 
 	if d.getAccount() == "" {
+		if res.PresentURL != "" {
+			return &model.Link{URL: res.PresentURL}, nil
+		}
 		return nil, fmt.Errorf("139 share download requires account authentication")
 	}
 


### PR DESCRIPTION
## Summary / 摘要

- Support multiple 139 share link ids in `share` mode.
- Support password form `link_id#password`.
- Merge multiple share roots into one root listing instead of showing raw share ids.
- Keep preview and download behavior as 302 redirects.
- Add regression tests for multi-share parsing and reference encoding.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs: https://github.com/OpenListTeam/OpenList-Docs/pull/346

## Related Issues / 关联 Issue

N/A

## Testing / 测试

- [x] `GOTOOLCHAIN=local go test ./drivers/139`
- [x] Manual test / 手动测试: verified merged share root listing and direct 302 preview/download behavior in source-mode local run

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [x] Codex

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [x] Tests / 测试
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
