### PR TITLE
feat(fs): add native save-from-share for cloud drivers

### DIFF
--- a/drivers/quark_uc/driver.go
+++ b/drivers/quark_uc/driver.go
@@ -235,4 +235,7 @@ func (d *QuarkOrUC) GetDetails(ctx context.Context) (*model.StorageDetails, erro
 	}, nil
 }
 
-var _ driver.Driver = (*QuarkOrUC)(nil)
+var (
+	_ driver.Driver        = (*QuarkOrUC)(nil)
+	_ driver.SaveFromShare = (*QuarkOrUC)(nil)
+)

--- a/drivers/quark_uc/share.go
+++ b/drivers/quark_uc/share.go
@@ -1,0 +1,227 @@
+package quark
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/drivers/base"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/go-resty/resty/v2"
+	"github.com/pkg/errors"
+)
+
+var (
+	quarkShareURLRe = regexp.MustCompile(`(?i)https?://(?:(?:www|pan)\.)?quark\.cn/s/([A-Za-z0-9]+)`)
+	ucShareURLRe    = regexp.MustCompile(`(?i)https?://(?:drive\.)?uc\.cn/s/([A-Za-z0-9]+)`)
+	sharePassRe     = regexp.MustCompile(`(?i)(?:pwd|passcode|pass|提取码|密码)\s*[：:=\s]\s*([A-Za-z0-9]{4,8})`)
+)
+
+func ParseShareLink(raw string) (pwdID, passcode string, err error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", errors.New("empty share link")
+	}
+
+	if m := quarkShareURLRe.FindStringSubmatch(raw); len(m) > 1 {
+		pwdID = m[1]
+	} else if m := ucShareURLRe.FindStringSubmatch(raw); len(m) > 1 {
+		pwdID = m[1]
+	}
+	if pwdID == "" {
+		return "", "", errors.New("unsupported share link")
+	}
+
+	if u, parseErr := url.Parse(firstURL(raw)); parseErr == nil {
+		passcode = u.Query().Get("pwd")
+	}
+	if passcode == "" {
+		if m := sharePassRe.FindStringSubmatch(raw); len(m) > 1 {
+			passcode = m[1]
+		}
+	}
+	return pwdID, passcode, nil
+}
+
+func firstURL(raw string) string {
+	for _, field := range strings.Fields(raw) {
+		if strings.Contains(strings.ToLower(field), "://") {
+			return field
+		}
+	}
+	return raw
+}
+
+func (d *QuarkOrUC) SaveFromShare(ctx context.Context, dstDir model.Obj, args model.SaveFromShareArgs) error {
+	pwdID, passcode, err := ParseShareLink(args.URL)
+	if err != nil {
+		return err
+	}
+	if args.Password != "" {
+		passcode = args.Password
+	}
+
+	stoken, err := d.getShareToken(ctx, pwdID, passcode)
+	if err != nil {
+		return err
+	}
+	files, err := d.getShareRootFiles(ctx, pwdID, stoken)
+	if err != nil {
+		return err
+	}
+	if len(files) == 0 {
+		return errors.New("share is empty")
+	}
+
+	fidList := make([]string, 0, len(files))
+	tokenList := make([]string, 0, len(files))
+	for _, f := range files {
+		if f.Fid == "" {
+			continue
+		}
+		fidList = append(fidList, f.Fid)
+		tokenList = append(tokenList, f.ShareFidToken)
+	}
+	if len(fidList) == 0 {
+		return errors.New("share is empty")
+	}
+
+	taskID, tqGap, err := d.saveShare(ctx, pwdID, stoken, fidList, tokenList, dstDir.GetID())
+	if err != nil {
+		return err
+	}
+	return d.waitShareTask(ctx, taskID, tqGap)
+}
+
+func (d *QuarkOrUC) getShareToken(ctx context.Context, pwdID, passcode string) (string, error) {
+	var resp ShareTokenResp
+	_, err := d.request("/share/sharepage/token", http.MethodPost, func(req *resty.Request) {
+		req.SetContext(ctx).SetBody(base.Json{
+			"pwd_id":                            pwdID,
+			"passcode":                          passcode,
+			"support_visit_limit_private_share": true,
+		})
+	}, &resp)
+	if err != nil {
+		return "", err
+	}
+	if resp.Data.Stoken == "" {
+		return "", errors.New("failed to get share token")
+	}
+	return resp.Data.Stoken, nil
+}
+
+func (d *QuarkOrUC) getShareRootFiles(ctx context.Context, pwdID, stoken string) ([]ShareFile, error) {
+	files := make([]ShareFile, 0)
+	page := 1
+	size := 100
+	for {
+		query := map[string]string{
+			"pwd_id":       pwdID,
+			"stoken":       stoken,
+			"pdir_fid":     "0",
+			"force":        "0",
+			"_page":        fmt.Sprintf("%d", page),
+			"_size":        fmt.Sprintf("%d", size),
+			"_fetch_total": "1",
+		}
+		var resp ShareDetailResp
+		_, err := d.request("/share/sharepage/detail", http.MethodGet, func(req *resty.Request) {
+			req.SetContext(ctx).SetQueryParams(query)
+		}, &resp)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, resp.Data.List...)
+		if page*size >= resp.Metadata.Total || len(resp.Data.List) == 0 {
+			break
+		}
+		page++
+	}
+	return files, nil
+}
+
+func (d *QuarkOrUC) saveShare(ctx context.Context, pwdID, stoken string, fidList, fidTokenList []string, toPdirFid string) (string, time.Duration, error) {
+	if toPdirFid == "" {
+		toPdirFid = "0"
+	}
+	data := base.Json{
+		"fid_list":       fidList,
+		"fid_token_list": fidTokenList,
+		"to_pdir_fid":    toPdirFid,
+		"pwd_id":         pwdID,
+		"stoken":         stoken,
+		"pdir_fid":       "0",
+		"scene":          "link",
+	}
+	var resp ShareSaveResp
+	_, err := d.request("/share/sharepage/save", http.MethodPost, func(req *resty.Request) {
+		req.SetContext(ctx).SetBody(data)
+	}, &resp)
+	if err != nil {
+		return "", 0, err
+	}
+	if resp.Data.TaskId == "" {
+		return "", 0, errors.New("empty save task id")
+	}
+	return resp.Data.TaskId, tqGapDuration(resp.Metadata.TqGap), nil
+}
+
+func (d *QuarkOrUC) waitShareTask(ctx context.Context, taskID string, gap time.Duration) error {
+	if gap <= 0 {
+		gap = 500 * time.Millisecond
+	}
+	const maxWait = 2 * time.Minute
+	deadline := time.Now().Add(maxWait)
+	retryIndex := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return errors.New("save from share timed out")
+		}
+		var resp ShareTaskResp
+		_, err := d.request("/task", http.MethodGet, func(req *resty.Request) {
+			req.SetContext(ctx).SetQueryParams(map[string]string{
+				"task_id":     taskID,
+				"retry_index": fmt.Sprintf("%d", retryIndex),
+			})
+		}, &resp)
+		if err != nil {
+			return err
+		}
+		switch resp.Data.Status {
+		case 2:
+			return nil
+		case 3:
+			msg := resp.Message
+			if msg == "" || msg == "ok" {
+				msg = "save from share failed"
+			}
+			return errors.New(msg)
+		}
+		if g := tqGapDuration(resp.Metadata.TqGap); g > 0 {
+			gap = g
+		}
+		retryIndex++
+		timer := time.NewTimer(gap)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func tqGapDuration(ms int) time.Duration {
+	if ms <= 0 {
+		return 0
+	}
+	return time.Duration(ms) * time.Millisecond
+}

