### PR TITLE
feat(server): trust configured Unix socket requests

### DIFF
--- a/internal/bootstrap/run.go
+++ b/internal/bootstrap/run.go
@@ -170,7 +170,11 @@ func Start() {
 	if conf.Conf.Scheme.UnixFile != "" {
 		fmt.Printf("start unix server @ %s\n", conf.Conf.Scheme.UnixFile)
 		utils.Log.Infof("start unix server @ %s", conf.Conf.Scheme.UnixFile)
-		unixSrv = &http.Server{Handler: httpHandler}
+		unixHandler := httpHandler
+		if conf.Conf.Scheme.UnixFileTrusted {
+			unixHandler = middlewares.UnixFileTrusted(unixHandler)
+		}
+		unixSrv = &http.Server{Handler: unixHandler}
 		go func() {
 			listener, err := net.Listen("unix", conf.Conf.Scheme.UnixFile)
 			if err != nil {

--- a/internal/conf/config.go
+++ b/internal/conf/config.go
@@ -26,16 +26,17 @@ type Meilisearch struct {
 }
 
 type Scheme struct {
-	Address      string `json:"address" env:"ADDR"`
-	HttpPort     int    `json:"http_port" env:"HTTP_PORT"`
-	HttpsPort    int    `json:"https_port" env:"HTTPS_PORT"`
-	ForceHttps   bool   `json:"force_https" env:"FORCE_HTTPS"`
-	CertFile     string `json:"cert_file" env:"CERT_FILE"`
-	KeyFile      string `json:"key_file" env:"KEY_FILE"`
-	UnixFile     string `json:"unix_file" env:"UNIX_FILE"`
-	UnixFilePerm string `json:"unix_file_perm" env:"UNIX_FILE_PERM"`
-	EnableH2c    bool   `json:"enable_h2c" env:"ENABLE_H2C"`
-	EnableH3     bool   `json:"enable_h3" env:"ENABLE_H3"`
+	Address         string `json:"address" env:"ADDR"`
+	HttpPort        int    `json:"http_port" env:"HTTP_PORT"`
+	HttpsPort       int    `json:"https_port" env:"HTTPS_PORT"`
+	ForceHttps      bool   `json:"force_https" env:"FORCE_HTTPS"`
+	CertFile        string `json:"cert_file" env:"CERT_FILE"`
+	KeyFile         string `json:"key_file" env:"KEY_FILE"`
+	UnixFile        string `json:"unix_file" env:"UNIX_FILE"`
+	UnixFileTrusted bool   `json:"unix_file_trusted" env:"UNIX_FILE_TRUSTED"`
+	UnixFilePerm    string `json:"unix_file_perm" env:"UNIX_FILE_PERM"`
+	EnableH2c       bool   `json:"enable_h2c" env:"ENABLE_H2C"`
+	EnableH3        bool   `json:"enable_h3" env:"ENABLE_H3"`
 }
 
 type LogConfig struct {

--- a/server/middlewares/auth.go
+++ b/server/middlewares/auth.go
@@ -1,7 +1,9 @@
 package middlewares
 
 import (
+	"context"
 	"crypto/subtle"
+	"net/http"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/conf"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
@@ -16,6 +18,9 @@ import (
 // if token is empty, set user to guest
 func Auth(allowDisabledGuest bool) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		if authenticateUnixFileTrusted(c) {
+			return
+		}
 		token := c.GetHeader("Authorization")
 		if subtle.ConstantTimeCompare([]byte(token), []byte(setting.GetStr(conf.Token))) == 1 {
 			admin, err := op.GetAdmin()
@@ -76,6 +81,9 @@ func Auth(allowDisabledGuest bool) func(c *gin.Context) {
 }
 
 func Authn(c *gin.Context) {
+	if authenticateUnixFileTrusted(c) {
+		return
+	}
 	token := c.GetHeader("Authorization")
 	if subtle.ConstantTimeCompare([]byte(token), []byte(setting.GetStr(conf.Token))) == 1 {
 		admin, err := op.GetAdmin()
@@ -127,6 +135,36 @@ func Authn(c *gin.Context) {
 	common.GinAppendValues(c, conf.UserKey, user)
 	log.Debugf("use login token: %+v", user)
 	c.Next()
+}
+
+func authenticateUnixFileTrusted(c *gin.Context) bool {
+	if !IsUnixFileTrusted(c) {
+		return false
+	}
+	admin, err := op.GetAdmin()
+	if err != nil {
+		common.ErrorResp(c, err, 500)
+		c.Abort()
+		return true
+	}
+	common.GinAppendValues(c, conf.UserKey, admin)
+	log.Debug("use admin identity for trusted Unix socket request")
+	c.Next()
+	return true
+}
+
+type unixFileTrustedKey struct{}
+
+func UnixFileTrusted(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), unixFileTrustedKey{}, true)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func IsUnixFileTrusted(c *gin.Context) bool {
+	trusted, _ := c.Request.Context().Value(unixFileTrustedKey{}).(bool)
+	return conf.Conf.Scheme.UnixFileTrusted && trusted
 }
 
 func AuthNotGuest(c *gin.Context) {

--- a/server/middlewares/down.go
+++ b/server/middlewares/down.go
@@ -31,7 +31,7 @@ func Down(verifyFunc func(string, string) error) func(c *gin.Context) {
 		}
 		common.GinAppendValues(c, conf.MetaKey, meta)
 		// verify sign
-		if needSign(meta, rawPath) {
+		if !IsUnixFileTrusted(c) && needSign(meta, rawPath) {
 			s := c.Query("sign")
 			err = verifyFunc(rawPath, strings.TrimSuffix(s, "/"))
 			if err != nil {

--- a/server/webdav.go
+++ b/server/webdav.go
@@ -48,6 +48,17 @@ func ServeWebDAV(c *gin.Context) {
 }
 
 func WebDAVAuth(c *gin.Context) {
+	if middlewares.IsUnixFileTrusted(c) {
+		admin, err := op.GetAdmin()
+		if err != nil {
+			common.ErrorResp(c, err, http.StatusInternalServerError)
+			c.Abort()
+			return
+		}
+		common.GinAppendValues(c, conf.UserKey, admin)
+		c.Next()
+		return
+	}
 	// check count of login
 	ip := c.ClientIP()
 	guest, _ := op.GetGuest()


### PR DESCRIPTION
增加scheme.unix_file_trusted，使得对于来自 unix_socket 的请求免认证。一个主要的用途是供服务器内部程序使用 unix_sock 挂载 webdav 以避免使用/泄漏 API_KEY 或 PASSWORD，unix_socket 的权限组相当于已经做了身份认证，nginx proxy pass可以使用http 端口以要求身份认证

## Summary / 摘要

- Add `scheme.unix_file_trusted` and `OPENLIST_UNIX_FILE_TRUSTED`; the zero-value default remains `false`.
- Treat requests received through the configured Unix socket as an administrator without requiring account credentials, passwords, or an API key, including WebDAV requests.
- Skip protected-download signature validation only for trusted Unix socket requests.
- Keep existing HTTP and HTTPS authentication behavior unchanged.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

## Testing / 测试

- [ ] `go test ./...`
- [x] `go test ./internal/conf ./server/middlewares ./server ./internal/bootstrap`
- [x] `gofmt -d internal/bootstrap/run.go internal/conf/config.go server/middlewares/auth.go server/middlewares/down.go server/webdav.go` (no output)
- [ ] Manual test / 手动测试: Not run.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [ ] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [x] Codex

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Tests / 测试
- [x] Review assistance / 审查辅助

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。