### PR TITLE
feat(task): persist task timestamps across restarts

### DIFF
--- a/internal/fs/copy_queue_persistence_test.go
+++ b/internal/fs/copy_queue_persistence_test.go
@@ -1,0 +1,65 @@
+package fs
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/conf"
+	"github.com/OpenListTeam/tache"
+)
+
+func TestMigratedCopyTaskRecoversNativeFields(t *testing.T) {
+	previousConf := conf.Conf
+	conf.Conf = &conf.Config{}
+	t.Cleanup(func() { conf.Conf = previousConf })
+
+	raw := []byte(`{
+		"id":"task-one",
+		"state":0,
+		"retry":0,
+		"max_retry":0,
+		"Creator":{"id":1,"username":"admin","password":"","base_path":"/","role":2,"disabled":false,"permission":511,"sso_id":"","allow_ldap":true},
+		"start_time":"2026-08-11T01:00:00Z",
+		"end_time":"2026-08-11T01:01:00Z",
+		"TotalBytes":42,
+		"ApiUrl":"http://openlist.test:5244",
+		"src_path":"/folder/file",
+		"dst_path":"/backup",
+		"src_storage_mp":"/source",
+		"dst_storage_mp":"/target",
+		"TaskType":0
+	}`)
+
+	var task FileTransferTask
+	if err := json.Unmarshal(raw, &task); err != nil {
+		t.Fatalf("unmarshal migrated task: %v", err)
+	}
+	if task.GetID() != "task-one" || task.GetState() != tache.StatePending {
+		t.Fatalf("unexpected base fields: id=%q state=%d", task.GetID(), task.GetState())
+	}
+	if task.GetCreator() == nil || task.GetCreator().Username != "admin" {
+		t.Fatal("creator was not recovered")
+	}
+	if task.GetStartTime() == nil || task.GetEndTime() == nil {
+		t.Fatal("task timestamps were not recovered")
+	}
+	if task.TaskType != copy {
+		t.Fatalf("unexpected task type: %d", task.TaskType)
+	}
+	if task.SrcActualPath != "/folder/file" || task.DstActualPath != "/backup" {
+		t.Fatal("copy paths were not recovered")
+	}
+
+	_, maxRetry := task.GetRetry()
+	if maxRetry != 0 {
+		t.Fatalf("migration must defer retry initialization, got %d", maxRetry)
+	}
+	task.SetRetry(0, 2)
+	_, maxRetry = task.GetRetry()
+	if maxRetry != 2 {
+		t.Fatalf("retry initialization failed, got %d", maxRetry)
+	}
+	if task.groupID != "/target/backup" {
+		t.Fatalf("task group was not rebuilt: %q", task.groupID)
+	}
+}

--- a/internal/task/base.go
+++ b/internal/task/base.go
@@ -12,8 +12,8 @@ import (
 type TaskExtension struct {
 	tache.Base
 	Creator    *model.User
-	startTime  *time.Time
-	endTime    *time.Time
+	StartTime  *time.Time `json:"start_time,omitempty"`
+	EndTime    *time.Time `json:"end_time,omitempty"`
 	TotalBytes int64
 	ApiUrl     string
 }
@@ -38,23 +38,23 @@ func (t *TaskExtension) GetCreator() *model.User {
 }
 
 func (t *TaskExtension) SetStartTime(startTime time.Time) {
-	t.startTime = &startTime
+	t.StartTime = &startTime
 }
 
 func (t *TaskExtension) GetStartTime() *time.Time {
-	return t.startTime
+	return t.StartTime
 }
 
 func (t *TaskExtension) SetEndTime(endTime time.Time) {
-	t.endTime = &endTime
+	t.EndTime = &endTime
 }
 
 func (t *TaskExtension) GetEndTime() *time.Time {
-	return t.endTime
+	return t.EndTime
 }
 
 func (t *TaskExtension) ClearEndTime() {
-	t.endTime = nil
+	t.EndTime = nil
 }
 
 func (t *TaskExtension) SetTotalBytes(totalBytes int64) {


### PR DESCRIPTION
## Summary / 摘要

This PR makes task start/end timestamps part of the persisted task representation so copy tasks can recover their visible timing information after a normal restart or container recreation. It also adds a regression test covering native task unmarshalling and recovery fields.

本 PR 将任务开始/结束时间纳入持久化任务表示，使复制任务在正常重启或容器重建后能够恢复可见的时间信息，并增加原生任务反序列化与恢复字段的回归测试。

- [ ] This PR has breaking changes.
- [x] This PR changes public API, config, storage format, or migration behavior. The persisted JSON gains additive `start_time`/`end_time` fields; older payloads remain readable.
- [x] This PR requires corresponding changes in related repositories.

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: https://github.com/OpenListTeam/OpenList-Frontend/pull/629
- OpenList-Docs: not required.

## Testing / 测试

- [x] `go test ./internal/fs -run '^TestMigratedCopyTaskRecoversNativeFields$' -count=1`
- [ ] `go test ./...` — the current upstream baseline still has unrelated failures in several drivers under the current Go toolchain, an environment-dependent `internal/net` transport assertion, and aria2 RPC tests when no local aria2 service is running.
- [x] The added regression test verifies task IDs, state, creator, timestamps, paths, task type, retry initialization, and task grouping.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
- [x] I have formatted the changed code with `gofmt` or `go fmt`.
- [ ] I have requested review from relevant maintainers or code owners where applicable.

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.

Tools used / 使用工具:

- [x] Codex

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [x] Tests / 测试
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
- [x] I have ensured that this AI-assisted commit includes `Co-Authored-By` attribution.
- [x] I can reproduce the checked behavior from the committed source and test commands without relying on hidden runtime state.
