### PR TITLE
fix(alist_v3): set child paths so nested directories resolve

### DIFF
--- a/drivers/alist_v3/driver.go
+++ b/drivers/alist_v3/driver.go
@@ -95,6 +95,7 @@ func (d *AListV3) List(ctx context.Context, dir model.Obj, args model.ListArgs) 
 		file := model.ObjThumb{
 			Object: model.Object{
 				Name:     f.Name,
+				Path:     path.Join(dir.GetPath(), f.Name),
 				Modified: f.Modified,
 				Ctime:    f.Created,
 				Size:     f.Size,

--- a/drivers/alist_v3/driver_test.go
+++ b/drivers/alist_v3/driver_test.go
@@ -1,0 +1,173 @@
+package alist_v3
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/drivers/base"
+	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/go-resty/resty/v2"
+)
+
+// useTestClient installs a resty client that does not read conf.Conf, which is
+// nil outside of a booted server.
+func useTestClient(t *testing.T) {
+	t.Helper()
+	prev := base.RestyClient
+	base.RestyClient = resty.New().SetTimeout(5 * time.Second)
+	t.Cleanup(func() { base.RestyClient = prev })
+}
+
+// recorder collects the paths a fake upstream was asked for.
+type recorder struct {
+	mu    sync.Mutex
+	paths []string
+}
+
+func (r *recorder) add(p string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.paths = append(r.paths, p)
+}
+
+func (r *recorder) get() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.paths...)
+}
+
+// fakeUpstream serves /api/fs/list from a fixed tree.
+//
+// The important detail is the fallback: an OpenList server resolves an empty
+// path to its own root, so a request that lost its sub-path does not fail --
+// it silently returns the wrong directory.
+func fakeUpstream(t *testing.T, tree map[string][]ObjResp) (string, *recorder) {
+	t.Helper()
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ListReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("undecodable request body: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		rec.add(req.Path)
+		content, ok := tree[req.Path]
+		if !ok {
+			content = tree["/"]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"code":    200,
+			"message": "success",
+			"data": map[string]any{
+				"content": content,
+				"total":   len(content),
+			},
+		}); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, rec
+}
+
+func newTestDriver(address, rootFolderPath string) *AListV3 {
+	return &AListV3{
+		Addition: Addition{
+			RootPath: driver.RootPath{RootFolderPath: rootFolderPath},
+			Address:  address,
+			Token:    "test-token",
+		},
+	}
+}
+
+func names(objs []model.Obj) []string {
+	out := make([]string, 0, len(objs))
+	for _, o := range objs {
+		out = append(out, o.GetName())
+	}
+	return out
+}
+
+// TestListSetsChildPaths pins the contract op.Get relies on: it returns the
+// child object from its parent's listing verbatim, so whatever Path that object
+// carries is what the next List sends upstream.
+func TestListSetsChildPaths(t *testing.T) {
+	useTestClient(t)
+
+	address, _ := fakeUpstream(t, map[string][]ObjResp{
+		"/":      {{Name: "root-marker", IsDir: true}},
+		"/drive": {{Name: "concerts", IsDir: true}, {Name: "movie.mkv"}},
+	})
+	d := newTestDriver(address, "/drive")
+
+	objs, err := d.List(context.Background(),
+		&model.Object{Path: d.RootFolderPath, Name: "root", IsFolder: true},
+		model.ListArgs{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(objs) != 2 {
+		t.Fatalf("got %d objects, want 2: %v", len(objs), names(objs))
+	}
+	for _, obj := range objs {
+		want := "/drive/" + obj.GetName()
+		if got := obj.GetPath(); got != want {
+			t.Errorf("child %q has path %q, want %q", obj.GetName(), got, want)
+		}
+	}
+}
+
+// TestListDoesNotLoopOnNestedDirectories is the regression proper. A child
+// without a Path makes the driver ask the upstream server for "", the server
+// answers with its own root, and every level below the mount point serves that
+// same listing back -- an endless self-similar directory.
+func TestListDoesNotLoopOnNestedDirectories(t *testing.T) {
+	useTestClient(t)
+
+	address, rec := fakeUpstream(t, map[string][]ObjResp{
+		"/":                             {{Name: "drive", IsDir: true}, {Name: "public", IsDir: true}},
+		"/drive":                        {{Name: "concerts", IsDir: true}},
+		"/drive/concerts":               {{Name: "live-in-tokyo", IsDir: true}},
+		"/drive/concerts/live-in-tokyo": {{Name: "show.mkv"}},
+	})
+	d := newTestDriver(address, "/drive")
+	ctx := context.Background()
+
+	dir := model.Obj(&model.Object{Path: d.RootFolderPath, Name: "root", IsFolder: true})
+	for _, want := range []struct {
+		requested string
+		listing   []string
+	}{
+		{"/drive", []string{"concerts"}},
+		{"/drive/concerts", []string{"live-in-tokyo"}},
+		{"/drive/concerts/live-in-tokyo", []string{"show.mkv"}},
+	} {
+		objs, err := d.List(ctx, dir, model.ListArgs{})
+		if err != nil {
+			t.Fatalf("List(%q): %v", want.requested, err)
+		}
+		if got := names(objs); len(got) != 1 || got[0] != want.listing[0] {
+			t.Fatalf("listing under %q is %v, want %v", want.requested, got, want.listing)
+		}
+		dir = objs[0]
+	}
+
+	got := rec.get()
+	wantPaths := []string{"/drive", "/drive/concerts", "/drive/concerts/live-in-tokyo"}
+	if len(got) != len(wantPaths) {
+		t.Fatalf("upstream saw %v, want %v", got, wantPaths)
+	}
+	for i, want := range wantPaths {
+		if got[i] != want {
+			t.Errorf("request %d asked for %q, want %q", i, got[i], want)
+		}
+	}
+}


### PR DESCRIPTION
- Set `Path` on every object returned by `List`, matching the OpenList driver. `op.Get` hands a child object straight back to `List`, so a child without a path made the driver request `""` from the upstream server, which answered with its own root: every directory below the mount point served the same listing back, endlessly.
- Add tests covering the child paths and a three-level descent.

<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
- For breaking changes, add `!`: `feat(driver)!: change auth flow`
-->

## Summary / 摘要

<!--
Briefly describe what changed and why.
简要说明改了什么，以及为什么需要改。
-->

<!--
- List user-visible behavior changes.
- List important implementation changes.
- Mention config, storage, API, or compatibility changes if any.

- 列出用户可感知的行为变化。
- 列出重要实现变化。
- 如涉及配置、存储、API 或兼容性变化，请明确说明。
-->

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend:
- OpenList-Docs:

## Related Issues / 关联 Issue

<!--
Use `Closes #123`, `Fixes #123`, or `Relates to #123`.
Remove this section if not applicable.
使用 `Closes #123`、`Fixes #123` 或 `Relates to #123`。
不适用时请删除本节。
-->

## Testing / 测试

<!--
Describe commands, platforms, and manual checks.
If not tested, explain why.

说明执行过的命令、测试平台和手动验证。
如果未测试，请说明原因。
-->

- [ ] `go test ./...`
- [ ] Manual test / 手动测试:

## Checklist / 检查清单

- [ ] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [ ] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [ ] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

<!--
Please disclose any substantial AI assistance used in this PR.
Minor AI assistance, such as typo fixes, autocomplete, formatting suggestions,
or wording polish, does not need to be disclosed.
Remove this section if not applicable.

请披露此 PR 中使用的重要 AI 辅助内容。
轻微 AI 辅助，例如拼写修正、自动补全、格式建议或文字润色，无需披露。
如不适用，请删除本节。

Deliberate non-disclosure may be treated as a trust and compliance issue.

故意隐瞒 AI 使用情况可能被视为信任与合规问题。
-->

- [ ] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [ ] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [ ] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
