### PR TITLE
fix(drivers/onedrive_sharelink): htm/html file download failure via WebDAV and improve checks

### DIFF
--- a/drivers/onedrive_sharelink/driver.go
+++ b/drivers/onedrive_sharelink/driver.go
@@ -132,11 +132,12 @@ func (d *OnedriveSharelink) Link(ctx context.Context, file model.Obj, args model
 		}, nil
 	}
 
+	fileName := file.GetName()
 	return &model.Link{
 		URL:    url,
 		Header: header,
 		RangeReader: rangeReaderFunc(func(ctx context.Context, hr http_range.Range) (io.ReadCloser, error) {
-			return d.rangeReadWithRefresh(ctx, url, hr)
+			return d.rangeReadWithRefresh(ctx, url, hr, fileName)
 		}),
 	}, nil
 }
@@ -615,7 +616,8 @@ var _ driver.Driver = (*OnedriveSharelink)(nil)
 
 // rangeReadWithRefresh tries once with current headers, and if the response
 // looks invalid (error status or html login page), it refreshes headers and retries.
-func (d *OnedriveSharelink) rangeReadWithRefresh(ctx context.Context, url string, hr http_range.Range) (io.ReadCloser, error) {
+func (d *OnedriveSharelink) rangeReadWithRefresh(ctx context.Context, url string, hr http_range.Range, fileName string) (io.ReadCloser, error) {
+	isHTMLFile := strings.HasSuffix(strings.ToLower(fileName), ".htm") || strings.HasSuffix(strings.ToLower(fileName), ".html")
 	tryOnce := func(header http.Header) (io.ReadCloser, error) {
 		h := cloneHeader(header)
 		if h == nil {
@@ -626,10 +628,25 @@ func (d *OnedriveSharelink) rangeReadWithRefresh(ctx context.Context, url string
 		if err != nil {
 			return nil, err
 		}
-		ct := strings.ToLower(resp.Header.Get("Content-Type"))
-		if strings.Contains(ct, "text/html") {
-			_ = resp.Body.Close()
-			return nil, fmt.Errorf("unexpected html response")
+		if isHTMLFile {
+			// For HTML files, detect token expiry via redirect chain:
+			// expired token → 302 → Authenticate.aspx → login.microsoftonline.com
+			if resp.Request != nil && resp.Request.URL != nil {
+				finalHost := strings.ToLower(resp.Request.URL.Hostname())
+				if strings.Contains(finalHost, "login.microsoftonline.com") ||
+					strings.Contains(finalHost, "login.live.com") ||
+					strings.Contains(finalHost, "login.microsoft.com") {
+					_ = resp.Body.Close()
+					return nil, fmt.Errorf("token expired, redirected to login page")
+				}
+			}
+		} else {
+			// For non-HTML files, text/html response indicates login page
+			ct := strings.ToLower(resp.Header.Get("Content-Type"))
+			if strings.Contains(ct, "text/html") {
+				_ = resp.Body.Close()
+				return nil, fmt.Errorf("unexpected html response")
+			}
 		}
 		return resp.Body, nil
 	}

--- a/drivers/onedrive_sharelink/util.go
+++ b/drivers/onedrive_sharelink/util.go
@@ -235,10 +235,16 @@ func (d *OnedriveSharelink) getFiles(ctx context.Context, path string) ([]Item, 
 			return nil, err
 		}
 		template := re.FindString(string(body))
-		template = template[strings.Index(template, "templateUrl\":\"")+len("templateUrl\":\""):]
-		template = template[:strings.Index(template, "?id=")]
-		template = template[:strings.LastIndex(template, "/")]
-		downloadLinkPrefix = template + "/download.aspx?UniqueId="
+		if template == "" {
+			log.Warnf("onedrive_sharelink: templateUrl not found in page body, falling back to redirect URL parsing")
+			redirectUrlCut := redirectUrl[:strings.LastIndex(redirectUrl, "/")]
+			downloadLinkPrefix = redirectUrlCut + "/download.aspx?UniqueId="
+		} else {
+			template = template[strings.Index(template, "templateUrl\":\"")+len("templateUrl\":\""):]
+			template = template[:strings.Index(template, "?id=")]
+			template = template[:strings.LastIndex(template, "/")]
+			downloadLinkPrefix = template + "/download.aspx?UniqueId="
+		}
 		params, err := url.ParseQuery(redirectUrl[strings.Index(redirectUrl, "?")+1:])
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->

## Summary / 摘要

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->

在使用webdav客户端（如rclone）下载OneDrive for business分享链接里的html/htm时，会发生416错误。问题的根源在于，云端返回的文件为text/html时，程序会认为返回的html文件一定是OneDrive的错误页或者登录页，进而觉得是token失效了，然后重新获取token，而不是返回要下载的文件。

When downloading html/htm files from a shared link in OneDrive for Business using a WebDAV client (such as rclone), a 416 error will occur. The root cause is that when the file returned by cloud side is text/html, the program assumes the returned HTML file must be an error page or login page of OneDrive, and thus considers that the token has expired, then reacquires the token instead of returning the target file.

做出的改动如下/Changes made：

对 .htm/.html 文件：通过检测重定向的最终目标是不是 Microsoft 登录页（login.microsoftonline.com）来判断 token 是否过期。这样的性能开销很小，还不会误判。

For .htm/.html files: Determine whether the token has expired by checking if the final redirect target is the Microsoft login page (login.microsoftonline.com). It has minimal performance overhead and avoids misjudgment.

对非 HTML 文件：保留原有逻辑，返回的文件为text/html时，则认为token过期了，然后重新获取token。

For non-HTML files: Keep the original behavior. When the MIME type of returned file is text/html, consider the token expired and then reacquire the token.

同时为 templateUrl 正则匹配失败添加回退保护。

Also add fallback protection for templateUrl regex matching failure.

<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。


## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [ ] `go test ./...`
- [x] Manual test / 手动测试: 使用 `rclone copy openlist:/onedrive/xxx /tmp/test/xxx --transfers 4 --checksum` 复制具有10000多个1KB左右的HTML文件的文件夹，期间未出现任何错误。涉及隐私的部分已打码。 
Copy 10000 1kb size html files from a folder via `rclone copy openlist:/onedrive/xxx /tmp/test/xxx --transfers 4 --checksum`, no error occurred. Privacy info was removed.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [x] Other (please specify) / 其他（请注明）:deepseek手机版

Usage scope / 使用范围:

- [ ] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [x] Translation / 翻译
- [ ] Review assistance / 审查辅助
- [x]  Chat / 知识问答

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
