### PR TITLE
fix(drivers/189): support updated time format from 189Cloud

### DIFF
--- a/drivers/189_tv/help.go
+++ b/drivers/189_tv/help.go
@@ -72,9 +72,15 @@ func (t *Time) UnmarshalXML(e *xml.Decoder, ee xml.StartElement) error {
 }
 func (t *Time) Unmarshal(b []byte) error {
 	bs := strings.Trim(string(b), "\"")
+	bs = strings.ReplaceAll(bs, "\u202f", " ")
+	bs = strings.ReplaceAll(bs, "\u00a0", " ")
 	var v time.Time
 	var err error
-	for _, f := range []string{"2006-01-02 15:04:05 -07", "Jan 2, 2006 15:04:05 PM -07"} {
+	for _, f := range []string{
+		"2006-01-02 15:04:05 -07",
+		"Jan 2, 2006 15:04:05 PM -07",
+		"Jan 2, 2006, 3:04:05 PM -07",
+	} {
 		v, err = time.ParseInLocation(f, bs+" +08", time.Local)
 		if err == nil {
 			break

--- a/drivers/189_tv/help_test.go
+++ b/drivers/189_tv/help_test.go
@@ -1,0 +1,70 @@
+package _189_tv
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeUnmarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{
+			name:  "numeric date",
+			input: "2026-08-12 03:32:44",
+			want:  time.Date(2026, time.August, 12, 3, 32, 44, 0, time.Local),
+		},
+		{
+			name:  "legacy month date",
+			input: "Aug 12, 2026 15:32:44 PM",
+			want:  time.Date(2026, time.August, 12, 15, 32, 44, 0, time.Local),
+		},
+		{
+			name:  "updated format with AM",
+			input: "Aug 12, 2026, 12:35:41 AM",
+			want:  time.Date(2026, time.August, 12, 0, 35, 41, 0, time.Local),
+		},
+		{
+			name:  "updated format with PM",
+			input: "Aug 12, 2026, 3:32:44 PM",
+			want:  time.Date(2026, time.August, 12, 15, 32, 44, 0, time.Local),
+		},
+		{
+			name:  "narrow no-break space",
+			input: "Aug 12, 2026, 3:32:44\u202fPM",
+			want:  time.Date(2026, time.August, 12, 15, 32, 44, 0, time.Local),
+		},
+		{
+			name:  "no-break space",
+			input: "Aug 12, 2026, 3:32:44\u00a0AM",
+			want:  time.Date(2026, time.August, 12, 3, 32, 44, 0, time.Local),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got Time
+			if err := got.Unmarshal([]byte(tt.input)); err != nil {
+				t.Fatalf("Time.Unmarshal(%q) returned error: %v", tt.input, err)
+			}
+			gotTime := time.Time(got)
+			gotYear, gotMonth, gotDay := gotTime.Date()
+			wantYear, wantMonth, wantDay := tt.want.Date()
+			gotHour, gotMinute, gotSecond := gotTime.Clock()
+			wantHour, wantMinute, wantSecond := tt.want.Clock()
+			if gotYear != wantYear || gotMonth != wantMonth || gotDay != wantDay ||
+				gotHour != wantHour || gotMinute != wantMinute || gotSecond != wantSecond {
+				t.Fatalf("Time.Unmarshal(%q) = %v, want %v", tt.input, gotTime, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeUnmarshalRejectsInvalidTime(t *testing.T) {
+	var got Time
+	if err := got.Unmarshal([]byte("Aug 12, 2026, 25:32:44 PM")); err == nil {
+		t.Fatal("Time.Unmarshal accepted an invalid time")
+	}
+}

--- a/drivers/189pc/help.go
+++ b/drivers/189pc/help.go
@@ -116,9 +116,15 @@ func (t *Time) UnmarshalXML(e *xml.Decoder, ee xml.StartElement) error {
 }
 func (t *Time) Unmarshal(b []byte) error {
 	bs := strings.Trim(string(b), "\"")
+	bs = strings.ReplaceAll(bs, "\u202f", " ")
+	bs = strings.ReplaceAll(bs, "\u00a0", " ")
 	var v time.Time
 	var err error
-	for _, f := range []string{"2006-01-02 15:04:05 -07", "Jan 2, 2006 15:04:05 PM -07"} {
+	for _, f := range []string{
+		"2006-01-02 15:04:05 -07",
+		"Jan 2, 2006 15:04:05 PM -07",
+		"Jan 2, 2006, 3:04:05 PM -07",
+	} {
 		v, err = time.ParseInLocation(f, bs+" +08", time.Local)
 		if err == nil {
 			break

--- a/drivers/189pc/help_test.go
+++ b/drivers/189pc/help_test.go
@@ -1,0 +1,65 @@
+package _189pc
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeUnmarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{
+			name:  "numeric date",
+			input: "2026-08-12 03:32:44",
+			want:  time.Date(2026, time.August, 12, 3, 32, 44, 0, time.Local),
+		},
+		{
+			name:  "legacy month date",
+			input: "Aug 12, 2026 15:32:44 PM",
+			want:  time.Date(2026, time.August, 12, 15, 32, 44, 0, time.Local),
+		},
+		{
+			name:  "updated month date",
+			input: "Aug 12, 2026, 3:32:44 AM",
+			want:  time.Date(2026, time.August, 12, 3, 32, 44, 0, time.Local),
+		},
+		{
+			name:  "narrow no-break space before meridiem",
+			input: "Aug 12, 2026, 3:32:44\u202fAM",
+			want:  time.Date(2026, time.August, 12, 3, 32, 44, 0, time.Local),
+		},
+		{
+			name:  "no-break space before meridiem",
+			input: "Aug 12, 2026, 3:32:44\u00a0AM",
+			want:  time.Date(2026, time.August, 12, 3, 32, 44, 0, time.Local),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got Time
+			if err := got.Unmarshal([]byte(tt.input)); err != nil {
+				t.Fatalf("Time.Unmarshal(%q) returned error: %v", tt.input, err)
+			}
+			gotTime := time.Time(got)
+			gotYear, gotMonth, gotDay := gotTime.Date()
+			wantYear, wantMonth, wantDay := tt.want.Date()
+			gotHour, gotMinute, gotSecond := gotTime.Clock()
+			wantHour, wantMinute, wantSecond := tt.want.Clock()
+			if gotYear != wantYear || gotMonth != wantMonth || gotDay != wantDay ||
+				gotHour != wantHour || gotMinute != wantMinute || gotSecond != wantSecond {
+				t.Fatalf("Time.Unmarshal(%q) = %v, want %v", tt.input, gotTime, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeUnmarshalRejectsInvalidTime(t *testing.T) {
+	var got Time
+	if err := got.Unmarshal([]byte("Aug 12, 2026, 25:32:44 AM")); err == nil {
+		t.Fatal("Time.Unmarshal accepted an invalid time")
+	}
+}


### PR DESCRIPTION
## Summary / 摘要

Add compatibility for the updated time strings returned by the 189Cloud PC and TV clients.

- Normalize Unicode narrow no-break space (`U+202F`) and no-break space (`U+00A0`) before parsing.
- Preserve the existing 189PC and 189TV time layouts and add `Jan 2, 2006, 3:04:05 PM -07` for the current response format.
- Add unit coverage for both drivers, including legacy formats, the updated 12-hour format, both Unicode spaces, AM/PM conversion, and invalid input.

The 189Cloud API may now return values such as `Aug 12, 2026, 3:32:44 AM`. The existing parsers did not accept the comma after the year or the Unicode space before `AM`/`PM`. The parsing error can propagate to callers and may cause an otherwise successful operation to be reported as failed.

Real-world verification was performed against 189Cloud PC after opening this PR: uploads complete successfully and the previous time parsing error no longer occurs. The same parser compatibility update is also applied to `189_tv`, which uses the equivalent time parsing logic.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: N/A
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

Fixes #2917

## Testing / 测试

- [x] `go test -vet=off ./drivers/189pc`
- [x] `go test -vet=off ./drivers/189_tv`
- [x] `go test -vet=off ./drivers/189pc ./drivers/189_tv ./internal/model ./internal/op ./internal/fs ./pkg/utils`
- [ ] `go test ./...` — FAILED due to pre-existing vet, environment, and service-availability failures described below.
- [x] Manual test / 手动测试: Real-world 189Cloud PC upload verification was performed after this PR was opened; the upload completed successfully without the previous time parsing error.

The full command was run, but it did not pass for reasons unrelated to this change:

- Pre-existing non-constant format-string vet errors across multiple packages, including `drivers/189pc/utils.go:358` and `drivers/189pc/utils.go:418`.
- `internal/net` environment-sensitive failure: `TestNewOSSClientUsesEnvironmentHTTPSProxy` expected `*http.Transport` but received `*net.safeTransport`.
- `pkg/aria2/rpc` tests could not connect to the required local service at `localhost:6800`.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [x] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
