### PR TITLE
feat(drivers/alias): add `autoMakeDir` for missing dest

### DIFF
--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -243,7 +243,7 @@ func (d *Alias) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 
 func (d *Alias) Link(ctx context.Context, file model.Obj, args model.LinkArgs) (*model.Link, error) {
 	if d.ReadConflictPolicy == AllRWP && !args.Redirect {
-		files, err := d.getAllObjs(ctx, file, getWriteAndPutFilterFunc(AllRWP))
+		files, err := d.getAllObjs(ctx, file, getWriteAndPutFilterFunc(AllRWP), false)
 		if err != nil {
 			return nil, err
 		}

--- a/drivers/alias/util.go
+++ b/drivers/alias/util.go
@@ -120,7 +120,7 @@ func isConsistent(a, b model.Obj) bool {
 	return true
 }
 
-func (d *Alias) getAllObjs(ctx context.Context, bObj model.Obj, ifContinue func(err error) (bool, error)) (BalancedObjs, error) {
+func (d *Alias) getAllObjs(ctx context.Context, bObj model.Obj, ifContinue func(err error) (bool, error), autoMakeDir bool) (BalancedObjs, error) {
 	objs := bObj.(BalancedObjs)
 	length := 0
 	for _, o := range objs {
@@ -138,6 +138,14 @@ func (d *Alias) getAllObjs(ctx context.Context, bObj model.Obj, ifContinue func(
 					}
 				} else if !obj.IsDir() {
 					err = errs.NotFolder
+				}
+			}
+			// 目标为目录但该后端不存在时，按需自动创建，使新加入的存储也能参与写入
+			if err != nil && autoMakeDir && bObj.IsDir() && errs.IsObjectNotFound(err) {
+				if mkErr := fs.MakeDir(ctx, o.GetPath()); mkErr == nil {
+					err = nil
+				} else {
+					log.Debugf("auto make dir %s failed: %+v", o.GetPath(), mkErr)
 				}
 			}
 		} else if o == nil {
@@ -180,8 +188,14 @@ func (d *Alias) getBalancedPath(ctx context.Context, file model.Obj) string {
 	if rand.Intn(len(files)) == 0 {
 		return file.GetPath()
 	}
-	files, _ = d.getAllObjs(ctx, file, getWriteAndPutFilterFunc(AllRWP))
+	files, _ = d.getAllObjs(ctx, file, getWriteAndPutFilterFunc(AllRWP), false)
 	return files[rand.Intn(len(files))].GetPath()
+}
+
+// isAllWritePolicy 判断是否为"写入所有有效路径"类策略，
+// 此类策略下目标目录缺失时可自动补建，使新加入的存储也能参与写入
+func isAllWritePolicy(policy string) bool {
+	return policy == AllRWP || policy == AllStrictWP
 }
 
 func getWriteAndPutFilterFunc(policy string) func(error) (bool, error) {
@@ -226,14 +240,14 @@ func (d *Alias) getWriteObjs(ctx context.Context, obj model.Obj) (BalancedObjs, 
 	if d.WriteConflictPolicy == DisabledWP {
 		return nil, errs.PermissionDenied
 	}
-	return d.getAllObjs(ctx, obj, getWriteAndPutFilterFunc(d.WriteConflictPolicy))
+	return d.getAllObjs(ctx, obj, getWriteAndPutFilterFunc(d.WriteConflictPolicy), isAllWritePolicy(d.WriteConflictPolicy))
 }
 
 func (d *Alias) getPutObjs(ctx context.Context, obj model.Obj) (BalancedObjs, error) {
 	if d.PutConflictPolicy == DisabledWP {
 		return nil, errs.PermissionDenied
 	}
-	objs, err := d.getAllObjs(ctx, obj, getWriteAndPutFilterFunc(d.PutConflictPolicy))
+	objs, err := d.getAllObjs(ctx, obj, getWriteAndPutFilterFunc(d.PutConflictPolicy), isAllWritePolicy(d.PutConflictPolicy))
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +354,7 @@ func (d *Alias) getCopyObjs(ctx context.Context, srcObj, dstDir model.Obj) (Bala
 	if d.PutConflictPolicy == DisabledWP {
 		return nil, nil, errs.PermissionDenied
 	}
-	dstObjs, err := d.getAllObjs(ctx, dstDir, getWriteAndPutFilterFunc(d.PutConflictPolicy))
+	dstObjs, err := d.getAllObjs(ctx, dstDir, getWriteAndPutFilterFunc(d.PutConflictPolicy), isAllWritePolicy(d.PutConflictPolicy))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -355,7 +369,7 @@ func (d *Alias) getCopyObjs(ctx context.Context, srcObj, dstDir model.Obj) (Bala
 		dstStorageMap[mp] = append(dstStorageMap[mp], o)
 		allocatingDst[o] = struct{}{}
 	}
-	tmpSrcObjs, err := d.getAllObjs(ctx, srcObj, getWriteAndPutFilterFunc(AllRWP))
+	tmpSrcObjs, err := d.getAllObjs(ctx, srcObj, getWriteAndPutFilterFunc(AllRWP), false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -391,11 +405,11 @@ func (d *Alias) getMoveObjs(ctx context.Context, srcObj, dstDir model.Obj) (Bala
 	if d.PutConflictPolicy == DisabledWP {
 		return nil, nil, errs.PermissionDenied
 	}
-	dstObjs, err := d.getAllObjs(ctx, dstDir, getWriteAndPutFilterFunc(d.PutConflictPolicy))
+	dstObjs, err := d.getAllObjs(ctx, dstDir, getWriteAndPutFilterFunc(d.PutConflictPolicy), isAllWritePolicy(d.PutConflictPolicy))
 	if err != nil {
 		return nil, nil, err
 	}
-	tmpSrcObjs, err := d.getAllObjs(ctx, srcObj, getWriteAndPutFilterFunc(AllRWP))
+	tmpSrcObjs, err := d.getAllObjs(ctx, srcObj, getWriteAndPutFilterFunc(AllRWP), false)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Summary / 摘要

为 `alias` 驱动的 `all` / `all_strict` 写入策略增加目标目录缺失时自动创建，使新加入的存储也能参与写入。

此前，写入操作的「有效路径」仅指目标对象已存在且类型匹配的后端路径。当某个后端（例如新加入的存储）缺少对应的子目录时，会被判定为无效路径而跳过，导致数据不会写入该后端。本次改动在解析写入目标时，对返回 `ObjectNotFound` 的目录后端自动调用 `fs.MakeDir` 创建目录后纳入写入目标。

实现要点：

- [`getAllObjs()`](drivers/alias/util.go:123) 新增 `autoMakeDir bool` 参数；当目标为目录、后端返回 `ObjectNotFound` 且开关开启时，自动 [`fs.MakeDir`](internal/fs/fs.go:63) 创建后继续参与写入。
- 新增 [`isAllWritePolicy()`](drivers/alias/util.go:195) 辅助函数，判断策略是否为 `all` / `all_strict`。
- 写入目标（Put/Copy/Mkdir/Rename/Remove 的目标目录）在 `all` / `all_strict` 策略下启用自动建目录；源对象与读操作（Link 等）保持 `false`，不受影响。

- [ ] This PR has breaking changes.
  / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
  / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
  / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Testing / 测试

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
  / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
  / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
  / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
  / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
  / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [ ] Code generation / 代码生成
- [ ] Refactoring / 重构
- [x] Documentation / 文档
- [x] Tests / 测试
- [x] Translation / 翻译
- [x] Review assistance / 审查辅助
- [x] I have reviewed and validated all AI-assisted content included in this PR.
  / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
  / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
  / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。