### PR TITLE
fix(webdav): fix stat on directory with 301 redirect and empty displa…

### DIFF
--- a/drivers/webdav/driver.go
+++ b/drivers/webdav/driver.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
@@ -137,8 +138,16 @@ func (d *WebDav) Get(ctx context.Context, _path string) (model.Obj, error) {
 		return nil, err
 	}
 
+	name := info.Name()
+	if name == "" {
+		// gowebdav's Stat derives the name from the WebDAV `displayname`
+		// property, which some servers leave empty. Fall
+		// back to the path basename so the object keeps a usable name.
+		name = path.Base(strings.TrimSuffix(_path, "/"))
+	}
+
 	return &model.Object{
-		Name:     info.Name(),
+		Name:     name,
 		Size:     info.Size(),
 		Modified: info.ModTime(),
 		IsFolder: info.IsDir(),

--- a/pkg/gowebdav/client.go
+++ b/pkg/gowebdav/client.go
@@ -62,7 +62,15 @@ func (n *NoAuth) Authorize(req *http.Request, method string, path string) {
 
 // NewClient creates a new instance of client
 func NewClient(uri, user, pw string) *Client {
-	return &Client{FixSlash(uri), make(http.Header), nil, &http.Client{}, sync.Mutex{}, &NoAuth{user, pw}}
+	c := &Client{FixSlash(uri), make(http.Header), nil, &http.Client{}, sync.Mutex{}, &NoAuth{user, pw}}
+	// Disable the standard library's automatic redirect handling: for
+	// non-GET methods it downgrades the request to GET and drops the body,
+	// which breaks WebDAV methods such as PROPFIND. Redirects are followed
+	// manually in redirectReq while preserving the method and body.
+	c.c.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return c
 }
 
 // SetHeader lets us set arbitrary headers for a given client

--- a/pkg/gowebdav/requests.go
+++ b/pkg/gowebdav/requests.go
@@ -41,6 +41,16 @@ func (c *Client) req(method, path string, body io.Reader, intercept func(*http.R
 		return nil, err
 	}
 
+	return c.redirectReq(method, path, r, retryBuf, canRetry, intercept, 0)
+}
+
+// maxRedirects bounds how many times a request is redirected to avoid loops.
+const maxRedirects = 10
+
+// redirectReq applies the client headers, authentication and interceptors to
+// the given request, performs it, and handles redirects and authentication
+// challenges. r may already carry an absolute URL when following a redirect.
+func (c *Client) redirectReq(method, path string, r *http.Request, retryBuf io.Reader, canRetry bool, intercept func(*http.Request), redirects int) (req *http.Response, err error) {
 	for k, vals := range c.headers {
 		for _, v := range vals {
 			r.Header.Add(k, v)
@@ -66,6 +76,48 @@ func (c *Client) req(method, path string, body io.Reader, intercept func(*http.R
 	rs, err := c.c.Do(r)
 	if err != nil {
 		return nil, err
+	}
+
+	// Some WebDAV servers respond to a request issued on a collection
+	// without a trailing slash with a redirect (301/302). The standard
+	// library client mishandles redirects for non-GET methods: it
+	// downgrades them to GET and drops the request body, which breaks
+	// methods such as PROPFIND. Follow the redirect ourselves while
+	// preserving the original method and request body.
+	if rs.StatusCode == http.StatusMovedPermanently || rs.StatusCode == http.StatusFound ||
+		rs.StatusCode == http.StatusTemporaryRedirect || rs.StatusCode == http.StatusPermanentRedirect {
+		loc := rs.Header.Get("Location")
+		if loc != "" && redirects < maxRedirects {
+			rs.Body.Close()
+			u, err := r.URL.Parse(loc)
+			if err != nil {
+				return nil, err
+			}
+			// Skip a self-redirect (Location points back to the same URL) to
+			// avoid an immediate loop; the maxRedirects counter still bounds
+			// any longer redirect chains.
+			if u.String() == r.URL.String() {
+				return rs, nil
+			}
+			var newBody io.Reader
+			if retryBuf != nil {
+				if sk, ok := retryBuf.(io.Seeker); ok {
+					if _, err = sk.Seek(0, io.SeekStart); err != nil {
+						return nil, err
+					}
+				}
+				newBody = retryBuf
+			} else if method != http.MethodGet && method != http.MethodHead {
+				// Body is not re-readable (e.g. an unbuffered PUT), so we
+				// cannot follow the redirect with the payload intact.
+				return rs, nil
+			}
+			r, err = http.NewRequest(method, u.String(), newBody)
+			if err != nil {
+				return nil, err
+			}
+			return c.redirectReq(method, path, r, retryBuf, canRetry, intercept, redirects+1)
+		}
 	}
 
 	if rs.StatusCode == 401 && auth.Type() == "NoAuth" {


### PR DESCRIPTION

<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->

## Summary / 摘要

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->

修正 v4.2.2 版本因 webdav driver 实现 get 方法后导致的兼容性问题。

部分 webdav 服务（如 InfiniCLOUD）在执行 PROPFIND 目录时，若目录路径缺少 "/"，会返回 301 重定向要求添加 "/"。但 golang http client 在处理重定向时，会默认将 PROPFIND 转换为 GET 请求，导致 openlist 访问目录出错。

修复方法：修改 gowebdav 不自动 follow 处理重定向，自己处理重定向继续使用 PROPFIND 请求。

之前的关联 PR：https://github.com/OpenListTeam/OpenList/pull/2421

<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Related Issues / 关联 Issue

<!--
Use `Closes #123`, `Fixes #123`, or `Relates to #123`.
Remove this section if not applicable.
使用 `Closes #123`、`Fixes #123` 或 `Relates to #123`。
不适用时请删除本节。
-->

Relates to #2586

## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [ ] `go test ./...`
- [x] Manual test / 手动测试:

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [x] Other (please specify) / 其他（请注明）: opencode

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
