### PR TITLE
fix(drivers/189pc,drivers/189tv): fix extra requests when viewing files

### DIFF
--- a/drivers/189_tv/utils.go
+++ b/drivers/189_tv/utils.go
@@ -218,13 +218,22 @@ func (y *Cloud189TV) getFiles(ctx context.Context, fileId string, isFamily bool)
 		if resp.FileListAO.Count == 0 {
 			break
 		}
+		
+		FolderCount := len(resp.FileListAO.FolderList) // 当前文件夹总数
+        FileCount := len(resp.FileListAO.FileList) // 当前文件总数
+        PageCount := FolderCount + FileCount // 当前页数总数
 
-		for i := 0; i < len(resp.FileListAO.FolderList); i++ {
+		for i := 0; i < FolderCount; i++ {
 			res = append(res, &resp.FileListAO.FolderList[i])
 		}
-		for i := 0; i < len(resp.FileListAO.FileList); i++ {
+		for i := 0; i < FileCount; i++ {
 			res = append(res, &resp.FileListAO.FileList[i])
 		}
+		
+		// 文件数量小于130则跳出
+		if PageCount < 130 {
+            break
+        }
 	}
 	return res, nil
 }

--- a/drivers/189_tv/utils.go
+++ b/drivers/189_tv/utils.go
@@ -184,6 +184,7 @@ func (y *Cloud189TV) getFiles(ctx context.Context, fileId string, isFamily bool)
 	}
 	fullUrl += "/listFiles.action"
 
+    pageSize := 130  // 每一页返回的文件数量
 	res := make([]model.Obj, 0, 130)
 	for pageNum := 1; ; pageNum++ {
 		var resp Cloud189FilesResp
@@ -195,7 +196,7 @@ func (y *Cloud189TV) getFiles(ctx context.Context, fileId string, isFamily bool)
 				"mediaAttr":  "0",
 				"iconOption": "5",
 				"pageNum":    fmt.Sprint(pageNum),
-				"pageSize":   "130",
+				"pageSize":   fmt.Sprint(pageSize),
 			})
 			if isFamily {
 				r.SetQueryParams(map[string]string{
@@ -230,8 +231,8 @@ func (y *Cloud189TV) getFiles(ctx context.Context, fileId string, isFamily bool)
 			res = append(res, &resp.FileListAO.FileList[i])
 		}
 		
-		// 文件数量小于130则跳出
-		if PageCount < 130 {
+		// 文件数量小于设定数量时跳出
+		if PageCount < pageSize {
             break
         }
 	}

--- a/drivers/189pc/utils.go
+++ b/drivers/189pc/utils.go
@@ -195,9 +195,10 @@ func (y *Cloud189PC) put(ctx context.Context, url string, headers map[string]str
 }
 
 func (y *Cloud189PC) getFiles(ctx context.Context, fileId string, isFamily bool) ([]model.Obj, error) {
+    pageSize := 1000  // 每一页返回的文件数量
 	res := make([]model.Obj, 0, 100)
 	for pageNum := 1; ; pageNum++ {
-		resp, err := y.getFilesWithPage(ctx, fileId, isFamily, pageNum, 1000, y.OrderBy, y.OrderDirection)
+		resp, err := y.getFilesWithPage(ctx, fileId, isFamily, pageNum, pageSize, y.OrderBy, y.OrderDirection)
 		if err != nil {
 			return nil, err
 		}
@@ -218,8 +219,8 @@ func (y *Cloud189PC) getFiles(ctx context.Context, fileId string, isFamily bool)
 			res = append(res, &resp.FileListAO.FileList[i])
 		}
 		
-		// 当前文件数量小于1000则跳出
-		if PageCount < 1000 {
+		// 当前文件数量小于设定数量则跳出
+		if PageCount < pageSize {
             break
         }
 	}

--- a/drivers/189pc/utils.go
+++ b/drivers/189pc/utils.go
@@ -205,14 +205,23 @@ func (y *Cloud189PC) getFiles(ctx context.Context, fileId string, isFamily bool)
 		if resp.FileListAO.Count == 0 {
 			break
 		}
+		
+		FolderCount := len(resp.FileListAO.FolderList) // 当前文件夹总数
+        FileCount := len(resp.FileListAO.FileList) // 当前文件总数
+        PageCount := FolderCount + FileCount // 当前页数总数
 
-		for i := 0; i < len(resp.FileListAO.FolderList); i++ {
+		for i := 0; i < FolderCount; i++ {
 			res = append(res, &resp.FileListAO.FolderList[i])
 		}
-		for i := 0; i < len(resp.FileListAO.FileList); i++ {
+		for i := 0; i < FileCount; i++ {
 			resp.FileListAO.FileList[i].ParentID = fileId
 			res = append(res, &resp.FileListAO.FileList[i])
 		}
+		
+		// 当前文件数量小于1000则跳出
+		if PageCount < 1000 {
+            break
+        }
 	}
 	return res, nil
 }


### PR DESCRIPTION
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->

## Summary / 摘要

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->
原有代码中，翻页的终止条件只判断了 Count == 0（总数为0），但并未判断当前返回的文件数量是否未达到数量，导致额外请求获取下一页的文件。这里添加了判断返回的文件数量是否达到所设置的pageSize才触发请求下一页。

fileListAO.count获取的是当前文件夹下总共的文件数量而不是当前返回的文件数量，但实际测试发现：当你请求的页码超出实际范围时（比如总共只有 3 页，你却请求第 4 页），接口返回的 Count 变成了 0。

<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Related Issues / 关联 Issue

<!--
Use `Closes #123`, `Fixes #123`, or `Relates to #123`.
Remove this section if not applicable.
使用 `Closes #123`、`Fixes #123` 或 `Relates to #123`。
不适用时请删除本节。
-->

## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [ ] `go test ./...`
- [x] Manual test / 手动测试: 编译运行后使用网络调试工具检查网络请求行为

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [ ] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [ ] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
