### PR TITLE
fix(buffer): wait for active I/O before closing

### DIFF
--- a/pkg/buffer/pipe.go
+++ b/pkg/buffer/pipe.go
@@ -75,10 +75,10 @@ func (br *PipeBuffer) Read(p []byte) (int, error) {
 	off := br.offR
 	block := br.block
 	br.ioWg.Add(1)
+	defer br.ioWg.Done()
 	br.rw.Unlock()
 
 	n, err := block.ReadAt(p[:min(len(p), canRead)], int64(off))
-	br.ioWg.Done()
 
 	br.rw.Lock()
 	br.offR += n
@@ -113,10 +113,10 @@ func (br *PipeBuffer) Write(p []byte) (int, error) {
 	off := br.offW
 	block := br.block
 	br.ioWg.Add(1)
+	defer br.ioWg.Done()
 	br.rw.Unlock()
 
 	n, err := block.WriteAt(p[:min(canWrite, len(p))], int64(off))
-	br.ioWg.Done()
 
 	br.rw.Lock()
 	br.offW += n
@@ -136,6 +136,7 @@ func (br *PipeBuffer) Write(p []byte) (int, error) {
 }
 
 func (br *PipeBuffer) Reset(limit int) error {
+	br.ioWg.Wait()
 	br.rw.Lock()
 	defer br.rw.Unlock()
 	if br.block == nil {

--- a/pkg/buffer/pipe.go
+++ b/pkg/buffer/pipe.go
@@ -13,6 +13,7 @@ type PipeBuffer struct {
 	offR  int
 	offW  int
 	rw    sync.Mutex
+	ioWg  sync.WaitGroup
 	block Block
 
 	readSignal  chan struct{}
@@ -73,9 +74,11 @@ func (br *PipeBuffer) Read(p []byte) (int, error) {
 
 	off := br.offR
 	block := br.block
+	br.ioWg.Add(1)
 	br.rw.Unlock()
 
 	n, err := block.ReadAt(p[:min(len(p), canRead)], int64(off))
+	br.ioWg.Done()
 
 	br.rw.Lock()
 	br.offR += n
@@ -109,9 +112,11 @@ func (br *PipeBuffer) Write(p []byte) (int, error) {
 
 	off := br.offW
 	block := br.block
+	br.ioWg.Add(1)
 	br.rw.Unlock()
 
 	n, err := block.WriteAt(p[:min(canWrite, len(p))], int64(off))
+	br.ioWg.Done()
 
 	br.rw.Lock()
 	br.offW += n
@@ -147,11 +152,12 @@ func (br *PipeBuffer) Reset(limit int) error {
 
 func (br *PipeBuffer) Close() error {
 	br.rw.Lock()
-	defer br.rw.Unlock()
 	if br.block != nil {
 		br.block = nil
 		br.readPending = false
 		close(br.readSignal)
 	}
+	br.rw.Unlock()
+	br.ioWg.Wait()
 	return nil
 }

--- a/pkg/buffer/pipe_test.go
+++ b/pkg/buffer/pipe_test.go
@@ -1,0 +1,131 @@
+package buffer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+type blockingBlock struct {
+	data    []byte
+	blockOn string
+	started chan struct{}
+	release chan struct{}
+}
+
+func newBlockingBlock(blockOn string) *blockingBlock {
+	return &blockingBlock{
+		data:    make([]byte, 1),
+		blockOn: blockOn,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (b *blockingBlock) Size() int64 {
+	return int64(len(b.data))
+}
+
+func (b *blockingBlock) ReadAt(p []byte, off int64) (int, error) {
+	if b.blockOn == "read" {
+		close(b.started)
+		<-b.release
+	}
+	n := copy(p, b.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (b *blockingBlock) WriteAt(p []byte, off int64) (int, error) {
+	if b.blockOn == "write" {
+		close(b.started)
+		<-b.release
+	}
+	n := copy(b.data[off:], p)
+	if n < len(p) {
+		return n, io.ErrShortWrite
+	}
+	return n, nil
+}
+
+func TestPipeBufferCloseWaitsForActiveIO(t *testing.T) {
+	for _, operation := range []string{"read", "write"} {
+		t.Run(operation, func(t *testing.T) {
+			block := newBlockingBlock(operation)
+			buf := NewPipeBuffer(context.Background(), block)
+			if operation == "read" {
+				if _, err := buf.Write([]byte{1}); err != nil {
+					t.Fatalf("prepare read: %v", err)
+				}
+			}
+
+			ioDone := make(chan error, 1)
+			go func() {
+				var err error
+				if operation == "read" {
+					_, err = buf.Read(make([]byte, 1))
+				} else {
+					_, err = buf.Write([]byte{1})
+				}
+				ioDone <- err
+			}()
+
+			select {
+			case <-block.started:
+			case <-time.After(time.Second):
+				t.Fatal("I/O did not start")
+			}
+
+			closeDone := make(chan error, 1)
+			go func() {
+				closeDone <- buf.Close()
+			}()
+
+			deadline := time.Now().Add(time.Second)
+			for {
+				buf.rw.Lock()
+				closed := buf.block == nil
+				buf.rw.Unlock()
+				if closed {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("buffer did not enter the closed state")
+				}
+				time.Sleep(time.Millisecond)
+			}
+
+			select {
+			case err := <-closeDone:
+				t.Fatalf("Close returned before active %s completed: %v", operation, err)
+			default:
+			}
+
+			close(block.release)
+			select {
+			case err := <-ioDone:
+				if err != nil {
+					t.Fatalf("active %s failed: %v", operation, err)
+				}
+			case <-time.After(time.Second):
+				t.Fatalf("active %s did not complete", operation)
+			}
+			select {
+			case err := <-closeDone:
+				if err != nil {
+					t.Fatalf("Close failed: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("Close did not wait for active I/O")
+			}
+
+			if _, err := buf.Write([]byte{1}); !errors.Is(err, io.ErrClosedPipe) {
+				t.Fatalf("write after Close error = %v, want %v", err, io.ErrClosedPipe)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary / 摘要

- Prevent `PipeBuffer.Close` from returning while `ReadAt` or `WriteAt` operations are still using the backing block.
- Reject new I/O during close and wait for in-flight operations before the downloader releases its mmap-backed cache.
- Add deterministic concurrent close regression tests covering both reads and writes.
- Preserve the existing concurrent reader and writer behavior without changing public APIs or configuration.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

## Related Issues / 关联 Issue

Fixes #2823

## Testing / 测试

- [ ] `go test ./...`
- [x] `go test -race ./pkg/buffer`
- [x] `go vet ./pkg/buffer`
- [x] `go test ./internal/net -run '^(TestDownloadOrder|TestDownloadInterrupt|TestHighConcurrency|TestDownloadSingle)$'`
- [ ] Manual test / 手动测试: Not run; the race is covered by deterministic concurrent close tests.

The full `go test ./internal/net` command was also attempted. The unrelated `TestNewOSSClientUsesEnvironmentHTTPSProxy` test failed because it expected `*http.Transport` but received `*net.safeTransport`; the downloader-specific tests passed when run directly.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。