### PR TITLE
fix(offline): expose native 115 tools for ED2K downloads

### DIFF
--- a/internal/offline_download/tool/add.go
+++ b/internal/offline_download/tool/add.go
@@ -223,11 +223,34 @@ func isEd2kURL(urlStr string) bool {
 }
 
 func ed2kToolForStorage(storage driver.Driver) string {
+	switch toolNameForStorage(storage) {
+	case "115 Cloud", "115 Open":
+		return toolNameForStorage(storage)
+	default:
+		return ""
+	}
+}
+
+func toolNameForStorage(storage driver.Driver) string {
 	switch storage.(type) {
 	case *_115.Pan115:
 		return "115 Cloud"
 	case *_115_open.Open115:
 		return "115 Open"
+	case *_123.Pan123:
+		return "123Pan"
+	case *_123_open.Open123:
+		return "123 Open"
+	case *guangyapan.GuangYaPan:
+		return "GuangYaPan"
+	case *pikpak.PikPak:
+		return "PikPak"
+	case *thunder.Thunder:
+		return "Thunder"
+	case *thunderx.ThunderX:
+		return "ThunderX"
+	case *thunder_browser.ThunderBrowser, *thunder_browser.ThunderBrowserExpert:
+		return "ThunderBrowser"
 	default:
 		return ""
 	}

--- a/internal/offline_download/tool/add.go
+++ b/internal/offline_download/tool/add.go
@@ -18,6 +18,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/drivers/thunder_browser"
 	"github.com/OpenListTeam/OpenList/v4/drivers/thunderx"
 	"github.com/OpenListTeam/OpenList/v4/internal/conf"
+	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 	"github.com/OpenListTeam/OpenList/v4/internal/errs"
 	"github.com/OpenListTeam/OpenList/v4/internal/fs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
@@ -69,7 +70,7 @@ func AddURL(ctx context.Context, args *AddURLArgs) (task.TaskExtensionInfo, erro
 		}
 	}
 	// try putting url
