### PR TITLE
fix(drivers/189): support updated 189 time format

### DIFF
--- a/drivers/189_tv/help.go
+++ b/drivers/189_tv/help.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 )
 
 func clientSuffix() map[string]string {
@@ -72,10 +74,19 @@ func (t *Time) UnmarshalXML(e *xml.Decoder, ee xml.StartElement) error {
 }
 func (t *Time) Unmarshal(b []byte) error {
 	bs := strings.Trim(string(b), "\"")
+	// 189 时间串里 AM/PM 前可能使用 U+202F 窄不换行空格或 U+00A0 不换行空格，统一替换为普通空格
+	bs = strings.ReplaceAll(bs, "\u202f", " ")
+	bs = strings.ReplaceAll(bs, "\u00a0", " ")
 	var v time.Time
 	var err error
-	for _, f := range []string{"2006-01-02 15:04:05 -07", "Jan 2, 2006 15:04:05 PM -07"} {
-		v, err = time.ParseInLocation(f, bs+" +08", time.Local)
+	// 189 返回的时间可能自带时区（如 "Aug 11, 2026, 10:37:18 PM +08"），也可能不带，分别尝试
+	for _, s := range []string{bs, bs + " +08"} {
+		for _, f := range []string{"2006-01-02 15:04:05 -07", "Jan 2, 2006 3:04:05 PM -07", "Jan 2, 2006, 3:04:05 PM -07"} {
+			v, err = time.ParseInLocation(f, s, utils.CNLoc)
+			if err == nil {
+				break
+			}
+		}
 		if err == nil {
 			break
 		}

--- a/drivers/189_tv/help_test.go
+++ b/drivers/189_tv/help_test.go
@@ -1,0 +1,39 @@
+package _189_tv
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeUnmarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{"numeric date", `"2026-08-11 10:37:18"`, time.Date(2026, 8, 11, 10, 37, 18, 0, time.FixedZone("", 8*3600))},
+		{"legacy month date", `"Aug 11, 2026 10:37:18 PM"`, time.Date(2026, 8, 11, 22, 37, 18, 0, time.FixedZone("", 8*3600))},
+		{"new format with tz", `"Aug 11, 2026, 10:37:18 PM +08"`, time.Date(2026, 8, 11, 22, 37, 18, 0, time.FixedZone("", 8*3600))},
+		{"new format no tz", `"Aug 11, 2026, 10:37:18 PM"`, time.Date(2026, 8, 11, 22, 37, 18, 0, time.FixedZone("", 8*3600))},
+		{"narrow no-break space (U+202F)", "\"Aug 12, 2026, 12:35:41\u202fAM +08\"", time.Date(2026, 8, 12, 0, 35, 41, 0, time.FixedZone("", 8*3600))},
+		{"no-break space (U+00A0)", "\"Aug 12, 2026, 12:35:41\u00a0AM +08\"", time.Date(2026, 8, 12, 0, 35, 41, 0, time.FixedZone("", 8*3600))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tm Time
+			if err := tm.Unmarshal([]byte(tt.input)); err != nil {
+				t.Fatalf("Unmarshal(%s) error: %v", tt.input, err)
+			}
+			if !tt.want.Equal(time.Time(tm)) {
+				t.Fatalf("Unmarshal(%s) = %v, want %v", tt.input, time.Time(tm), tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeUnmarshalRejectsInvalid(t *testing.T) {
+	var tm Time
+	if err := tm.Unmarshal([]byte("Aug 12, 2026, 25:32:44 AM")); err == nil {
+		t.Fatal("Unmarshal accepted an invalid time")
+	}
+}

--- a/drivers/189pc/help.go
+++ b/drivers/189pc/help.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils/random"
 )
 
@@ -116,10 +117,19 @@ func (t *Time) UnmarshalXML(e *xml.Decoder, ee xml.StartElement) error {
 }
 func (t *Time) Unmarshal(b []byte) error {
 	bs := strings.Trim(string(b), "\"")
+	// 189 时间串里 AM/PM 前可能使用 U+202F 窄不换行空格或 U+00A0 不换行空格，统一替换为普通空格
+	bs = strings.ReplaceAll(bs, "\u202f", " ")
+	bs = strings.ReplaceAll(bs, "\u00a0", " ")
 	var v time.Time
 	var err error
-	for _, f := range []string{"2006-01-02 15:04:05 -07", "Jan 2, 2006 15:04:05 PM -07"} {
-		v, err = time.ParseInLocation(f, bs+" +08", time.Local)
+	// 189 返回的时间可能自带时区（如 "Aug 11, 2026, 10:37:18 PM +08"），也可能不带，分别尝试
+	for _, s := range []string{bs, bs + " +08"} {
+		for _, f := range []string{"2006-01-02 15:04:05 -07", "Jan 2, 2006 3:04:05 PM -07", "Jan 2, 2006, 3:04:05 PM -07"} {
+			v, err = time.ParseInLocation(f, s, utils.CNLoc)
+			if err == nil {
+				break
+			}
+		}
 		if err == nil {
 			break
 		}

--- a/drivers/189pc/help_test.go
+++ b/drivers/189pc/help_test.go
@@ -1,0 +1,39 @@
+package _189pc
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeUnmarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{"numeric date", `"2026-08-11 10:37:18"`, time.Date(2026, 8, 11, 10, 37, 18, 0, time.FixedZone("", 8*3600))},
+		{"legacy month date", `"Aug 11, 2026 10:37:18 PM"`, time.Date(2026, 8, 11, 22, 37, 18, 0, time.FixedZone("", 8*3600))},
+		{"new format with tz", `"Aug 11, 2026, 10:37:18 PM +08"`, time.Date(2026, 8, 11, 22, 37, 18, 0, time.FixedZone("", 8*3600))},
+		{"new format no tz", `"Aug 11, 2026, 10:37:18 PM"`, time.Date(2026, 8, 11, 22, 37, 18, 0, time.FixedZone("", 8*3600))},
+		{"narrow no-break space (U+202F)", "\"Aug 12, 2026, 12:35:41\u202fAM +08\"", time.Date(2026, 8, 12, 0, 35, 41, 0, time.FixedZone("", 8*3600))},
+		{"no-break space (U+00A0)", "\"Aug 12, 2026, 12:35:41\u00a0AM +08\"", time.Date(2026, 8, 12, 0, 35, 41, 0, time.FixedZone("", 8*3600))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tm Time
+			if err := tm.Unmarshal([]byte(tt.input)); err != nil {
+				t.Fatalf("Unmarshal(%s) error: %v", tt.input, err)
+			}
+			if !tt.want.Equal(time.Time(tm)) {
+				t.Fatalf("Unmarshal(%s) = %v, want %v", tt.input, time.Time(tm), tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeUnmarshalRejectsInvalid(t *testing.T) {
+	var tm Time
+	if err := tm.Unmarshal([]byte("Aug 12, 2026, 25:32:44 AM")); err == nil {
+		t.Fatal("Unmarshal accepted an invalid time")
+	}
+}


### PR DESCRIPTION
## Summary / 摘要

189 API 变更了时间返回格式，现有 `Time.Unmarshal` 无法解析，导致 189pc/189_tv 驱动所有写操作失败（Put → 500）。

- 新增模板 `Jan 2, 2006, 3:04:05 PM -07`（带逗号，`3` 12 小时制配 PM），覆盖 `Aug 11, 2026, 10:37:18 PM +08`
- 解析前将 U+202F 窄不换行空格、U+00A0 不换行空格统一替换为普通空格
- 对可能不带时区的串，先试原串再试追加 ` +08`（向后兼容）
- 同步修复 189pc 与 189_tv 两个驱动

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: N/A
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

Fixes #2917

## Testing / 测试

- [ ] `go test ./...`
- [x] Manual test / 手动测试: 本地 docker 运行 patched 镜像 + 真实 189 存储，S3 PUT 200，日志 0 个 parsing time 错误

执行命令：

```
go test -vet=off -run TestTimeUnmarshal ./drivers/189pc/ ./drivers/189_tv/
```

```
--- PASS: TestTimeUnmarshal (0.00s)
    --- PASS: TestTimeUnmarshal/numeric_date
    --- PASS: TestTimeUnmarshal/legacy_month_date
    --- PASS: TestTimeUnmarshal/new_format_with_tz
    --- PASS: TestTimeUnmarshal/new_format_no_tz
    --- PASS: TestTimeUnmarshal/narrow_no-break_space_(U+202F)
    --- PASS: TestTimeUnmarshal/no-break_space_(U+00A0)
--- PASS: TestTimeUnmarshalRejectsInvalid (0.00s)
```

`go test ./...` 因 pre-existing vet 错误（`drivers/189pc/utils.go:358` 非常量格式串）未通过，与本次改动无关。

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [x] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。