### PR TITLE
fix(drivers/onedrive_sharelink): reuse shared HTTP clients

### DIFF
--- a/drivers/onedrive_sharelink/util.go
+++ b/drivers/onedrive_sharelink/util.go
@@ -2,7 +2,6 @@ package onedrive_sharelink
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,30 +12,28 @@ import (
 	"time"
 
 	"github.com/OpenListTeam/OpenList/v4/drivers/base"
-	"github.com/OpenListTeam/OpenList/v4/internal/conf"
+	internalNet "github.com/OpenListTeam/OpenList/v4/internal/net"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/html"
 )
 
 // NewNoRedirectClient creates an HTTP client that doesn't follow redirects
 func NewNoRedirectCLient() *http.Client {
-	return &http.Client{
-		Timeout: time.Hour * 48,
-		Transport: &http.Transport{
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.Conf.TlsInsecureSkipVerify},
-		},
-		// Prevent following redirects
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+	client := internalNet.NewHttpClient()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
 	}
+	return client
 }
 
 // getCookiesWithPassword fetches cookies required for authenticated access using the provided password
-func getCookiesWithPassword(link, password string) (string, error) {
+func getCookiesWithPassword(ctx context.Context, link, password string) (string, error) {
 	// Send GET request
-	resp, err := http.Get(link)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, link, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := base.HttpClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -95,16 +92,18 @@ func getCookiesWithPassword(link, password string) (string, error) {
 		"__VIEWSTATEENCRYPTED": []string{""},
 	}
 
-	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	client := NewNoRedirectCLient()
 	// Send the POST request, preventing redirects
-	resp, err = client.PostForm(newURL, data)
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost, newURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return "", err
 	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err = client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
 
 	// Extract the desired cookie value
 	cookie := resp.Cookies()
@@ -153,6 +152,7 @@ func (d *OnedriveSharelink) getHeaders(ctx context.Context) (http.Header, error)
 		if err != nil {
 			return nil, err
 		}
+		defer answerNoRedirect.Body.Close()
 		redirectUrl := answerNoRedirect.Header.Get("Location")
 		log.Debugln("redirectUrl:", redirectUrl)
 		if redirectUrl == "" {
@@ -169,7 +169,7 @@ func (d *OnedriveSharelink) getHeaders(ctx context.Context) (http.Header, error)
 		header.Set("authority", u.Host)
 		return header, nil
 	} else {
-		cookie, err := getCookiesWithPassword(d.ShareLinkURL, d.ShareLinkPassword)
+		cookie, err := getCookiesWithPassword(ctx, d.ShareLinkURL, d.ShareLinkPassword)
 		if err != nil {
 			return nil, err
 		}
@@ -197,6 +197,7 @@ func (d *OnedriveSharelink) getFiles(ctx context.Context, path string) ([]Item, 
 		if err != nil {
 			return nil, err
 		}
+		_ = answerNoRedirect.Body.Close()
 		redirectUrl = answerNoRedirect.Header.Get("Location")
 	} else {
 		header = d.Headers
@@ -205,6 +206,7 @@ func (d *OnedriveSharelink) getFiles(ctx context.Context, path string) ([]Item, 
 		if err != nil {
 			return nil, err
 		}
+		_ = answerNoRedirect.Body.Close()
 		redirectUrl = answerNoRedirect.Header.Get("Location")
 	}
 	redirectSplitURL := strings.Split(redirectUrl, "/")
@@ -289,9 +291,9 @@ func (d *OnedriveSharelink) getFiles(ctx context.Context, path string) ([]Item, 
 	}
 	tempHeader["Content-Type"] = []string{"application/json;odata=verbose"}
 
-	client := &http.Client{}
+	client := base.HttpClient
 	postUrl := strings.Join(redirectSplitURL[:len(redirectSplitURL)-3], "/") + "/_api/v2.1/graphql"
-	req, err = http.NewRequest(http.MethodPost, postUrl, strings.NewReader(graphqlVar))
+	req, err = http.NewRequestWithContext(ctx, http.MethodPost, postUrl, strings.NewReader(graphqlVar))
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +328,10 @@ func (d *OnedriveSharelink) getFiles(ctx context.Context, path string) ([]Item, 
 			log.Debugln("nextHref:", nextHref)
 			graphqlReqNEW := GraphQLNEWRequest{}
 			postUrl = strings.Join(redirectSplitURL[:len(redirectSplitURL)-3], "/") + "/_api/web/GetListUsingPath(DecodedUrl=@a1)/RenderListDataAsStream" + nextHref
-			req, _ = http.NewRequest(http.MethodPost, postUrl, strings.NewReader(renderListDataAsStreamVar))
+			req, err = http.NewRequestWithContext(ctx, http.MethodPost, postUrl, strings.NewReader(renderListDataAsStreamVar))
+			if err != nil {
+				return nil, err
+			}
 			req.Header = tempHeader
 
 			resp, err := client.Do(req)

--- a/drivers/onedrive_sharelink/util_test.go
+++ b/drivers/onedrive_sharelink/util_test.go
@@ -1,0 +1,46 @@
+package onedrive_sharelink
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	internalNet "github.com/OpenListTeam/OpenList/v4/internal/net"
+)
+
+func TestNoRedirectClientUsesSharedSettings(t *testing.T) {
+	client := NewNoRedirectCLient()
+	sharedClient := internalNet.NewHttpClient()
+	if client.Timeout != sharedClient.Timeout {
+		t.Fatalf("expected shared timeout %s, got %s", sharedClient.Timeout, client.Timeout)
+	}
+	if reflect.TypeOf(client.Transport) != reflect.TypeOf(sharedClient.Transport) {
+		t.Fatalf("expected shared transport type %T, got %T", sharedClient.Transport, client.Transport)
+	}
+}
+
+func TestNoRedirectClientStopsRedirects(t *testing.T) {
+	targetRequested := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/target" {
+			targetRequested = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.Redirect(w, r, "/target", http.StatusFound)
+	}))
+	defer server.Close()
+
+	resp, err := NewNoRedirectCLient().Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected redirect response, got %d", resp.StatusCode)
+	}
+	if targetRequested {
+		t.Fatal("redirect target was requested")
+	}
+}


### PR DESCRIPTION
## Summary / 摘要

- Reuse the project's shared HTTP clients for OneDrive ShareLink password, no-redirect, and GraphQL requests.
- Preserve no-redirect behavior while inheriting the shared timeout, TLS, and proxy settings.
- Propagate request contexts and close response bodies that previously lacked cleanup.
- Add tests for shared client settings and redirect handling.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: None
- OpenList-Docs: None

## Testing / 测试

- [ ] `go test ./...`
- [ ] Manual test / 手动测试:
- [x] `gofmt -w drivers/onedrive_sharelink/util.go drivers/onedrive_sharelink/util_test.go`
- [x] `git diff --check`

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。