### PR TITLE
feat(drivers/139): support SMS challenge login

### DIFF
--- a/drivers/139/credential_exchange_test.go
+++ b/drivers/139/credential_exchange_test.go
@@ -1,0 +1,258 @@
+package _139
+
+import (
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/drivers/base"
+	"github.com/go-resty/resty/v2"
+)
+
+func TestShouldExchangeAuthorization(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tests := []struct {
+		name string
+		ttl  time.Duration
+		want bool
+	}{
+		{name: "outside window", ttl: 3*24*time.Hour + time.Millisecond},
+		{name: "at three day boundary", ttl: 3 * 24 * time.Hour, want: true},
+		{name: "inside window", ttl: 12 * time.Hour, want: true},
+		{name: "expired", ttl: -time.Millisecond, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldExchangeAuthorization(now, now.Add(tt.ttl)); got != tt.want {
+				t.Fatalf("shouldExchangeAuthorization() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInvalidAuthorizationDoesNotUseCookieFastLogin(t *testing.T) {
+	d := Yun139{Addition: Addition{
+		Authorization: "not-base64",
+		MailCookies:   "Os_SSo_Sid=sid; RMKEY=rmkey",
+	}}
+
+	err := d.refreshTokenAt(time.Unix(1_700_000_000, 0))
+	if err == nil || !strings.Contains(err.Error(), "password login failed") {
+		t.Fatalf("refreshTokenAt() error = %v, want password login fallback error", err)
+	}
+	if d.Authorization != "not-base64" {
+		t.Fatalf("Authorization = %q, want original invalid value retained", d.Authorization)
+	}
+}
+
+func TestSMSSceneForRisk(t *testing.T) {
+	tests := map[string]int{
+		"S025":         1,
+		"S035":         1,
+		"PML401010062": 2,
+		"MW0016":       4,
+	}
+	for riskCode, want := range tests {
+		got, ok := smsSceneForRisk(riskCode)
+		if !ok || got != want {
+			t.Fatalf("smsSceneForRisk(%q) = %d, %t; want %d, true", riskCode, got, ok, want)
+		}
+	}
+	if _, ok := smsSceneForRisk("PICTURE_ONLY"); ok {
+		t.Fatal("smsSceneForRisk() accepted unsupported risk code")
+	}
+}
+
+func TestSanitizeMailLoginCookiesKeepsDeviceContext(t *testing.T) {
+	got := sanitizeMailLoginCookies(
+		"behaviorid=device; Os_SSo_Sid=old-sid; RMKEY=old-rmkey; JSESSIONID=old-session; S_DEVICE_TOKEN=fingerprint",
+		"new-session",
+	)
+	want := "behaviorid=device;JSESSIONID=new-session;S_DEVICE_TOKEN=fingerprint"
+	if got != want {
+		t.Fatalf("sanitizeMailLoginCookies() = %q, want %q", got, want)
+	}
+}
+
+func TestSendSMSVerificationCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		if r.URL.Query().Get("func") != "login:sendSmsCodeByScene" {
+			t.Errorf("func = %q", r.URL.Query().Get("func"))
+		}
+		if !strings.Contains(string(body), `<string name="scene">1</string>`) {
+			t.Errorf("request body = %s", body)
+		}
+		if !strings.Contains(r.Header.Get("Cookie"), "device=fingerprint") {
+			t.Errorf("Cookie = %q", r.Header.Get("Cookie"))
+		}
+		http.SetCookie(w, &http.Cookie{Name: "challenge", Value: "sms"})
+		_, _ = io.WriteString(w, `{"code":"S_OK"}`)
+	}))
+	defer server.Close()
+
+	oldURL := mailSMSURL
+	mailSMSURL = server.URL
+	defer func() { mailSMSURL = oldURL }()
+
+	d := Yun139{Addition: Addition{Username: "18800000000", MailCookies: "device=fingerprint"}}
+	if err := d.sendSMSVerificationCode("S025"); err != nil {
+		t.Fatalf("sendSMSVerificationCode() error = %v", err)
+	}
+	if !strings.Contains(d.MailCookies, "challenge=sms") {
+		t.Fatalf("MailCookies = %q", d.MailCookies)
+	}
+}
+
+func TestSendSMSVerificationCodeStopsAtPictureChallenge(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"code":"PML401010021"}`)
+	}))
+	defer server.Close()
+
+	oldURL := mailSMSURL
+	mailSMSURL = server.URL
+	defer func() { mailSMSURL = oldURL }()
+
+	d := Yun139{Addition: Addition{Username: "18800000000"}}
+	err := d.sendSMSVerificationCode("S025")
+	if err == nil || !strings.Contains(err.Error(), "requires picture verification") {
+		t.Fatalf("sendSMSVerificationCode() error = %v", err)
+	}
+}
+
+func TestVerifySMSCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		if r.URL.Query().Get("func") != "/login/inlogin.action" {
+			t.Errorf("func = %q", r.URL.Query().Get("func"))
+		}
+		wantHash := sha1Hash("fetion.com.cn:123456")
+		if !strings.Contains(string(body), `<string name="loginPassword">`+wantHash+`</string>`) {
+			t.Errorf("request body does not contain SMS code hash: %s", body)
+		}
+		http.SetCookie(w, &http.Cookie{Name: "RMKEY", Value: "new-rmkey"})
+		_, _ = io.WriteString(w, `{"code":"S_OK","var":{"loginSuccessUrl":"https://mail.10086.cn/?sid=sms-sid"}}`)
+	}))
+	defer server.Close()
+
+	oldURL := mailSMSURL
+	mailSMSURL = server.URL
+	defer func() { mailSMSURL = oldURL }()
+
+	d := Yun139{Addition: Addition{
+		Username:    "18800000000",
+		SmsCode:     "123456",
+		MailCookies: "challenge=sms",
+	}}
+	sid, err := d.verifySMSCode("S025")
+	if err != nil {
+		t.Fatalf("verifySMSCode() error = %v", err)
+	}
+	if sid != "sms-sid" {
+		t.Fatalf("sid = %q", sid)
+	}
+	if d.SmsCode != "" {
+		t.Fatalf("SmsCode = %q, want cleared", d.SmsCode)
+	}
+	if !strings.Contains(d.MailCookies, "RMKEY=new-rmkey") {
+		t.Fatalf("MailCookies = %q", d.MailCookies)
+	}
+}
+
+func TestDecodeDriveAuthorization(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("mobile:18800000000:token:with:colons"))
+	account, token, err := decodeDriveAuthorization("Basic " + encoded)
+	if err != nil {
+		t.Fatalf("decodeDriveAuthorization() error = %v", err)
+	}
+	if account != "18800000000" || token != "token:with:colons" {
+		t.Fatalf("decodeDriveAuthorization() = %q, %q", account, token)
+	}
+}
+
+func TestRecoverMailSessionFromDrive(t *testing.T) {
+	oldClient := base.RestyClient
+	base.RestyClient = resty.New().SetRetryCount(0)
+	defer func() { base.RestyClient = oldClient }()
+
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		switch r.URL.Path {
+		case "/tellin/querySpecToken.do":
+			decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(r.Header.Get("Authorization"), "Basic "))
+			if err != nil || string(decoded) != "pc:18800000000:drive-auth-token" {
+				t.Errorf("Authorization = %q, decode error = %v", decoded, err)
+			}
+			if !strings.Contains(string(body), "<toSourceId>001003</toSourceId>") || strings.Contains(string(body), "001005") {
+				t.Errorf("ticket body = %s", body)
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = io.WriteString(w, "<root><return>0</return><token>mail-ticket</token></root>")
+		case "/login/inlogin.action":
+			if !strings.Contains(string(body), `<string name="token">mail-ticket</string>`) {
+				t.Errorf("mail login body = %s", body)
+			}
+			http.SetCookie(w, &http.Cookie{Name: "Os_SSo_Sid", Value: "session-cookie"})
+			http.SetCookie(w, &http.Cookie{Name: "mailTheme", Value: "blue"})
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"code":"S_OK","var":{"sid":"sid-from-body","rmkey":"rmkey-from-body"}}`)
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	oldTicketURL, oldLoginURL := driveMailTicketURL, driveMailLoginURL
+	driveMailTicketURL = server.URL + "/tellin/querySpecToken.do"
+	driveMailLoginURL = server.URL + "/login/inlogin.action"
+	defer func() {
+		driveMailTicketURL = oldTicketURL
+		driveMailLoginURL = oldLoginURL
+	}()
+
+	d := Yun139{Addition: Addition{
+		Authorization: base64.StdEncoding.EncodeToString([]byte("mobile:18800000000:drive-auth-token")),
+	}}
+	sid, err := d.recoverMailSessionFromDrive()
+	if err != nil {
+		t.Fatalf("recoverMailSessionFromDrive() error = %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	if sid != "sid-from-body" {
+		t.Fatalf("sid = %q", sid)
+	}
+	for _, cookie := range []string{
+		"Os_SSo_Sid=session-cookie",
+		"mailTheme=blue",
+		"sid=sid-from-body",
+		"RMKEY=rmkey-from-body",
+	} {
+		if !strings.Contains(d.MailCookies, cookie) {
+			t.Fatalf("MailCookies = %q, missing %q", d.MailCookies, cookie)
+		}
+	}
+	if d.Username != "18800000000" || d.Account != "18800000000" {
+		t.Fatalf("account fields = %q, %q", d.Username, d.Account)
+	}
+}