--- a/drivers/quark_uc/share_test.go
+++ b/drivers/quark_uc/share_test.go
@@ -1,0 +1,71 @@
+package quark
+
+import "testing"
+
+func TestParseShareLink(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          string
+		wantID       string
+		wantPasscode string
+		wantErr      bool
+	}{
+		{
+			name:   "quark url",
+			raw:    "https://pan.quark.cn/s/abc123def456",
+			wantID: "abc123def456",
+		},
+		{
+			name:   "quark url with hash",
+			raw:    "https://pan.quark.cn/s/abc123def456#/list/share",
+			wantID: "abc123def456",
+		},
+		{
+			name:         "quark url with query pwd",
+			raw:          "https://pan.quark.cn/s/abc123def456?pwd=xy12",
+			wantID:       "abc123def456",
+			wantPasscode: "xy12",
+		},
+		{
+			name:         "quark url with chinese passcode",
+			raw:          "链接: https://pan.quark.cn/s/abc123def456 提取码: abcd",
+			wantID:       "abc123def456",
+			wantPasscode: "abcd",
+		},
+		{
+			name:   "uc url",
+			raw:    "https://drive.uc.cn/s/ucshareid01",
+			wantID: "ucshareid01",
+		},
+		{
+			name:    "unsupported",
+			raw:     "https://pan.baidu.com/s/xxxx",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			raw:     "   ",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotPass, err := ParseShareLink(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got pwdID=%s", gotID)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotID != tt.wantID {
+				t.Fatalf("pwdID = %s, want %s", gotID, tt.wantID)
+			}
+			if gotPass != tt.wantPasscode {
+				t.Fatalf("passcode = %s, want %s", gotPass, tt.wantPasscode)
+			}
+		})
+	}
+}

