### PR TITLE
fix(search): serialize index updates by parent

### DIFF
--- a/internal/search/build.go
+++ b/internal/search/build.go
@@ -225,6 +225,9 @@ func Update(ctx context.Context, parent string, objs []model.Obj) {
 		return
 	}
 
+	unlock := lockUpdate(parent)
+	defer unlock()
+
 	nodes, err := instance.Get(ctx, parent)
 	if err != nil {
 		log.Errorf("update search index error while get nodes: %+v", err)

--- a/internal/search/build_test.go
+++ b/internal/search/build_test.go
@@ -1,0 +1,58 @@
+package search
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLockUpdateSerializesSameParent(t *testing.T) {
+	unlockFirst := lockUpdate("/same-parent")
+	secondStarted := make(chan struct{})
+	secondAcquired := make(chan struct{})
+	secondReleased := make(chan struct{})
+	go func() {
+		close(secondStarted)
+		unlockSecond := lockUpdate("/same-parent")
+		close(secondAcquired)
+		unlockSecond()
+		close(secondReleased)
+	}()
+	<-secondStarted
+
+	select {
+	case <-secondAcquired:
+		t.Fatal("second update acquired the same parent lock")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	unlockFirst()
+	select {
+	case <-secondReleased:
+	case <-time.After(time.Second):
+		t.Fatal("second update did not acquire the released parent lock")
+	}
+
+	updateLocksMu.Lock()
+	defer updateLocksMu.Unlock()
+	if len(updateLocks) != 0 {
+		t.Fatalf("update locks were not cleaned up: %d", len(updateLocks))
+	}
+}
+
+func TestLockUpdateAllowsDifferentParents(t *testing.T) {
+	unlockFirst := lockUpdate("/first-parent")
+	defer unlockFirst()
+
+	secondAcquired := make(chan struct{})
+	go func() {
+		unlockSecond := lockUpdate("/second-parent")
+		unlockSecond()
+		close(secondAcquired)
+	}()
+
+	select {
+	case <-secondAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("update for a different parent was blocked")
+	}
+}

--- a/internal/search/update_lock.go
+++ b/internal/search/update_lock.go
@@ -1,0 +1,38 @@
+package search
+
+import "sync"
+
+var (
+	updateLocksMu sync.Mutex
+	updateLocks   = make(map[string]*updateLock)
+)
+
+type updateLock struct {
+	mu   sync.Mutex
+	refs uint
+}
+
+// lockUpdate serializes index updates for the same parent while allowing
+// unrelated directories to update concurrently.
+func lockUpdate(parent string) func() {
+	updateLocksMu.Lock()
+	lock, ok := updateLocks[parent]
+	if !ok {
+		lock = &updateLock{}
+		updateLocks[parent] = lock
+	}
+	lock.refs++
+	updateLocksMu.Unlock()
+
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+
+		updateLocksMu.Lock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(updateLocks, parent)
+		}
+		updateLocksMu.Unlock()
+	}
+}


### PR DESCRIPTION
## Summary / 摘要

- Serialize automatic search index updates targeting the same parent path to prevent duplicate entries caused by concurrent stale reads.
- Preserve concurrent updates for unrelated parent paths and clean up idle locks.
- Add tests covering same-parent serialization, cross-parent concurrency, lock cleanup, and race detection.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- N/A

## Related Issues / 关联 Issue

Fixes #2814

## Testing / 测试

- [ ] `go test ./...` — Not run because required modules were unavailable offline, and no dependencies were downloaded.
- [x] Targeted unit tests passed.
- [x] Targeted tests passed with the Go race detector.
- [ ] Manual test / 手动测试: Not run because the original issue is timing-dependent and no local reproducer was available.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。