### PR TITLE
fix(drivers/guangyapan): report multipart upload progress to copy task

### DIFF
--- a/drivers/guangyapan/util.go
+++ b/drivers/guangyapan/util.go
@@ -241,6 +241,7 @@ func (d *GuangYaPan) multipartUploadToOSS(ctx context.Context, bucket *oss.Bucke
 	}
 
 	parts := make([]oss.UploadPart, 0, partCount)
+	var uploaded int64
 	for i := 0; i < partCount; i++ {
 		if utils.IsCanceled(ctx) {
 			return ctx.Err()
@@ -273,6 +274,10 @@ func (d *GuangYaPan) multipartUploadToOSS(ctx context.Context, bucket *oss.Bucke
 			return fmt.Errorf("failed to upload part %d: %w", i+1, err)
 		}
 		parts = append(parts, part)
+		uploaded += length
+		if total > 0 {
+			up(100 * float64(uploaded) / float64(total))
+		}
 	}
 
 	_, err = bucket.CompleteMultipartUpload(imur, parts)


### PR DESCRIPTION
## Summary / 摘要

修复 GuangYaPan 驱动 OSS 分片上传不更新任务进度的问题。

**背景**：从其他存储（跨存储复制）复制到光鸭云盘时，OpenList 会创建  
`FileTransferTask` 并通过 `GuangYaPan.Put` -> `multipartUploadToOSS` 上传，  
但该函数把进度回调 `up` 传入 `stream.NewStreamSectionReader` 后从未再调用，  
而 `NewStreamSectionReader` 的实现会忽略 `up` 参数，导致任务进度始终为 0，  
任务列表不显示进度条和速度。

**修复**：在 `multipartUploadToOSS` 的分片循环中累计已上传字节数，并在每个  
分片上传完成后调用 `up(100 * uploaded / total)` 上报进度，与其他驱动保持  
一致的实现方式。

### Behavior changes / 用户可感知的行为变化

- 跨存储复制到光鸭云盘时，管理后台「任务」列表中的复制任务现在会实时显示  
  进度条与速度（此前停留在 0%）。
- 同存储复制行为不变（仍走驱动内 `copy_file` 异步任务，不经任务系统）。

### Implementation changes / 重要实现变化

- [x] `drivers/guangyapan/util.go`：`multipartUploadToOSS` 新增 `uploaded` 累计  
  计数，每分片上传成功后调用 `up` 上报百分比进度。
- [ ] This PR has breaking changes.  
  / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.  
  / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.  
  / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Related Issues / 关联 Issue

Relates to #2970 

## Testing / 测试

- [x] `go build ./drivers/guangyapan/`
- [ ] `go test ./...`
- [x] Manual test / 手动测试: 在真实账号上执行跨存储复制到光鸭云盘, 确认任务列表进度条随分片上传增长。

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).  
  / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.  
  / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.  
  / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.  
  / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.  
  / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [x] Gemini
- [ ] Other (please specify) / 其他（请注明）: WorkBuddy 自主智能体

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助
- [x] I have reviewed and validated all AI-assisted content included in this PR.  
  / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.  
  / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.  
  / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
