### PR TITLE
feat(crypt): add encrypt-to-disk option to avoid OOM on large file uploads

### DIFF
--- a/drivers/crypt/driver.go
+++ b/drivers/crypt/driver.go
@@ -180,7 +180,7 @@ func (d *Crypt) Get(ctx context.Context, path string) (model.Obj, error) {
 			remoteFullPath = stdpath.Join(d.RemotePath, path)
 			remoteObj, err = fs.Get(ctx, remoteFullPath, &fs.GetArgs{NoLog: true})
 			if err != nil {
-				// 可能�?虚拟路径+开启文件夹加密：返回NotSupport让op.Get去尝试op.List查找
+				// 可能是虚拟路径+开启文件夹加密：返回NotSupport让op.Get去尝试op.List查找
 				return nil, errs.NotSupport
 			}
 		} else if secondTry && errs.IsObjectNotFound(err) {

--- a/drivers/crypt/driver.go
+++ b/drivers/crypt/driver.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	stdpath "path"
 	"regexp"
 	"strings"
@@ -179,7 +180,7 @@ func (d *Crypt) Get(ctx context.Context, path string) (model.Obj, error) {
 			remoteFullPath = stdpath.Join(d.RemotePath, path)
 			remoteObj, err = fs.Get(ctx, remoteFullPath, &fs.GetArgs{NoLog: true})
 			if err != nil {
-				// 可能是 虚拟路径+开启文件夹加密：返回NotSupport让op.Get去尝试op.List查找
+				// 可能�?虚拟路径+开启文件夹加密：返回NotSupport让op.Get去尝试op.List查找
 				return nil, errs.NotSupport
 			}
 		} else if secondTry && errs.IsObjectNotFound(err) {
@@ -363,21 +364,44 @@ func (d *Crypt) Put(ctx context.Context, dstDir model.Obj, streamer model.FileSt
 		return fmt.Errorf("failed to EncryptData: %w", err)
 	}
 
+	encryptedSize := d.cipher.EncryptedSize(streamer.GetSize())
+
 	// doesn't support seekableStream, since rapid-upload is not working for encrypted data
 	streamOut := &stream.FileStream{
 		Obj: &model.Object{
 			ID:       streamer.GetID(),
 			Path:     streamer.GetPath(),
 			Name:     d.cipher.EncryptFileName(streamer.GetName()),
-			Size:     d.cipher.EncryptedSize(streamer.GetSize()),
+			Size:     encryptedSize,
 			Modified: streamer.ModTime(),
 			IsFolder: streamer.IsDir(),
 		},
-		Reader:            wrappedIn,
 		Mimetype:          "application/octet-stream",
 		ForceStreamUpload: true,
 		Exist:             streamer.GetExist(),
 	}
+
+	if d.EncryptToDisk {
+		// Encrypt to a temp file on disk so that downstream drivers receive a seekable Reader.
+		// This avoids forcing downstream drivers (e.g. quark_open) to cache the entire
+		// encrypted stream into HybridCache, which causes excessive Page Cache usage
+		// and OOM kills in memory-constrained containers.
+		tmpFile, err := utils.CreateTempFile(wrappedIn, encryptedSize)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt to temp file: %w", err)
+		}
+		streamOut.Reader = tmpFile
+		// Ensure the temp file is closed and removed after upload finishes
+		streamOut.Add(utils.CloseFunc(func() error {
+			tmpName := tmpFile.Name()
+			closeErr := tmpFile.Close()
+			removeErr := os.Remove(tmpName)
+			return errors.Join(closeErr, removeErr)
+		}))
+	} else {
+		streamOut.Reader = wrappedIn
+	}
+
 	return op.Put(ctx, remoteStorage, remoteActualPath, streamOut, up)
 }
 

--- a/drivers/crypt/meta.go
+++ b/drivers/crypt/meta.go
@@ -16,7 +16,7 @@ type Addition struct {
 	FileNameEncoding string `json:"filename_encoding" type:"select" required:"true" options:"base64,base32,base32768" default:"base64" help:"for advanced user only!"`
 
 	Thumbnail bool `json:"thumbnail" required:"true" default:"false" help:"enable thumbnail which pre-generated under .thumbnails folder"`
-
+	EncryptToDisk    bool   `json:"encrypt_to_disk" default:"false" help:"Encrypt to temp file on disk before uploading to avoid high memory usage"`
 	ShowHidden bool `json:"show_hidden"  default:"true" required:"false" help:"show hidden directories and files"`
 }
 


### PR DESCRIPTION
## Summary / 摘要

When uploading encrypted files through downstream drivers (e.g. quark_open), `crypt.Put()` passes `cipher.EncryptData()`'s `io.Reader` (non-seekable) directly. Drivers that need random reads (e.g. for proof generation or chunked upload) must cache the entire stream into HybridCache, which writes through Linux Page Cache. In memory-constrained Docker containers, dirty pages accumulate and cause OOM kills — a 6GB encrypted file dies in ~30s with a 2GB container limit.

Add `encrypt_to_disk` option (default: `false`) to crypt storage config. When enabled, the encrypted stream is first written to a temp file on disk (via `TEMP_DIR`), then the resulting `*os.File` (seekable, implements `model.File`) is passed to downstream drivers. This avoids HybridCache entirely — memory usage drops from ~fileSize to ~50MB.

The temp file is automatically cleaned up via `streamOut.Closers` when `op.Put()` completes (success or failure).

- User-visible: new "Encrypt To Disk" checkbox in crypt storage config
- Default `false`, no behavior change for existing setups
- Tradeoff: encryption and upload become serial instead of overlapping, and `TEMP_DIR` must have enough space for the largest encrypted file

- [ ] This PR has breaking changes. 
- [ ] This PR changes public API, config, storage format, or migration behavior.
- [ ] This PR requires corresponding changes in related repositories.

## Related Issues / 关联 Issue

None found.

## Testing / 测试

- [ ] `go test ./...`
- [x] Manual test / 手动测试:
  - Built custom Docker image from this branch
  - Uploaded 6GB file via `local → crypt(EncryptToDisk=true) → quark_open`
  - Container memory stayed <100MB throughout (previously OOM killed at 30s with 2GB limit)
  - Temp file on disk cleaned up after upload completed
  - Verified `EncryptToDisk=false` (default) preserves original behavior

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
- [ ] I have requested review from relevant maintainers or code owners where applicable.

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.