--- a/drivers/139/meta.go
+++ b/drivers/139/meta.go
@@ -10,7 +10,8 @@ type Addition struct {
 	Authorization string `json:"authorization" type:"text" required:"true"`
 	Username      string `json:"username" required:"true"`
 	Password      string `json:"password" required:"true" secret:"true"`
-	MailCookies   string `json:"mail_cookies" required:"true" type:"text" help:"Cookies from mail.139.com used for login authentication."`
+	SmsCode       string `json:"sms_code" secret:"true" help:"Fill this only after OpenList reports that a 139 Mail SMS verification code was sent, then save the storage again."`
+	MailCookies   string `json:"mail_cookies" required:"true" type:"text" help:"Cookies from mail.139.com. Used for fast login only when Authorization is empty; otherwise retained as device context for password login fallback."`
 	driver.RootID
 	Type                 string `json:"type" type:"select" options:"personal_new,family,group,personal,share" default:"personal_new"`
 	LinkID               string `json:"link_id" type:"text" help:"Multiple shares are separated by commas or new lines. Use link_id#password for password-protected shares."`

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -6,9 +6,12 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	crypto_rand "crypto/rand"
+	"crypto/rsa"
 	"crypto/sha1"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -27,6 +30,7 @@ import (
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
 	streamPkg "github.com/OpenListTeam/OpenList/v4/internal/stream"
+	cookiepkg "github.com/OpenListTeam/OpenList/v4/pkg/cookie"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils"
 	"github.com/OpenListTeam/OpenList/v4/pkg/utils/random"
 	"github.com/avast/retry-go"
@@ -36,9 +40,39 @@ import (
 )
 
 const (
-	KEY_HEX_1 = "73634235495062495331515373756c734e7253306c673d3d" // 第一层 AES 解密密钥
-	KEY_HEX_2 = "7150714477323633586746674c337538"                 // 第二层 AES 解密密钥
+	KEY_HEX_1                = "73634235495062495331515373756c734e7253306c673d3d" // 第一层 AES 解密密钥
+	KEY_HEX_2                = "7150714477323633586746674c337538"                 // 第二层 AES 解密密钥
+	credentialExchangeWindow = 3 * 24 * time.Hour
+	mailPublicKey            = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnsOHTFtwW5rq/8gGhPlM5Z3RPdeN/d+FYIHb5JmcfBOCozXuT8c+0anvxtkjzghixwNlnmBuhN8OYfS789YuH/qReQbHC7OdlisLildNWPHRNUYcPa0W3lXSG3+81CXK7FDXPvXo5ubw2GqVbIsccMarI1dyfXdi4ITiCXvmM9wYBdUs9yXtoorhlpyYUI2GV8HNsQjWK9P5QZHT3ox5Qy+mjRmvv6RUFJLPOMkOS/pGZ0DwC1ypFZBxstW0/ftVupdOmGWvW7J2/e3dq3A/UvIkC4YUY/diL1wighJx1G9MiRROISjNMvNyUDSTqPJy516+l3sgHEbc067QIJx2NQIDAQAB"
 )
+
+var (
+	driveMailTicketURL = "https://aas.caiyun.feixin.10086.cn/tellin/querySpecToken.do"
+	driveMailLoginURL  = "https://mail.10086.cn/login/inlogin.action"
+	mailRootURL        = "https://mail.10086.cn/"
+	mailPasswordURL    = "https://mail.10086.cn/Login/Login.ashx"
+	mailSMSURL         = "https://mail.10086.cn/s"
+)
+
+var mailLoginCookieExclusions = map[string]struct{}{
+	"hecaiyun_stay_time":          {},
+	"isShowAgreeIconNew":          {},
+	"hecaiyundata2021jssdkcross":  {},
+	"random":                      {},
+	"a_l2":                        {},
+	"hecaiyun_stay_url":           {},
+	"a_l":                         {},
+	"_139mail_login_type":         {},
+	"_139mail_login_shortAddr":    {},
+	"sajssdk_2015_cross_new_user": {},
+	"fromhtml5":                   {},
+	"html5SkinPath8011":           {},
+	"Os_SSo_Sid":                  {},
+	"sid":                         {},
+	"Login_UserNumber":            {},
+	"RMKEY":                       {},
+	"rtexpired":                   {},
+}
 
 // do others that not defined in Driver interface
 func (d *Yun139) isFamily() bool {
@@ -84,31 +118,50 @@ func (d *Yun139) refreshToken() error {
 	if d.ref != nil {
 		return d.ref.refreshToken()
 	}
+	return d.refreshTokenAt(time.Now())
+}
+
+func shouldExchangeAuthorization(now, authorizationExpiresAt time.Time) bool {
+	return authorizationExpiresAt.Sub(now) <= credentialExchangeWindow
+}
+
+func (d *Yun139) refreshTokenAt(now time.Time) error {
 	decode, err := base64.StdEncoding.DecodeString(d.Authorization)
 	if err != nil {
-		return fmt.Errorf("authorization decode failed: %s", err)
+		return d.loginAfterAuthorizationFailure(fmt.Errorf("authorization decode failed: %w", err))
 	}
 	decodeStr := string(decode)
 	splits := strings.Split(decodeStr, ":")
 	if len(splits) < 3 {
-		return fmt.Errorf("authorization is invalid, splits < 3")
+		return d.loginAfterAuthorizationFailure(errors.New("authorization is invalid, splits < 3"))
 	}
 	d.Account = splits[1]
 	strs := strings.Split(splits[2], "|")
 	if len(strs) < 4 {
-		return fmt.Errorf("authorization is invalid, strs < 4")
+		return d.loginAfterAuthorizationFailure(errors.New("authorization is invalid, strs < 4"))
 	}
 	expiration, err := strconv.ParseInt(strs[3], 10, 64)
 	if err != nil {
-		return fmt.Errorf("authorization is invalid")
+		return d.loginAfterAuthorizationFailure(errors.New("authorization expiration is invalid"))
 	}
-	expiration -= time.Now().UnixMilli()
-	if expiration > 1000*60*60*24*15 {
-		// Authorization有效期大于15天无需刷新
+	authorizationExpiresAt := time.UnixMilli(expiration)
+	if !shouldExchangeAuthorization(now, authorizationExpiresAt) {
 		return nil
 	}
-	if expiration < 0 {
-		return fmt.Errorf("authorization has expired")
+
+	// Authorization is the lifecycle anchor. While it is still valid, create a
+	// fresh mail session and consume that session immediately to issue the next
+	// Authorization. The mail session is not maintained independently.
+	if authorizationExpiresAt.After(now) {
+		if exchangeErr := d.renewAuthorizationFromDrive(); exchangeErr == nil {
+			return nil
+		} else {
+			log.Warnf("139yun: scheduled credential exchange failed: %v", exchangeErr)
+		}
+	}
+
+	if !authorizationExpiresAt.After(now) {
+		return d.loginAfterAuthorizationFailure(errors.New("authorization has expired"))
 	}
 
 	url := "https://aas.caiyun.feixin.10086.cn:443/tellin/authTokenRefresh.do"
@@ -120,17 +173,23 @@ func (d *Yun139) refreshToken() error {
 		SetResult(&resp).
 		Post(url)
 	if err != nil || resp.Return != "0" {
-		log.Warnf("139yun: failed to refresh token with old token: %v, desc: %s. trying to login with password.", err, resp.Desc)
-		newAuth, loginErr := d.loginWithPassword()
-		log.Debugf("newAuth: Ok: %s", newAuth)
-		if loginErr != nil {
-			return fmt.Errorf("failed to login with password after refresh failed: %w", loginErr)
-		}
-		return nil
+		return d.loginAfterAuthorizationFailure(fmt.Errorf("token refresh failed: %v, desc: %s", err, resp.Desc))
 	}
 
 	d.Authorization = base64.StdEncoding.EncodeToString([]byte(splits[0] + ":" + splits[1] + ":" + resp.Token))
 	op.MustSaveDriverStorage(d)
+	return nil
+}
+
+// loginAfterAuthorizationFailure deliberately skips cookie fast login. Mail
+// cookies are only reused as device context for the password login request.
+func (d *Yun139) loginAfterAuthorizationFailure(cause error) error {
+	log.Warnf("139yun: %v; trying password login.", cause)
+	newAuth, err := d.loginWithPassword()
+	log.Debugf("139yun: password fallback generated authorization: %t", newAuth != "")
+	if err != nil {
+		return fmt.Errorf("%v; password login failed: %w", cause, err)
+	}
 	return nil
 }
 
@@ -1116,15 +1175,246 @@ func (d *Yun139) getDiskQuotaDetail(ctx context.Context) (*DiskQuotaDetail, erro
 	return &resp, nil
 }
 
+type mailLoginResponse struct {
+	Code    string `json:"code"`
+	Summary string `json:"summary"`
+	Var     struct {
+		LoginSuccessURL string `json:"loginSuccessUrl"`
+	} `json:"var"`
+}
+
+func parseMailLoginResponse(body []byte) mailLoginResponse {
+	var response mailLoginResponse
+	if utils.Json.Unmarshal(body, &response) == nil && (response.Code != "" || response.Summary != "" || response.Var.LoginSuccessURL != "") {
+		return response
+	}
+	if match := regexp.MustCompile(`['"]?code['"]?\s*:\s*['"]([^'"]+)`).FindSubmatch(body); len(match) == 2 {
+		response.Code = string(match[1])
+	}
+	if match := regexp.MustCompile(`['"]?summary['"]?\s*:\s*['"]([^'"]+)`).FindSubmatch(body); len(match) == 2 {
+		response.Summary = string(match[1])
+	}
+	if match := regexp.MustCompile(`['"]?loginSuccessUrl['"]?\s*:\s*['"]([^'"]+)`).FindSubmatch(body); len(match) == 2 {
+		response.Var.LoginSuccessURL = string(match[1])
+	}
+	return response
+}
+
+func mergeMailCookieHeader(existing string, responseCookies []*http.Cookie) string {
+	cookies := cookiepkg.Parse(existing)
+	for _, responseCookie := range responseCookies {
+		if responseCookie != nil && responseCookie.Name != "" {
+			cookies = cookiepkg.SetCookie(cookies, responseCookie.Name, responseCookie.Value)
+		}
+	}
+	return cookiepkg.ToString(cookies)
+}
+
+func sanitizeMailLoginCookies(existing, newJSessionID string) string {
+	cookies := cookiepkg.Parse(existing)
+	filtered := cookies[:0]
+	for _, cookie := range cookies {
+		if _, excluded := mailLoginCookieExclusions[cookie.Name]; excluded {
+			continue
+		}
+		if cookie.Name == "JSESSIONID" {
+			if newJSessionID == "" {
+				continue
+			}
+			cookie.Value = newJSessionID
+			newJSessionID = ""
+		}
+		filtered = append(filtered, cookie)
+	}
+	if newJSessionID != "" {
+		filtered = append(filtered, &http.Cookie{Name: "JSESSIONID", Value: newJSessionID})
+	}
+	return cookiepkg.ToString(filtered)
+}
+
+func mailRiskCode(location string) string {
+	parsed, err := url.Parse(location)
+	if err != nil {
+		return ""
+	}
+	return parsed.Query().Get("ec")
+}
+
+func smsSceneForRisk(riskCode string) (int, bool) {
+	switch riskCode {
+	case "PML401010062":
+		return 2, true
+	case "MW0016":
+		return 4, true
+	case "S025", "S035":
+		return 1, true
+	default:
+		return 0, false
+	}
+}
+
+func encryptMailLoginName(account string) (string, error) {
+	der, err := base64.StdEncoding.DecodeString(mailPublicKey)
+	if err != nil {
+		return "", fmt.Errorf("decode mail public key: %w", err)
+	}
+	parsed, err := x509.ParsePKIXPublicKey(der)
+	if err != nil {
+		return "", fmt.Errorf("parse mail public key: %w", err)
+	}
+	publicKey, ok := parsed.(*rsa.PublicKey)
+	if !ok {
+		return "", errors.New("mail public key is not RSA")
+	}
+	encrypted, err := rsa.EncryptPKCS1v15(crypto_rand.Reader, publicKey, []byte(account))
+	if err != nil {
+		return "", fmt.Errorf("encrypt mail login name: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(encrypted), nil
+}
+
+func mailXMLHeaders(cookie string) map[string]string {
+	return map[string]string{
+		"Cookie":          cookie,
+		"Content-Type":    "application/xml; charset=utf-8",
+		"Accept-Encoding": "gzip",
+		"User-Agent":      "okhttp/4.12.0",
+	}
+}
+
+func (d *Yun139) sendSMSVerificationCode(riskCode string) error {
+	scene, ok := smsSceneForRisk(riskCode)
+	if !ok {
+		return fmt.Errorf("139 Mail risk control does not support SMS verification: %s", riskCode)
+	}
+	loginName, err := encryptMailLoginName(d.Username)
+	if err != nil {
+		return err
+	}
+	body := strings.Join([]string{
+		"<object>",
+		mailXMLField("loginName", loginName),
+		mailXMLField("fv", "4"),
+		mailXMLField("clientId", "1003"),
+		mailXMLField("eMode", "1"),
+		mailXMLField("loginFailureUrl", ""),
+		mailXMLField("loginSuccessUrl", ""),
+		mailXMLField("verifyCode", ""),
+		mailXMLField("version", "1.0"),
+		mailXMLField("scene", strconv.Itoa(scene)),
+		"</object>",
+	}, "")
+	res, err := resty.New().R().
+		SetHeaders(mailXMLHeaders(d.MailCookies)).
+		SetBody(body).
+		Post(mailSMSURL + "?func=" + url.QueryEscape("login:sendSmsCodeByScene") + "&cguid=" + strconv.FormatInt(time.Now().UnixMilli(), 10))
+	if err != nil {
+		return fmt.Errorf("send 139 Mail SMS verification code: %w", err)
+	}
+	d.MailCookies = mergeMailCookieHeader(d.MailCookies, res.Cookies())
+	response := parseMailLoginResponse(res.Body())
+	if response.Code == "S_OK" {
+		return nil
+	}
+	switch response.Code {
+	case "PML401010021", "PML401010022":
+		return fmt.Errorf("139 Mail requires picture verification before SMS can be sent: %s", response.Code)
+	case "PML404010001":
+		return errors.New("139 Mail SMS verification code was requested too frequently")
+	case "PML401010002":
+		return errors.New("139 Mail rejected the SMS verification parameters")
+	default:
+		return fmt.Errorf("send 139 Mail SMS verification code failed: code=%s summary=%s", response.Code, response.Summary)
+	}
+}
+
+func (d *Yun139) verifySMSCode(riskCode string) (string, error) {
+	if _, ok := smsSceneForRisk(riskCode); !ok {
+		return "", fmt.Errorf("139 Mail risk control does not support SMS verification: %s", riskCode)
+	}
+	loginName, err := encryptMailLoginName(d.Username)
+	if err != nil {
+		return "", err
+	}
+	pwdType := ""
+	if riskCode == "MW0016" {
+		pwdType = mailXMLField("pwdType", "1")
+	}
+	body := strings.Join([]string{
+		"<object>",
+		mailXMLField("clientId", "1003"),
+		mailXMLField("version", "4"),
+		mailXMLField("loginType", "0"),
+		mailXMLField("authType", "2"),
+		mailXMLField("loginName", loginName),
+		mailXMLField("eMode", "1"),
+		mailXMLField("loginPassword", sha1Hash("fetion.com.cn:"+d.SmsCode)),
+		mailXMLField("createAutoLoginSecretKey", "1"),
+		mailXMLField("verifyCode", ""),
+		mailXMLField("verifyAgentId", ""),
+		mailXMLField("reqFrom", "3"),
+		mailXMLField("needWCookie", "1"),
+		pwdType,
+		"</object>",
+	}, "")
+	res, err := resty.New().R().
+		SetHeaders(mailXMLHeaders(d.MailCookies)).
+		SetBody(body).
+		Post(mailSMSURL + "?func=" + url.QueryEscape("/login/inlogin.action") + "&cguid=" + strconv.FormatInt(time.Now().UnixMilli(), 10))
+	if err != nil {
+		return "", fmt.Errorf("verify 139 Mail SMS code: %w", err)
+	}
+	d.MailCookies = mergeMailCookieHeader(d.MailCookies, res.Cookies())
+	response := parseMailLoginResponse(res.Body())
+	if response.Code != "S_OK" {
+		return "", fmt.Errorf("verify 139 Mail SMS code failed: code=%s summary=%s", response.Code, response.Summary)
+	}
+	sid := ""
+	if response.Var.LoginSuccessURL != "" {
+		if successURL, parseErr := url.Parse(response.Var.LoginSuccessURL); parseErr == nil {
+			sid = successURL.Query().Get("sid")
+		}
+	}
+	if sid == "" {
+		for _, cookie := range cookiepkg.Parse(d.MailCookies) {
+			if cookie.Name == "Os_SSo_Sid" || cookie.Name == "sid" {
+				sid = cookie.Value
+				break
+			}
+		}
+	}
+	if sid == "" {
+		return "", errors.New("139 Mail SMS verification succeeded but did not return sid")
+	}
+	d.SmsCode = ""
+	return sid, nil
+}
+
 func (d *Yun139) step1_password_login() (string, error) {
 	log.Debugf("--- 执行步骤 1: 登录 API ---")
-	loginURL := "https://mail.10086.cn/Login/Login.ashx"
+	loginURL := mailPasswordURL
+
+	preLogin, err := resty.New().SetRedirectPolicy(resty.NoRedirectPolicy()).R().Get(mailRootURL)
+	if preLogin == nil {
+		return "", fmt.Errorf("step1 pre-login request failed: %v", err)
+	}
+	if err != nil && (preLogin.StatusCode() < 300 || preLogin.StatusCode() >= 400) {
+		return "", fmt.Errorf("step1 pre-login request failed: %w", err)
+	}
+	jsessionid := ""
+	for _, cookie := range preLogin.Cookies() {
+		if cookie.Name == "JSESSIONID" {
+			jsessionid = cookie.Value
+			break
+		}
+	}
+	if jsessionid == "" {
+		return "", errors.New("step1 pre-login response did not set JSESSIONID")
+	}
+	loginCookies := sanitizeMailLoginCookies(d.MailCookies, jsessionid)
 
 	// 密码 SHA1 哈希
 	hashedPassword := sha1Hash(fmt.Sprintf("fetion.com.cn:%s", d.Password))
-	log.Debugf("DEBUG: 原始密码: %s", d.Password)
-	log.Debugf("DEBUG: SHA1 输入: fetion.com.cn:%s", d.Password)
-	log.Debugf("DEBUG: 生成的 Password 哈希: %s", hashedPassword)
 
 	cguid := strconv.FormatInt(time.Now().UnixMilli(), 10) // 随机生成 cguid
 
@@ -1146,7 +1436,7 @@ func (d *Yun139) step1_password_login() (string, error) {
 		"sec-fetch-user":            "?1",
 		"upgrade-insecure-requests": "1",
 		"user-agent":                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36 Edg/141.0.0.0",
-		"Cookie":                    d.MailCookies,
+		"Cookie":                    loginCookies,
 	}
 
 	loginData := url.Values{}
@@ -1160,11 +1450,10 @@ func (d *Yun139) step1_password_login() (string, error) {
 	loginData.Set("authType", "2")
 
 	log.Debugf("DEBUG: 登录请求 URL: %s", loginURL)
-	log.Debugf("DEBUG: 登录请求 Headers: %+v", loginHeaders)
-	log.Debugf("DEBUG: 登录请求 Body: %s", loginData.Encode())
+	log.Debugf("DEBUG: 登录请求已准备")
 
 	// 设置客户端不跟随重定向
-	client := base.RestyClient.SetRedirectPolicy(resty.NoRedirectPolicy())
+	client := resty.New().SetRedirectPolicy(resty.NoRedirectPolicy())
 	res, err := client.R().
 		SetHeaders(loginHeaders).
 		SetFormDataFromValues(loginData).
@@ -1180,24 +1469,36 @@ func (d *Yun139) step1_password_login() (string, error) {
 	} else {
 		log.Debugf("DEBUG: 登录响应 Status Code: %d", res.StatusCode())
 	}
-	// 恢复客户端的默认重定向策略，以免影响后续请求
-	base.RestyClient.SetRedirectPolicy(resty.FlexibleRedirectPolicy(10))
-	log.Debugf("DEBUG: 登录响应 Headers: %+v", res.Header())
+	log.Debugf("DEBUG: 登录响应 Location present: %t", res.Header().Get("Location") != "")
 
 	var sid, extractedCguid string
 
 	// 从 Location 头部提取 sid 和 cguid
 	locationHeader := res.Header().Get("Location")
 	if locationHeader != "" {
+		d.MailCookies = mergeMailCookieHeader(loginCookies, res.Cookies())
+		if riskCode := mailRiskCode(locationHeader); riskCode != "" {
+			if _, ok := smsSceneForRisk(riskCode); !ok {
+				return "", fmt.Errorf("139 Mail risk control triggered: %s", riskCode)
+			}
+			if strings.TrimSpace(d.SmsCode) == "" {
+				if sendErr := d.sendSMSVerificationCode(riskCode); sendErr != nil {
+					return "", sendErr
+				}
+				op.MustSaveDriverStorage(d)
+				return "", errors.New("139 Mail SMS verification code sent; fill sms_code and save the storage again")
+			}
+			return d.verifySMSCode(riskCode)
+		}
 		sidMatch := regexp.MustCompile(`sid=([^&]+)`).FindStringSubmatch(locationHeader)
 		cguidMatch := regexp.MustCompile(`cguid=([^&]+)`).FindStringSubmatch(locationHeader)
 		if len(sidMatch) > 1 {
 			sid = sidMatch[1]
-			log.Debugf("DEBUG: 从 Location 提取到 sid: %s", sid)
+			log.Debugf("DEBUG: 从 Location 提取到 sid.")
 		}
 		if len(cguidMatch) > 1 {
 			extractedCguid = cguidMatch[1]
-			log.Debugf("DEBUG: 从 Location 提取到 cguid: %s", extractedCguid)
+			log.Debugf("DEBUG: 从 Location 提取到 cguid.")
 		}
 	}
 
@@ -1209,11 +1510,11 @@ func (d *Yun139) step1_password_login() (string, error) {
 			cookieCguidMatch := regexp.MustCompile(`cguid=([^;]+)`).FindStringSubmatch(cookieStr)
 			if len(ssoSidMatch) > 1 && sid == "" {
 				sid = ssoSidMatch[1]
-				log.Debugf("DEBUG: 从 Set-Cookie 提取到 sid: %s", sid)
+				log.Debugf("DEBUG: 从 Set-Cookie 提取到 sid.")
 			}
 			if len(cookieCguidMatch) > 1 && extractedCguid == "" {
 				extractedCguid = cookieCguidMatch[1]
-				log.Debugf("DEBUG: 从 Set-Cookie 提取到 cguid: %s", extractedCguid)
+				log.Debugf("DEBUG: 从 Set-Cookie 提取到 cguid.")
 			}
 		}
 	}
@@ -1222,16 +1523,7 @@ func (d *Yun139) step1_password_login() (string, error) {
 		return "", errors.New("failed to extract sid or cguid from login response")
 	}
 
-	// 提取并记录 cookies
-	loginUrlObj, _ := url.Parse(loginURL)
-	cookies := base.RestyClient.GetClient().Jar.Cookies(loginUrlObj)
-	var cookieStrings []string
-	for _, cookie := range cookies {
-		cookieStrings = append(cookieStrings, cookie.Name+"="+cookie.Value)
-	}
-	cookieStr := strings.Join(cookieStrings, "; ")
-	log.Debugf("DEBUG: 提取到的 Cookies: %s", cookieStr)
-	d.MailCookies = cookieStr
+	d.MailCookies = mergeMailCookieHeader(loginCookies, res.Cookies())
 
 	return sid, nil
 }
@@ -1285,6 +1577,180 @@ func (d *Yun139) step2_get_single_token(sid string) (string, error) {
 	log.Debugf("DEBUG: 提取到 dycpwd: %s", dycpwd)
 
 	return dycpwd, nil
+}
+
+type driveMailTicketResponse struct {
+	Return string `xml:"return"`
+	Code   string `xml:"code"`
+	Token  string `xml:"token"`
+	Desc   string `xml:"desc"`
+}
+
+type driveMailLoginResponse struct {
+	Code    string `json:"code"`
+	Summary string `json:"summary"`
+	Var     struct {
+		SID             string `json:"sid"`
+		RMKey           string `json:"rmkey"`
+		LoginSuccessURL string `json:"loginSuccessUrl"`
+	} `json:"var"`
+}
+
+// renewAuthorizationFromDrive converts a still-valid cloud-drive credential
+// into a fresh mail session, then uses the existing mail-to-drive exchange to
+// issue a new cloud-drive credential.
+func (d *Yun139) renewAuthorizationFromDrive() error {
+	sid, err := d.recoverMailSessionFromDrive()
+	if err != nil {
+		return err
+	}
+	artifact, err := d.step2_get_single_token(sid)
+	if err != nil {
+		return fmt.Errorf("get mail artifact after session recovery: %w", err)
+	}
+	authorization, err := d.step3_third_party_login(artifact)
+	if err != nil {
+		return fmt.Errorf("exchange mail artifact for cloud-drive authorization: %w", err)
+	}
+	d.Authorization = authorization
+	op.MustSaveDriverStorage(d)
+	return nil
+}
+
+// recoverMailSessionFromDrive exchanges the current cloud-drive Authorization
+// for a 139 Mail session containing sid and RMKEY.
+func (d *Yun139) recoverMailSessionFromDrive() (string, error) {
+	account, authToken, err := decodeDriveAuthorization(d.Authorization)
+	if err != nil {
+		return "", err
+	}
+	if d.Username != "" && d.Username != account {
+		return "", errors.New("authorization account does not match username")
+	}
+
+	pcAuthorization := base64.StdEncoding.EncodeToString([]byte("pc:" + account + ":" + authToken))
+	deviceInfo := "1|127.0.0.1|1|1.2.6|Xiaomi|23116PN5BC||02-00-00-00-00-00|android 15|1220X2574|zh||||108|"
+	ticketBody := "<root><account>" + escapeXML(account) + "</account><toSourceId>001003</toSourceId></root>"
+	ticketRes, err := base.RestyClient.R().
+		SetHeaders(map[string]string{
+			"x-nettype":           "1",
+			"x-deviceinfo":        deviceInfo,
+			"x-yun-client-info":   deviceInfo,
+			"x-yun-app-channel":   "10000023",
+			"x-huawei-channelsrc": "10000023",
+			"x-mm-source":         "108",
+			"x-svctype":           "1",
+			"app_number":          account,
+			"x-exproute-code":     "routeCode=" + account + ",type=10",
+			"authorization":       "Basic " + pcAuthorization,
+			"content-type":        "application/xml; charset=UTF-8",
+			"user-agent":          "okhttp/3.11.0",
+		}).
+		SetBody(ticketBody).
+		Post(driveMailTicketURL)
+	if err != nil {
+		return "", fmt.Errorf("exchange cloud-drive authorization for mail ticket: %w", err)
+	}
+	var ticket driveMailTicketResponse
+	if err = xml.Unmarshal(ticketRes.Body(), &ticket); err != nil {
+		return "", fmt.Errorf("decode mail ticket response: %w", err)
+	}
+	if ticket.Return != "0" || ticket.Token == "" {
+		code := ticket.Return
+		if code == "" {
+			code = ticket.Code
+		}
+		return "", fmt.Errorf("cloud-drive authorization was rejected while obtaining mail ticket: code=%s desc=%s", code, ticket.Desc)
+	}
+
+	cguid := strconv.FormatInt(time.Now().UnixMilli(), 10) + random.String(12)
+	loginBody := strings.Join([]string{
+		"<object>",
+		mailXMLField("clientid", "10891"),
+		mailXMLField("version", "66"),
+		mailXMLField("loginType", "7"),
+		mailXMLField("autoSecretKey", ""),
+		mailXMLField("createAutoLoginSecretKey", "1"),
+		mailXMLField("verifyCode", `""`),
+		mailXMLField("authType", "2"),
+		mailXMLField("needWCookie", "1"),
+		mailXMLField("verifyAgentId", ""),
+		mailXMLField("loginName", ""),
+		mailXMLField("loginPassword", ""),
+		mailXMLField("loginToken", ""),
+		mailXMLField("token", ticket.Token),
+		mailXMLField("logActionId", ""),
+		`<int name="eMode">1</int>`,
+		"</object>",
+	}, "")
+	loginRes, err := base.RestyClient.R().
+		SetHeaders(map[string]string{
+			"content-type": "application/xml",
+			"user-agent":   "Mozilla/5.0 (Linux; Android 16; Mobile) AppleWebKit/537.36 Chrome/67.0.3396.99 Safari/537.36",
+		}).
+		SetBody(loginBody).
+		Post(driveMailLoginURL + "?comefrom=2066&clientId=10891&cguid=" + cguid +
+			"&deviceToken=ZFHIXQJV8EDNJO6H3D9M77WEQG2NO6TQ&appVersion=8.0.28")
+	if err != nil {
+		return "", fmt.Errorf("login to mail with cloud-drive ticket: %w", err)
+	}
+	var login driveMailLoginResponse
+	if err = utils.Json.Unmarshal(loginRes.Body(), &login); err != nil {
+		return "", fmt.Errorf("decode mail login response: %w", err)
+	}
+	if login.Code != "S_OK" {
+		return "", fmt.Errorf("cloud-drive ticket login to mail failed: code=%s summary=%s", login.Code, login.Summary)
+	}
+
+	cookies := loginRes.Cookies()
+	sid := login.Var.SID
+	if sid == "" && login.Var.LoginSuccessURL != "" {
+		if successURL, parseErr := url.Parse(login.Var.LoginSuccessURL); parseErr == nil {
+			sid = successURL.Query().Get("sid")
+		}
+	}
+	if sid == "" {
+		if sidCookie := cookiepkg.GetCookie(cookies, "Os_SSo_Sid"); sidCookie != nil {
+			sid = sidCookie.Value
+		}
+	}
+	if sid == "" || login.Var.RMKey == "" {
+		return "", errors.New("cloud-drive ticket login did not return sid or RMKEY")
+	}
+	cookies = cookiepkg.SetCookie(cookies, "sid", sid)
+	cookies = cookiepkg.SetCookie(cookies, "RMKEY", login.Var.RMKey)
+	d.MailCookies = cookiepkg.ToString(cookies)
+	d.Account = account
+	if d.Username == "" {
+		d.Username = account
+	}
+	return sid, nil
+}
+
+func decodeDriveAuthorization(authorization string) (account string, authToken string, err error) {
+	encoded := strings.TrimSpace(authorization)
+	if strings.HasPrefix(strings.ToLower(encoded), "basic ") {
+		encoded = strings.TrimSpace(encoded[len("basic "):])
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", "", fmt.Errorf("decode authorization: %w", err)
+	}
+	parts := strings.SplitN(string(decoded), ":", 3)
+	if len(parts) != 3 || parts[1] == "" || parts[2] == "" {
+		return "", "", errors.New("authorization format is invalid")
+	}
+	return parts[1], parts[2], nil
+}
+
+func mailXMLField(name, value string) string {
+	return `<string name="` + escapeXML(name) + `">` + escapeXML(value) + `</string>`
+}
+
+func escapeXML(value string) string {
+	var escaped bytes.Buffer
+	_ = xml.EscapeText(&escaped, []byte(value))
+	return escaped.String()
 }
 
 // --- 辅助函数：加密/解密 ---


### PR DESCRIPTION
## Summary / 摘要

- Keep cloud-drive `Authorization` as the lifecycle anchor and renew it through a temporary 139 Mail session inside the three-day expiry window.
- Fall back to password login when a non-empty `Authorization` is invalid, expired, or cannot be refreshed; existing mail cookies are not used for fast login in that case.
- Add a two-step SMS challenge flow for `S025`, `S035`, `PML401010062`, and `MW0016`.
- Send one SMS code, persist the challenge cookies, then verify the user-supplied `sms_code` and continue the Artifact-to-Authorization flow.
- Fetch a fresh pre-login `JSESSIONID` and send only device-context cookies during password login.
- Stop with an explicit error when 139 Mail requires picture verification; no picture endpoint is called.
- Remove password, password hash, cookie header, and session identifier values from debug logging.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: Not required
- OpenList-Docs: Not required

## Testing / 测试

- [ ] `go test ./...`
- [x] `go test ./drivers/139`
- [x] `go vet ./drivers/139`
- [x] `go test -vet=off ./drivers/...`
- [ ] Manual test / 手动测试: Live SMS delivery was not triggered to avoid sending an unsolicited verification message.

## Checklist / 检查清单

- [ ] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [ ] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [x] Codex

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的 AI 辅助内容。