-	if args.Tool == "SimpleHttp" {
+	if args.Tool == "SimpleHttp" && !isEd2kURL(args.URL) {
 		if isSimpleHttpSchemeUnsupported(args.URL) {
 			return nil, fmt.Errorf("SimpleHttp tool does not support this URL scheme, please use aria2 or other tools for magnet/ed2k links")
 		}
@@ -83,13 +84,17 @@ func AddURL(ctx context.Context, args *AddURLArgs) (task.TaskExtensionInfo, erro
 	// ed2k 链接自动路由：如果当前工具不支持 ed2k，自动尝试使用迅雷系工具
 	if isEd2kURL(args.URL) {
 		if !isEd2kCapableTool(args.Tool) {
-			// 尝试找到一个可用的支持 ed2k 的工具
-			fallbackTool, fallbackName := findEd2kCapableTool()
-			if fallbackTool != nil {
-				// 使用找到的迅雷工具替代
-				args.Tool = fallbackName
+			if storageTool := ed2kToolForStorage(storage); storageTool != "" {
+				// Prefer the matching native tool when the destination storage supports ed2k.
+				args.Tool = storageTool
 			} else {
-				return nil, fmt.Errorf("ed2k protocol is not supported by %s. Please configure and use Thunder/ThunderX/ThunderBrowser for ed2k links", args.Tool)
+				// Otherwise, try to find an available Thunder-family tool.
+				fallbackTool, fallbackName := findEd2kCapableTool()
+				if fallbackTool != nil {
+					args.Tool = fallbackName
+				} else {
+					return nil, fmt.Errorf("ed2k protocol is not supported by %s. Please configure and use Thunder/ThunderX/ThunderBrowser for ed2k links", args.Tool)
+				}
 			}
 		}
 	}
@@ -215,6 +220,17 @@ func isSimpleHttpSchemeUnsupported(urlStr string) bool {
 // isEd2kURL 检测 URL 是否为 ed2k 协议
 func isEd2kURL(urlStr string) bool {
 	return strings.HasPrefix(strings.ToLower(urlStr), "ed2k://")
+}
+
+func ed2kToolForStorage(storage driver.Driver) string {
+	switch storage.(type) {
+	case *_115.Pan115:
+		return "115 Cloud"
+	case *_115_open.Open115:
+		return "115 Open"
+	default:
+		return ""
+	}
 }
 
 // ed2kCapableTools 支持 ed2k 协议的工具列表

--- a/internal/offline_download/tool/add.go
+++ b/internal/offline_download/tool/add.go
@@ -217,8 +217,11 @@ func isEd2kURL(urlStr string) bool {
 	return strings.HasPrefix(strings.ToLower(urlStr), "ed2k://")
 }
 
-// ed2kCapableTools 支持 ed2k 协议的工具列表（迅雷系）
-var ed2kCapableTools = []string{"Thunder", "ThunderX", "ThunderBrowser"}
+// ed2kCapableTools 支持 ed2k 协议的工具列表
+var ed2kCapableTools = []string{"115 Cloud", "115 Open", "Thunder", "ThunderX", "ThunderBrowser"}
+
+// ed2kFallbackTools 是当前可用于自动接管 ed2k 任务的工具列表。
+var ed2kFallbackTools = []string{"Thunder", "ThunderX", "ThunderBrowser"}
 
 // isEd2kCapableTool 检查工具是否支持 ed2k 协议
 func isEd2kCapableTool(toolName string) bool {
@@ -232,7 +235,7 @@ func isEd2kCapableTool(toolName string) bool {
 
 // findEd2kCapableTool 查找一个可用的支持 ed2k 的工具
 func findEd2kCapableTool() (Tool, string) {
-	for _, name := range ed2kCapableTools {
+	for _, name := range ed2kFallbackTools {
 		t, err := Tools.Get(name)
 		if err != nil {
 			continue

--- a/internal/offline_download/tool/add_test.go
+++ b/internal/offline_download/tool/add_test.go
@@ -1,0 +1,26 @@
+package tool
+
+import "testing"
+
+func TestIsEd2kCapableTool(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "115 Cloud", want: true},
+		{name: "115 Open", want: true},
+		{name: "Thunder", want: true},
+		{name: "ThunderX", want: true},
+		{name: "ThunderBrowser", want: true},
+		{name: "aria2", want: false},
+		{name: "SimpleHttp", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isEd2kCapableTool(tt.name); got != tt.want {
+				t.Fatalf("isEd2kCapableTool(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/offline_download/tool/add_test.go
+++ b/internal/offline_download/tool/add_test.go
@@ -1,6 +1,12 @@
 package tool
 
-import "testing"
+import (
+	"testing"
+
+	_115 "github.com/OpenListTeam/OpenList/v4/drivers/115"
+	_115_open "github.com/OpenListTeam/OpenList/v4/drivers/115_open"
+	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+)
 
 func TestIsEd2kCapableTool(t *testing.T) {
 	tests := []struct {
@@ -20,6 +26,26 @@ func TestIsEd2kCapableTool(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isEd2kCapableTool(tt.name); got != tt.want {
 				t.Fatalf("isEd2kCapableTool(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEd2kToolForStorage(t *testing.T) {
+	tests := []struct {
+		name    string
+		storage driver.Driver
+		want    string
+	}{
+		{name: "115 Cloud", storage: &_115.Pan115{}, want: "115 Cloud"},
+		{name: "115 Open", storage: &_115_open.Open115{}, want: "115 Open"},
+		{name: "other", storage: nil, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ed2kToolForStorage(tt.storage); got != tt.want {
+				t.Fatalf("ed2kToolForStorage(%T) = %q, want %q", tt.storage, got, tt.want)
 			}
 		})
 	}

--- a/internal/offline_download/tool/add_test.go
+++ b/internal/offline_download/tool/add_test.go
@@ -5,6 +5,13 @@ import (
 
 	_115 "github.com/OpenListTeam/OpenList/v4/drivers/115"
 	_115_open "github.com/OpenListTeam/OpenList/v4/drivers/115_open"
+	_123 "github.com/OpenListTeam/OpenList/v4/drivers/123"
+	_123_open "github.com/OpenListTeam/OpenList/v4/drivers/123_open"
+	"github.com/OpenListTeam/OpenList/v4/drivers/guangyapan"
+	"github.com/OpenListTeam/OpenList/v4/drivers/pikpak"
+	"github.com/OpenListTeam/OpenList/v4/drivers/thunder"
+	"github.com/OpenListTeam/OpenList/v4/drivers/thunder_browser"
+	"github.com/OpenListTeam/OpenList/v4/drivers/thunderx"
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
 )
 
@@ -46,6 +53,33 @@ func TestEd2kToolForStorage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ed2kToolForStorage(tt.storage); got != tt.want {
 				t.Fatalf("ed2kToolForStorage(%T) = %q, want %q", tt.storage, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToolNameForStorage(t *testing.T) {
+	tests := []struct {
+		name    string
+		storage driver.Driver
+		want    string
+	}{
+		{name: "115 Cloud", storage: &_115.Pan115{}, want: "115 Cloud"},
+		{name: "115 Open", storage: &_115_open.Open115{}, want: "115 Open"},
+		{name: "123Pan", storage: &_123.Pan123{}, want: "123Pan"},
+		{name: "123 Open", storage: &_123_open.Open123{}, want: "123 Open"},
+		{name: "GuangYaPan", storage: &guangyapan.GuangYaPan{}, want: "GuangYaPan"},
+		{name: "PikPak", storage: &pikpak.PikPak{}, want: "PikPak"},
+		{name: "Thunder", storage: &thunder.Thunder{}, want: "Thunder"},
+		{name: "ThunderX", storage: &thunderx.ThunderX{}, want: "ThunderX"},
+		{name: "ThunderBrowser", storage: &thunder_browser.ThunderBrowser{}, want: "ThunderBrowser"},
+		{name: "other", storage: nil, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toolNameForStorage(tt.storage); got != tt.want {
+				t.Fatalf("toolNameForStorage(%T) = %q, want %q", tt.storage, got, tt.want)
 			}
 		})
 	}

--- a/internal/offline_download/tool/tools.go
+++ b/internal/offline_download/tool/tools.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/internal/op"
 )
 
 var (
@@ -32,6 +33,31 @@ func (t ToolsManager) Names() []string {
 		}
 	}
 	sort.Strings(names)
+	return names
+}
+
+// NamesForPath returns ready tools and the native tool for the destination storage.
+// Native tools can write directly to their own storage even without a temporary path setting.
+func (t ToolsManager) NamesForPath(path string) []string {
+	names := t.Names()
+	storage, _, err := op.GetStorageAndActualPath(path)
+	if err != nil {
+		return names
+	}
+
+	name := toolNameForStorage(storage)
+	if name == "" {
+		return names
+	}
+	for _, existing := range names {
+		if existing == name {
+			return names
+		}
+	}
+	if _, ok := t[name]; ok {
+		names = append(names, name)
+		sort.Strings(names)
+	}
 	return names
 }
 

--- a/server/handles/offline_download.go
+++ b/server/handles/offline_download.go
@@ -518,7 +518,7 @@ func SetGuangYaPan(c *gin.Context) {
 }
 
 func OfflineDownloadTools(c *gin.Context) {
-	tools := tool.Tools.Names()
+	tools := tool.Tools.NamesForPath(c.Query("path"))
 	common.SuccessResp(c, tools)
 }
 


### PR DESCRIPTION
## Summary / 摘要

Expose the native offline-download tool for the destination storage and route ED2K requests to a compatible tool.

- Skip the SimpleHttp URL handling path for ED2K links so they can reach ED2K tool selection.
- Prefer the matching native 115 tool when the destination is 115 Cloud or 115 Open.
- Keep Thunder, ThunderX, and ThunderBrowser fallback behavior for other destinations.
- Include the destination storage's native tool in the path-aware tool list used by the frontend.
- Add focused regression coverage for ED2K capability and storage-to-tool mapping.

The existing 115 ED2K download path was manually verified successfully before this change. This PR addresses the empty/incomplete tool selection for the destination storage and adds backend routing safeguards; it does not claim that this change was the cause of the already successful download.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: [#631](https://github.com/OpenListTeam/OpenList-Frontend/pull/631)
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

Fixes #2891

## Testing / 测试

- [x] `go test ./internal/offline_download/tool ./server/handles`
- [x] `git diff --check`
- [x] `gofmt -d` on all changed Go files produced no output.
- [ ] `go test ./...` — NOT RUN.
- [ ] Manual test / 手动测试: a real 115 ED2K download was verified successfully before this change; no new live test was run after changing tool discovery/routing.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
