### PR TITLE
fix(115_open): clean parent path before lookup

### DIFF
--- a/drivers/115_open/driver.go
+++ b/drivers/115_open/driver.go
@@ -195,6 +195,7 @@ func (d *Open115) Get(ctx context.Context, path string) (model.Obj, error) {
 func (d *Open115) getFromParent(ctx context.Context, path, id string) (model.Obj, error) {
 	path = stdpath.Clean(path)
 	parent, name := stdpath.Split(path)
+	parent = stdpath.Clean(parent)
 	parentID := d.GetRootId()
 	if stdpath.Clean(parent) != stdpath.Clean(d.parentPath) {
 		if err := d.WaitLimit(ctx); err != nil {


### PR DESCRIPTION
## Summary / 摘要

- Normalize the parent path returned by `path.Split` before requesting 115 folder metadata.
- Restore nested directory creation in the 115 Open driver by avoiding a trailing slash that the 115 API interprets as an empty directory name.
- No public API, configuration, storage format, or dependency changes.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

## Testing / 测试

- [ ] `go test ./...`
- [x] Manual test / 手动测试:
  - macOS arm64, Go 1.26.5.
  - Ran from source with `go run main.go --data <test-data> server --debug --log-std`.
  - Reproduced the failure against beta commit `d90ef1e`, then verified the fix against current upstream `main` (`bacd0870`) plus this commit.
  - Used the same 115 Open storage for the before/after requests. The temporary directories were removed after verification.

### Failure log before the fix

Creating a directory directly below the mount root succeeded:

```http
POST /api/fs/mkdir
Content-Type: application/json

{"path":"/115/__openlist_mkdir_probe_20260722"}

HTTP/1.1 200
{"code":200,"message":"success","data":null}
```

Creating its child failed before `Mkdir` was reached:

```http
POST /api/fs/mkdir
Content-Type: application/json

{"path":"/115/__openlist_mkdir_probe_20260722/child_ascii"}

HTTP/1.1 500
{"code":500,"message":"failed to check if dir exists: failed to get obj: code: 20001, message: 目录名称不能为空。","data":null}
```

The first lookup of the missing child returned an empty data array as expected. The fallback then sent the parent path with the trailing slash produced by `path.Split`:

```http
POST https://proapi.115.com/open/folder/get_info
Content-Type: application/x-www-form-urlencoded

path=/__openlist_mkdir_probe_20260722/

HTTP/1.1 200
{"state":false,"message":"目录名称不能为空。","code":20001,"data":[]}
```

Sending the same parent path without the trailing slash returned the folder metadata successfully. Sensitive file IDs and pick codes are omitted:

```http
POST https://proapi.115.com/open/folder/get_info
Content-Type: application/x-www-form-urlencoded

path=/__openlist_mkdir_probe_20260722

HTTP/1.1 200
{"state":true,"message":"","code":0,"data":{"file_name":"__openlist_mkdir_probe_20260722","file_category":"0","...":"redacted"}}
```

### Verification log after the fix

Both root and nested directory creation succeeded:

```http
POST /api/fs/mkdir
{"path":"/115/__openlist_mkdir_fix_verify_20260722"}

{"code":200,"message":"success","data":null}

POST /api/fs/mkdir
{"path":"/115/__openlist_mkdir_fix_verify_20260722/二级目录测试"}

{"code":200,"message":"success","data":null}
```

Listing the parent confirmed that the child was created:

```json
{"code":200,"message":"success","data":{"content":[{"name":"二级目录测试","is_dir":true}],"total":1,"...":"omitted"}}
```

Cleanup succeeded, and the follow-up lookup confirmed removal:

```json
{"code":200,"message":"success","data":null}
{"code":500,"message":"failed to get obj: object not found","data":null}
```

Additional checks:

- `gofmt -d drivers/115_open/driver.go` produced no output.
- `git diff --check` passed.
- The full test suite was not run locally; repository CI is expected to perform the broader build checks.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [x] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
