### PR TITLE
fix(proxy): preserve proxied download filenames

### DIFF
--- a/server/common/proxy.go
+++ b/server/common/proxy.go
@@ -59,6 +59,7 @@ func Proxy(w http.ResponseWriter, r *http.Request, link *model.Link, file model.
 	defer res.Body.Close()
 
 	maps.Copy(w.Header(), res.Header)
+	w.Header().Set("Content-Disposition", utils.GenerateContentDisposition(file.GetName()))
 	w.WriteHeader(res.StatusCode)
 	if r.Method == http.MethodHead {
 		return nil

--- a/server/common/proxy_test.go
+++ b/server/common/proxy_test.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/conf"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
+)
+
+func TestProxyOverridesUpstreamContentDisposition(t *testing.T) {
+	previousConfig := conf.Conf
+	conf.Conf = conf.DefaultConfig("data")
+	t.Cleanup(func() {
+		conf.Conf = previousConfig
+	})
+
+	const content = "archive content"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Disposition", `attachment; filename="download"`)
+		w.Header().Set("Content-Type", "application/x-rar-compressed")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, content)
+	}))
+	t.Cleanup(upstream.Close)
+
+	file := &model.Object{
+		Name: "测试文件.rar",
+		Size: int64(len(content)),
+	}
+	link := &model.Link{URL: upstream.URL}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/sd/example", nil)
+
+	err := Proxy(recorder, request, link, file)
+	if err != nil {
+		t.Fatalf("Proxy() error = %v", err)
+	}
+	if got, want := recorder.Code, http.StatusOK; got != want {
+		t.Fatalf("status code = %d, want %d", got, want)
+	}
+	if got, want := recorder.Header().Get("Content-Disposition"), utils.GenerateContentDisposition(file.GetName()); got != want {
+		t.Errorf("Content-Disposition = %q, want %q", got, want)
+	}
+	if got, want := recorder.Header().Get("Content-Type"), "application/x-rar-compressed"; got != want {
+		t.Errorf("Content-Type = %q, want %q", got, want)
+	}
+	if got, want := recorder.Body.String(), content; got != want {
+		t.Errorf("body = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary / 摘要

- Override upstream `Content-Disposition` in transparent proxy responses with the OpenList object filename.
- Preserve upstream response status, content type, and body.
- Add regression coverage for incorrect upstream download filenames, including non-ASCII filenames.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: N/A
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

Fixes #2514

## Testing / 测试

- [ ] `go test ./...`
- [x] `go test ./server/common`
- [ ] Manual test / 手动测试: Not run. The regression test uses a local upstream server that returns an incorrect `Content-Disposition` header.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。