### PR TITLE
fix(onaddrive_sharelink): fix html file download failure via webdav

### DIFF
--- a/drivers/onedrive_sharelink/driver.go
+++ b/drivers/onedrive_sharelink/driver.go
@@ -132,11 +132,12 @@ func (d *OnedriveSharelink) Link(ctx context.Context, file model.Obj, args model
 		}, nil
 	}
 
+	fileName := file.GetName()
 	return &model.Link{
 		URL:    url,
 		Header: header,
 		RangeReader: rangeReaderFunc(func(ctx context.Context, hr http_range.Range) (io.ReadCloser, error) {
-			return d.rangeReadWithRefresh(ctx, url, hr)
+			return d.rangeReadWithRefresh(ctx, url, hr, fileName)
 		}),
 	}, nil
 }
@@ -614,8 +615,11 @@ func parsePageContext(body []byte) (*pageContextInfo, error) {
 var _ driver.Driver = (*OnedriveSharelink)(nil)
 
 // rangeReadWithRefresh tries once with current headers, and if the response
-// looks invalid (error status or html login page), it refreshes headers and retries.
-func (d *OnedriveSharelink) rangeReadWithRefresh(ctx context.Context, url string, hr http_range.Range) (io.ReadCloser, error) {
+// looks invalid (login page, error page), it refreshes headers and retries.
+// For HTML files: checks redirect chain for login pages and sharepointerror header.
+// For non-HTML files: checks Content-Type for text/html (indicates login page).
+func (d *OnedriveSharelink) rangeReadWithRefresh(ctx context.Context, url string, hr http_range.Range, fileName string) (io.ReadCloser, error) {
+	isHTMLFile := strings.HasSuffix(strings.ToLower(fileName), ".htm") || strings.HasSuffix(strings.ToLower(fileName), ".html")
 	tryOnce := func(header http.Header) (io.ReadCloser, error) {
 		h := cloneHeader(header)
 		if h == nil {
@@ -626,10 +630,30 @@ func (d *OnedriveSharelink) rangeReadWithRefresh(ctx context.Context, url string
 		if err != nil {
 			return nil, err
 		}
-		ct := strings.ToLower(resp.Header.Get("Content-Type"))
-		if strings.Contains(ct, "text/html") {
-			_ = resp.Body.Close()
-			return nil, fmt.Errorf("unexpected html response")
+		if isHTMLFile {
+			// For HTML files, detect problematic responses that should trigger retry:
+			// 1. Redirect chain to MS login page → token expired
+			// 2. sharepointerror response header → SharePoint error page
+			if resp.Request != nil && resp.Request.URL != nil {
+				finalHost := strings.ToLower(resp.Request.URL.Hostname())
+				if strings.Contains(finalHost, "login.microsoftonline.com") ||
+					strings.Contains(finalHost, "login.live.com") ||
+					strings.Contains(finalHost, "login.microsoft.com") {
+					_ = resp.Body.Close()
+					return nil, fmt.Errorf("token expired, redirected to login page")
+				}
+			}
+			if hasSharepointError(resp.Header) {
+				_ = resp.Body.Close()
+				return nil, fmt.Errorf("sharepoint error page")
+			}
+		} else {
+			// For non-HTML files, text/html response indicates login page
+			ct := strings.ToLower(resp.Header.Get("Content-Type"))
+			if strings.Contains(ct, "text/html") {
+				_ = resp.Body.Close()
+				return nil, fmt.Errorf("unexpected html response")
+			}
 		}
 		return resp.Body, nil
 	}
@@ -661,6 +685,17 @@ func cloneHeader(header http.Header) http.Header {
 		return nil
 	}
 	return header.Clone()
+}
+
+// hasSharepointError checks if the response headers contain the sharepointerror
+// header, which SharePoint sets on error pages (e.g. invalid UniqueId).
+func hasSharepointError(header http.Header) bool {
+	for key := range header {
+		if strings.EqualFold(key, "sharepointerror") {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *OnedriveSharelink) resolveDirectDownloadURL(ctx context.Context, file model.Obj, rawURL string, header http.Header) (string, error) {

--- a/drivers/onedrive_sharelink/util.go
+++ b/drivers/onedrive_sharelink/util.go
@@ -235,10 +235,16 @@ func (d *OnedriveSharelink) getFiles(ctx context.Context, path string) ([]Item, 
 			return nil, err
 		}
 		template := re.FindString(string(body))
-		template = template[strings.Index(template, "templateUrl\":\"")+len("templateUrl\":\""):]
-		template = template[:strings.Index(template, "?id=")]
-		template = template[:strings.LastIndex(template, "/")]
-		downloadLinkPrefix = template + "/download.aspx?UniqueId="
+		if template == "" {
+			log.Warnf("onedrive_sharelink: templateUrl not found in page body, falling back to redirect URL parsing")
+			redirectUrlCut := redirectUrl[:strings.LastIndex(redirectUrl, "/")]
+			downloadLinkPrefix = redirectUrlCut + "/download.aspx?UniqueId="
+		} else {
+			template = template[strings.Index(template, "templateUrl\":\"")+len("templateUrl\":\""):]
+			template = template[:strings.Index(template, "?id=")]
+			template = template[:strings.LastIndex(template, "/")]
+			downloadLinkPrefix = template + "/download.aspx?UniqueId="
+		}
 		params, err := url.ParseQuery(redirectUrl[strings.Index(redirectUrl, "?")+1:])
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->
# fix(onaddrive_sharelink): fix html file download failure via webdav

## Summary / 摘要

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->

对htm/html 文件：通过检测重定向链是否跳转至 Microsoft 登录页
来判断 token 是否过期，以及检测 SharePoint 错误页的 sharepointerror 响应头来判断是否收到了错误页。这样可以避免用户的html文件被当成登录页/错误页然后拒绝掉。

对非text/html文件：保留原有的 text/html Content-Type 检测，也就是检测到返回了html就认为需要刷新token。

同时为 templateUrl 正则匹配失败添加回退保护。

关于本次实验的发现：通过发送UniqueId格式错误的请求到SharePoint，可以调出SharePoint错误页，其响应里包含sharepointerror标头，值为0，测试多个SharePoint站点均可复现，且目前暂未发现其他页面的返回内容里带这个标头。也就是说，这个标头可以作为判断错误页的权威证据。如果通过UniqueId形式的链接下载SharePoint文件，且token过期，则服务器返回一连串302，最终目的地一定是 `login.microsoftonline.com` 或其他可能的微软登录页（目前只测试出`login.microsoftonline.com` 这一个）。

### 为什么这样做？

之前，使用webdav请求时，软件会认为所有text/html形式的返回数据均为错误页或登录页，然后尝试刷新token，这部分代码恰好在 `rangeReadWithRefresh` （driver.go）函数里，所以webdav客户端会收到416错误。

在经过实验后，发现登录页、错误页在标头处均有明显的特征（见“关于本次实验的发现”），通过这些特征判断登录页、错误页只需要读取响应标头，并不需要读取payload，也就是返回的HTML的具体内容。

因此即使哪个用户往自己网盘里存了个和 Microsoft 登录页一模一样的玩意，本软件也能帮ta把文件正确下载下来。

### 为什么非要把html/htm文件拉出来单独写一个判断逻辑？

因为先前版本依赖返回内容的content-type判断登录页或者错误页，也就是一刀切，直接认为所有htm/html全是登录页或错误页。如果用户想下载的恰好是个html文件，程序将永远无法完成用户的请求，这可能不是本程序的预期行为。

单独拉出来做判断的原因是，错误页、登录页、用户想要的html文件，他们的content-type都是text/html。需要靠其他的特征来分辨这三种东西。

<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

变更：现在，用户通过webdav客户端挂载openlist后，下载html文件不会产生416错误。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。


## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [ ] `go test ./...`
- [x] Manual test / 手动测试: `rclone copy` 复制15000个HTML文件，历时30分钟，未产生任何错误，文件均完整。

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

新增的错误页判断是mimo code帮我写的，它还帮我检查了代码，并且进行手动测试。

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [x] Other (please specify) / 其他（请注明）: mimocode + deepseek-v4-pro

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
