### PR TITLE
feat(drivers/alias): support filename escaping

### DIFF
--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -198,6 +198,12 @@ func (d *Alias) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 		}
 		for _, obj := range tmp {
 			rawName, name := obj.GetName(), d.escapeFilename(obj.GetName(), false)
+			escapedName := d.escapeFilename(name, true)
+			if d.FilenameAutoRename && escapedName != rawName {
+				if err := fs.Rename(ctx, stdpath.Join(dirPath, rawName), escapedName); err == nil {
+					rawName = escapedName
+				}
+			}
 			if _, exists := objMap[name]; exists {
 				continue
 			}

--- a/drivers/alias/driver.go
+++ b/drivers/alias/driver.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	stdpath "path"
 	"strings"
+	"unicode/utf16"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/errs"
@@ -117,8 +118,12 @@ func (d *Alias) Get(ctx context.Context, path string) (model.Obj, error) {
 		return nil, errs.ObjectNotFound
 	}
 	for idx, root := range roots {
-		rawPath := stdpath.Join(root, sub)
+		rawPath := stdpath.Join(root, d.escapeFilenamePath(sub))
 		obj, err := fs.Get(ctx, rawPath, &fs.GetArgs{NoLog: true})
+		if err != nil && errs.IsObjectNotFound(err) && rawPath != stdpath.Join(root, sub) {
+			rawPath = stdpath.Join(root, sub)
+			obj, err = fs.Get(ctx, rawPath, &fs.GetArgs{NoLog: true})
+		}
 		if err != nil {
 			continue
 		}
@@ -129,7 +134,7 @@ func (d *Alias) Get(ctx context.Context, path string) (model.Obj, error) {
 		}
 		ret := model.Object{
 			Path:     rawPath,
-			Name:     obj.GetName(),
+			Name:     d.escapeFilename(obj.GetName(), false),
 			Size:     obj.GetSize(),
 			Modified: obj.ModTime(),
 			IsFolder: obj.IsDir(),
@@ -159,9 +164,9 @@ func (d *Alias) Get(ctx context.Context, path string) (model.Obj, error) {
 		if idx > 0 {
 			objs = append(objs, nil)
 		}
-		for _, d := range roots {
+		for _, root := range roots {
 			objs = append(objs, &tempObj{model.Object{
-				Path: stdpath.Join(d, sub),
+				Path: stdpath.Join(root, d.escapeFilenamePath(sub)),
 			}})
 		}
 		return objs, nil
@@ -192,14 +197,14 @@ func (d *Alias) List(ctx context.Context, dir model.Obj, args model.ListArgs) ([
 			continue
 		}
 		for _, obj := range tmp {
-			name := obj.GetName()
+			rawName, name := obj.GetName(), d.escapeFilename(obj.GetName(), false)
 			if _, exists := objMap[name]; exists {
 				continue
 			}
 			mask := model.GetObjMask(obj) &^ model.Temp
 			objRes := model.Object{
 				Name:     name,
-				Path:     stdpath.Join(dirPath, name),
+				Path:     stdpath.Join(dirPath, rawName),
 				Size:     obj.GetSize(),
 				Modified: obj.ModTime(),
 				IsFolder: obj.IsDir(),
@@ -362,7 +367,7 @@ func (d *Alias) MakeDir(ctx context.Context, parentDir model.Obj, dirName string
 	objs, err := d.getWriteObjs(ctx, parentDir)
 	if err == nil {
 		for _, obj := range objs {
-			err = errors.Join(err, fs.MakeDir(ctx, stdpath.Join(obj.GetPath(), dirName)))
+			err = errors.Join(err, fs.MakeDir(ctx, stdpath.Join(obj.GetPath(), d.escapeFilename(dirName, true))))
 		}
 	}
 	return err
@@ -389,7 +394,7 @@ func (d *Alias) Rename(ctx context.Context, srcObj model.Obj, newName string) er
 	objs, err := d.getWriteObjs(ctx, srcObj)
 	if err == nil {
 		for _, obj := range objs {
-			err = errors.Join(err, fs.Rename(ctx, obj.GetPath(), newName))
+			err = errors.Join(err, fs.Rename(ctx, obj.GetPath(), d.escapeFilename(newName, true)))
 		}
 	}
 	return err
@@ -426,7 +431,7 @@ func (d *Alias) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer,
 				return err
 			}
 			return op.Put(ctx, storage, reqActualPath, &stream.FileStream{
-				Obj:      s,
+				Obj:      d.escapeObjName(s),
 				Mimetype: s.GetMimetype(),
 				Reader:   s,
 			}, up)
@@ -439,7 +444,7 @@ func (d *Alias) Put(ctx context.Context, dstDir model.Obj, s model.FileStreamer,
 			up(100 / count)
 			for i, obj := range objs {
 				err = errors.Join(err, fs.PutDirectly(ctx, obj.GetPath(), &stream.FileStream{
-					Obj:      s,
+					Obj:      d.escapeObjName(s),
 					Mimetype: s.GetMimetype(),
 					Reader:   file,
 				}))
@@ -459,7 +464,7 @@ func (d *Alias) PutURL(ctx context.Context, dstDir model.Obj, name, url string) 
 	objs, err := d.getPutObjs(ctx, dstDir)
 	if err == nil {
 		for _, obj := range objs {
-			err = errors.Join(err, fs.PutURL(ctx, obj.GetPath(), name, url))
+			err = errors.Join(err, fs.PutURL(ctx, obj.GetPath(), d.escapeFilename(name, true), url))
 		}
 		return err
 	}
@@ -574,6 +579,53 @@ func (d *Alias) ResolveLinkCacheMode(path string) driver.LinkCacheMode {
 		}
 	}
 	return 0
+}
+
+func (d *Alias) escapeObjName(obj model.Obj) model.Obj {
+	name := d.escapeFilename(obj.GetName(), true)
+	if name == obj.GetName() {
+		return obj
+	}
+	return &model.ObjWrapName{Name: name, Obj: obj}
+}
+
+func (d *Alias) escapeFilenamePath(path string) string {
+	parts := strings.Split(path, "/")
+	for i := range parts {
+		parts[i] = d.escapeFilename(parts[i], true)
+	}
+	return strings.Join(parts, "/")
+}
+
+func (d *Alias) escapeFilename(name string, encode bool) string {
+	if !d.FilenameEscape {
+		return name
+	}
+	var protected, characters []string
+	for char := range strings.SplitSeq(d.FilenameEscapeChars, "\n") {
+		char = strings.TrimSuffix(char, "\r")
+		if char == "" {
+			continue
+		}
+		runes := []rune(char)
+		var escaped string
+		for _, unit := range utf16.Encode(runes[:1]) {
+			escaped += fmt.Sprintf("_x%04X_", unit)
+		}
+		escaped += string(runes[1:])
+		safeToken := "_x005F_" + escaped[1:]
+		if encode {
+			protected = append(protected, escaped, safeToken)
+			characters = append(characters, char, escaped)
+		} else {
+			protected = append(protected, safeToken, escaped)
+			characters = append(characters, escaped, char)
+		}
+	}
+	if len(protected) == 0 {
+		return name
+	}
+	return strings.NewReplacer(append(protected, characters...)...).Replace(name)
 }
 
 var _ driver.Driver = (*Alias)(nil)

--- a/drivers/alias/meta.go
+++ b/drivers/alias/meta.go
@@ -17,6 +17,7 @@ type Addition struct {
 	DetailsPassThrough   bool   `json:"details_pass_through" type:"bool" default:"false"`
 	FilenameEscape       bool   `json:"filename_escape" type:"bool" default:"false"`
 	FilenameEscapeChars  string `json:"filename_escape_chars" type:"text" help:"Strings to escape by replacing the first character with _xHHHH_ UTF-16 code units, one per line"`
+	FilenameAutoRename   bool   `json:"filename_auto_rename" type:"bool" default:"false" help:"Automatically rename matching existing backend objects when listing directories"`
 }
 
 var config = driver.Config{

--- a/drivers/alias/meta.go
+++ b/drivers/alias/meta.go
@@ -15,6 +15,8 @@ type Addition struct {
 	DownloadPartSize     int    `json:"download_part_size" default:"0" type:"number" required:"false" help:"Need to enable proxy. Unit: KB"`
 	ProviderPassThrough  bool   `json:"provider_pass_through" type:"bool" default:"false"`
 	DetailsPassThrough   bool   `json:"details_pass_through" type:"bool" default:"false"`
+	FilenameEscape       bool   `json:"filename_escape" type:"bool" default:"false"`
+	FilenameEscapeChars  string `json:"filename_escape_chars" type:"text" help:"Strings to escape by replacing the first character with _xHHHH_ UTF-16 code units, one per line"`
 }
 
 var config = driver.Config{


### PR DESCRIPTION
该 feat 的一个直接 benefit 是用于 189cloud 文件名中 `'` 和 U+4E73 字符的可逆替换：前者会被 189cloud 替换为不一致的 `\'`，后者会导致文件无法下载；替换后字符分别变为 `_x0027_`、`_x4E73_`。`_xHHHH_` 是一种在 XML、数据库以及电子表格解析中用于表示非法或无效字符的转义编码格式，其中 HHHH 代表该字符的四位十六进制 Unicode / UCS-2 编码。该格式能够兼容大部分网盘，是一种成熟的替换方案。

由于新增了 `filename_escape`、`filename_escape_chars` 和 `filename_auto_rename` 三个配置项，前端需要同步增加翻译。

## Summary / 摘要

- 为 Alias 存储增加默认关闭的 `filename_escape` 和 `filename_auto_rename` 开关，以及按行配置待转义字符串的 `filename_escape_chars`。
- 开启文件名转义后，在 Alias 读写边界匹配配置字符串，并仅将匹配字符串的首字符转换为 `_xHHHH_` UTF-16 代码单元格式；同时保护原本存在的 `_xHHHH_` 字面量。
- 读取列表时保留后端真实路径，仅向用户展示还原后的名称；创建目录、重命名、上传和 URL 上传时向后端传递转义后的名称。
- 开启 `filename_auto_rename` 后，Alias 在列出目录时自动将命中的后端既有文件或目录重命名为转义名称；迁移失败时保留原路径并继续列出目录。
- 直接获取文件时兼容已存在的未转义文件名。
- 改动仅限 Alias 驱动，不修改公共驱动接口或 `internal` 文件系统流程。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

## Related Issues / 关联 Issue

Relates to #2792

## Testing / 测试

- [ ] `go test ./...`
- [x] `go test ./drivers/alias ./internal/op ./internal/fs`
- [x] `git diff --check`
- [ ] Manual test / 手动测试

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 CONTRIBUTING。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 此 PR 已是 ready-for-review 状态，尚未额外请求维护者或 code owner 审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [x] Codex

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [x] Tests / 测试
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 已审查并验证此 PR 中包含的 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / AI 辅助提交已包含 `Co-authored-by` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。