--- a/drivers/quark_uc/types.go
+++ b/drivers/quark_uc/types.go
@@ -260,6 +260,56 @@ type UpAuthResp struct {
 	Metadata struct{} `json:"metadata"`
 }
 
+type ShareFile struct {
+	Fid           string `json:"fid"`
+	FileName      string `json:"file_name"`
+	ShareFidToken string `json:"share_fid_token"`
+	File          bool   `json:"file"`
+}
+
+type ShareTokenResp struct {
+	Resp
+	Data struct {
+		Stoken string `json:"stoken"`
+		Title  string `json:"title"`
+	} `json:"data"`
+}
+
+type ShareDetailResp struct {
+	Resp
+	Data struct {
+		List []ShareFile `json:"list"`
+	} `json:"data"`
+	Metadata struct {
+		Size  int `json:"_size"`
+		Page  int `json:"_page"`
+		Count int `json:"_count"`
+		Total int `json:"_total"`
+	} `json:"metadata"`
+}
+
+type ShareSaveResp struct {
+	Resp
+	Data struct {
+		TaskId string `json:"task_id"`
+	} `json:"data"`
+	Metadata struct {
+		TqGap int `json:"tq_gap"`
+	} `json:"metadata"`
+}
+
+type ShareTaskResp struct {
+	Resp
+	Data struct {
+		TaskId   string `json:"task_id"`
+		Status   int    `json:"status"`
+		Progress int    `json:"progress"`
+	} `json:"data"`
+	Metadata struct {
+		TqGap int `json:"tq_gap"`
+	} `json:"metadata"`
+}
+
 type MemberResp struct {
 	Resp
 	Data struct {

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -218,3 +218,9 @@ type DirectUploader interface {
 	// return errs.NotImplement if the driver does not support the given direct upload tool
 	GetDirectUploadInfo(ctx context.Context, tool string, dstDir model.Obj, fileName string, fileSize int64) (any, error)
 }
+
+type SaveFromShare interface {
+	// SaveFromShare saves files from a cloud-drive share link into dstDir.
+	// Drivers that natively support saving from share links should implement this.
+	SaveFromShare(ctx context.Context, dstDir model.Obj, args model.SaveFromShareArgs) error
+}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -183,6 +183,14 @@ func Other(ctx context.Context, args model.FsOtherArgs) (interface{}, error) {
 	return res, err
 }
 
+func SaveFromShare(ctx context.Context, path, urlStr, password string) error {
+	err := saveFromShare(ctx, path, urlStr, password)
+	if err != nil {
+		log.Errorf("failed save from share %s to %s: %+v", urlStr, path, err)
+	}
+	return err
+}
+
 func PutURL(ctx context.Context, path, dstName, urlStr string) error {
 	storage, dstDirActualPath, err := op.GetStorageAndActualPath(path)
 	if err != nil {

--- a/internal/fs/other.go
+++ b/internal/fs/other.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/OpenListTeam/OpenList/v4/internal/conf"
 	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
 	"github.com/OpenListTeam/OpenList/v4/internal/model"
 	"github.com/OpenListTeam/OpenList/v4/internal/op"
 	"github.com/OpenListTeam/OpenList/v4/internal/task"
@@ -37,6 +38,20 @@ func remove(ctx context.Context, path string) error {
 		return errors.WithMessage(err, "failed get storage")
 	}
 	return op.Remove(ctx, storage, actualPath)
+}
+
+func saveFromShare(ctx context.Context, path, urlStr, password string) error {
+	storage, dstDirActualPath, err := op.GetStorageAndActualPath(path)
+	if err != nil {
+		return errors.WithMessage(err, "failed get storage")
+	}
+	if storage.Config().NoUpload {
+		return errors.WithStack(errs.UploadNotSupported)
+	}
+	return op.SaveFromShare(ctx, storage, dstDirActualPath, model.SaveFromShareArgs{
+		URL:      urlStr,
+		Password: password,
+	})
 }
 
 func other(ctx context.Context, args model.FsOtherArgs) (interface{}, error) {

--- a/internal/model/args.go
+++ b/internal/model/args.go
@@ -115,6 +115,14 @@ type SharingLinkArgs struct {
 	LinkArgs
 }
 
+type SaveFromShareArgs struct {
+	// URL is a share link. It may also contain a passcode in the same line,
+	// for example: "https://pan.quark.cn/s/xxxx 提取码: abcd"
+	URL string
+	// Password is an optional explicit passcode. It overrides any passcode parsed from URL.
+	Password string
+}
+
 type RangeReaderIF interface {
 	RangeRead(ctx context.Context, httpRange http_range.Range) (io.ReadCloser, error)
 }

--- a/internal/op/fs.go
+++ b/internal/op/fs.go
@@ -779,6 +779,50 @@ func GetDirectUploadTools(storage driver.Driver) []string {
 	return du.GetDirectUploadTools()
 }
 
+func SupportsSaveFromShare(storage driver.Driver) bool {
+	_, ok := storage.(driver.SaveFromShare)
+	if !ok {
+		return false
+	}
+	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
+		return false
+	}
+	return true
+}
+
+func SaveFromShare(ctx context.Context, storage driver.Driver, dstDirPath string, args model.SaveFromShareArgs) error {
+	if storage.Config().CheckStatus && storage.GetStorage().Status != WORK {
+		return errors.WithMessagef(errs.StorageNotInit, "storage status: %s", storage.GetStorage().Status)
+	}
+	s, ok := storage.(driver.SaveFromShare)
+	if !ok {
+		return errors.WithStack(errs.NotImplement)
+	}
+	dstDirPath = utils.FixAndCleanPath(dstDirPath)
+	if err := MakeDir(ctx, storage, dstDirPath); err != nil {
+		return errors.WithMessagef(err, "failed to make dir [%s]", dstDirPath)
+	}
+	dstDir, err := GetUnwrap(ctx, storage, dstDirPath)
+	if err != nil {
+		return errors.WithMessagef(err, "failed to get dir [%s]", dstDirPath)
+	}
+	if !dstDir.IsDir() {
+		return errors.WithStack(errs.NotFolder)
+	}
+	if model.ObjHasMask(dstDir, model.NoWrite) {
+		return errors.WithStack(errs.PermissionDenied)
+	}
+	if err = s.SaveFromShare(ctx, dstDir, args); err != nil {
+		return errors.WithStack(err)
+	}
+	Cache.DeleteDirectory(storage, dstDirPath)
+	if ctx.Value(conf.SkipHookKey) == nil && needHandleObjsUpdateHook() {
+		go objsUpdateHook(context.WithoutCancel(ctx), storage, dstDirPath, false)
+	}
+	log.Debugf("save from share [%s] to [%s] done", args.URL, dstDirPath)
+	return nil
+}
+
 func GetDirectUploadInfo(ctx context.Context, tool string, storage driver.Driver, dstDirPath, dstName string, fileSize int64, overwrite bool) (any, error) {
 	du, ok := storage.(driver.DirectUploader)
 	if !ok {

--- a/server/handles/fsread.go
+++ b/server/handles/fsread.go
@@ -55,6 +55,7 @@ type FsListResp struct {
 	WriteContentBypass bool      `json:"write_content_bypass"`
 	Provider           string    `json:"provider"`
 	DirectUploadTools  []string  `json:"direct_upload_tools,omitempty"`
+	SaveFromShare      bool      `json:"save_from_share,omitempty"`
 }
 
 func FsListSplit(c *gin.Context) {
@@ -109,9 +110,11 @@ func FsList(c *gin.Context, req *ListReq, user *model.User) {
 	total, objs := pagination(objs, &req.PageReq)
 	provider := "unknown"
 	var directUploadTools []string
+	var saveFromShare bool
 	if canWriteContentAtPath {
 		if storage, err := fs.GetStorage(reqPath, &fs.GetStoragesArgs{}); err == nil {
 			directUploadTools = op.GetDirectUploadTools(storage)
+			saveFromShare = op.SupportsSaveFromShare(storage)
 		}
 	}
 	common.SuccessResp(c, FsListResp{
@@ -123,6 +126,7 @@ func FsList(c *gin.Context, req *ListReq, user *model.User) {
 		WriteContentBypass: common.CanWriteContentBypassUserPerms(meta, reqPath),
 		Provider:           provider,
 		DirectUploadTools:  directUploadTools,
+		SaveFromShare:      saveFromShare,
 	})
 }
 

--- a/server/handles/save_from_share.go
+++ b/server/handles/save_from_share.go
@@ -1,0 +1,78 @@
+package handles
+
+import (
+	"strings"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/conf"
+	"github.com/OpenListTeam/OpenList/v4/internal/errs"
+	"github.com/OpenListTeam/OpenList/v4/internal/fs"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/internal/op"
+	"github.com/OpenListTeam/OpenList/v4/server/common"
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+)
+
+type SaveFromShareReq struct {
+	Urls     []string `json:"urls"`
+	Path     string   `json:"path"`
+	Password string   `json:"password"`
+}
+
+func SaveFromShare(c *gin.Context) {
+	user := c.Request.Context().Value(conf.UserKey).(*model.User)
+
+	var req SaveFromShareReq
+	if err := c.ShouldBind(&req); err != nil {
+		common.ErrorResp(c, err, 400)
+		return
+	}
+	reqPath, err := user.JoinPath(req.Path)
+	if err != nil {
+		common.ErrorResp(c, err, 403)
+		return
+	}
+	meta, err := op.GetNearestMeta(reqPath)
+	if err != nil && !errors.Is(errors.Cause(err), errs.MetaNotFound) {
+		common.ErrorResp(c, err, 500, true)
+		return
+	}
+	if !user.CanWriteContent() && !common.CanWriteContentBypassUserPerms(meta, reqPath) {
+		common.ErrorResp(c, errs.PermissionDenied, 403)
+		return
+	}
+	if !common.CanWrite(user, meta, reqPath) {
+		common.ErrorResp(c, errs.PermissionDenied, 403)
+		return
+	}
+
+	storage, err := fs.GetStorage(reqPath, &fs.GetStoragesArgs{})
+	if err != nil {
+		common.ErrorResp(c, err, 400)
+		return
+	}
+	if !op.SupportsSaveFromShare(storage) {
+		common.ErrorStrResp(c, "unsupported storage driver for save from share", 400)
+		return
+	}
+
+	saved := 0
+	for _, url := range req.Urls {
+		trimmedURL := strings.TrimSpace(url)
+		if trimmedURL == "" {
+			continue
+		}
+		if err := fs.SaveFromShare(c.Request.Context(), reqPath, trimmedURL, req.Password); err != nil {
+			common.ErrorResp(c, err, 500)
+			return
+		}
+		saved++
+	}
+	if saved == 0 {
+		common.ErrorStrResp(c, "no share links provided", 400)
+		return
+	}
+	common.SuccessResp(c, gin.H{
+		"saved": saved,
+	})
+}

--- a/server/router.go
+++ b/server/router.go
@@ -226,6 +226,7 @@ func _fs(g *gin.RouterGroup) {
 	// g.POST("/add_qbit", handles.AddQbittorrent)
 	// g.POST("/add_transmission", handles.SetTransmission)
 	g.POST("/add_offline_download", handles.AddOfflineDownload)
+	g.POST("/save_from_share", handles.SaveFromShare)
 	g.POST("/archive/decompress", handles.FsArchiveDecompress)
 	// Torrent 相关接口
 	g.POST("/torrent/parse", handles.ParseTorrent)


### PR DESCRIPTION
## Summary / 摘要

Add a driver-level save-from-share capability so cloud storages can save files from share links into a chosen directory. Quark/UC Session implements it first; the frontend “More” menu shows the action only when the current storage supports it.

新增驱动级「分享链接转存」能力，将分享中的文件保存到指定目录。先由夸克/UC Session 实现；前端仅在当前存储支持时，在「更多」菜单中显示转存入口。

- Users can paste one or more share links (optional passcode in the same line), pick a destination folder, and save natively on the cloud drive without downloading through OpenList.
  / 用户可粘贴一条或多条分享链接（同一行可带提取码），选择目标目录后由网盘原生转存，文件不经过 OpenList 中转。
- `/api/fs/list` now returns `save_from_share` so the UI can show or hide the button.
  / `/api/fs/list` 新增 `save_from_share`，前端据此显示或隐藏按钮。
- New API: `POST /api/fs/save_from_share` with `{ path, urls, password }`. Permission matches mkdir/upload (write on the destination path).
  / 新增接口 `POST /api/fs/save_from_share`，参数为 `{ path, urls, password }`。权限与新建目录/上传一致（目标路径可写）。
- New optional driver interface `driver.SaveFromShare`. Other drivers can implement the same method without HTTP or UI changes.
  / 新增可选驱动接口 `driver.SaveFromShare`。其他网盘实现同一方法即可，无需改 HTTP 或前端。
- Quark/UC flow: parse link → share token → list share root → save → poll `/task` until completion, then invalidate directory cache.
  / 夸克/UC 流程：解析链接 → 取分享 token → 列分享根目录 → 转存 → 轮询 `/task` 直到完成，然后失效目录缓存。
- No config, storage-format, or migration changes.
  / 不涉及配置、存储格式或迁移变更。

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [x] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList:
- OpenList-Docs:

## Testing / 测试

- [ ] `go test ./...`
- [x] Manual test / 手动测试:
  - `go test ./drivers/quark_uc/ ./internal/fs/ ./internal/op/ ./server/handles/`
  - Built a local binary with the matching frontend, started `./openlist server`, added a Quark Session storage, and confirmed save-from-share from the More menu into a chosen folder.
    / 使用配套前端构建本地二进制并启动 `./openlist server`，添加夸克 Session 存储后，从「更多」菜单转存分享链接到指定目录，行为正常。

Did not run full `go test ./...`.
/ 未执行完整的 `go test ./...`。

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [x] Other (please specify) / 其他（请注明）: Grok (xAI)

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。