### PR TITLE
fix(alist_v3): set child paths so nested directories resolve

### DIFF
--- a/drivers/alist_v3/driver.go
+++ b/drivers/alist_v3/driver.go
@@ -95,6 +95,7 @@ func (d *AListV3) List(ctx context.Context, dir model.Obj, args model.ListArgs) 
 		file := model.ObjThumb{
 			Object: model.Object{
 				Name:     f.Name,
+				Path:     path.Join(dir.GetPath(), f.Name),
 				Modified: f.Modified,
 				Ctime:    f.Created,
 				Size:     f.Size,

--- a/drivers/alist_v3/driver_test.go
+++ b/drivers/alist_v3/driver_test.go
@@ -1,0 +1,173 @@
+package alist_v3
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/OpenListTeam/OpenList/v4/drivers/base"
+	"github.com/OpenListTeam/OpenList/v4/internal/driver"
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/go-resty/resty/v2"
+)
+
+// useTestClient installs a resty client that does not read conf.Conf, which is
+// nil outside of a booted server.
+func useTestClient(t *testing.T) {
+	t.Helper()
+	prev := base.RestyClient
+	base.RestyClient = resty.New().SetTimeout(5 * time.Second)
+	t.Cleanup(func() { base.RestyClient = prev })
+}
+
+// recorder collects the paths a fake upstream was asked for.
+type recorder struct {
+	mu    sync.Mutex
+	paths []string
+}
+
+func (r *recorder) add(p string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.paths = append(r.paths, p)
+}
+
+func (r *recorder) get() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.paths...)
+}
+
+// fakeUpstream serves /api/fs/list from a fixed tree.
+//
+// The important detail is the fallback: an OpenList server resolves an empty
+// path to its own root, so a request that lost its sub-path does not fail --
+// it silently returns the wrong directory.
+func fakeUpstream(t *testing.T, tree map[string][]ObjResp) (string, *recorder) {
+	t.Helper()
+	rec := &recorder{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ListReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("undecodable request body: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		rec.add(req.Path)
+		content, ok := tree[req.Path]
+		if !ok {
+			content = tree["/"]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"code":    200,
+			"message": "success",
+			"data": map[string]any{
+				"content": content,
+				"total":   len(content),
+			},
+		}); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL, rec
+}
+
+func newTestDriver(address, rootFolderPath string) *AListV3 {
+	return &AListV3{
+		Addition: Addition{
+			RootPath: driver.RootPath{RootFolderPath: rootFolderPath},
+			Address:  address,
+			Token:    "test-token",
+		},
+	}
+}
+
+func names(objs []model.Obj) []string {
+	out := make([]string, 0, len(objs))
+	for _, o := range objs {
+		out = append(out, o.GetName())
+	}
+	return out
+}
+
+// TestListSetsChildPaths pins the contract op.Get relies on: it returns the
+// child object from its parent's listing verbatim, so whatever Path that object
+// carries is what the next List sends upstream.
+func TestListSetsChildPaths(t *testing.T) {
+	useTestClient(t)
+
+	address, _ := fakeUpstream(t, map[string][]ObjResp{
+		"/":      {{Name: "root-marker", IsDir: true}},
+		"/drive": {{Name: "concerts", IsDir: true}, {Name: "movie.mkv"}},
+	})
+	d := newTestDriver(address, "/drive")
+
+	objs, err := d.List(context.Background(),
+		&model.Object{Path: d.RootFolderPath, Name: "root", IsFolder: true},
+		model.ListArgs{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(objs) != 2 {
+		t.Fatalf("got %d objects, want 2: %v", len(objs), names(objs))
+	}
+	for _, obj := range objs {
+		want := "/drive/" + obj.GetName()
+		if got := obj.GetPath(); got != want {
+			t.Errorf("child %q has path %q, want %q", obj.GetName(), got, want)
+		}
+	}
+}
+
+// TestListDoesNotLoopOnNestedDirectories is the regression proper. A child
+// without a Path makes the driver ask the upstream server for "", the server
+// answers with its own root, and every level below the mount point serves that
+// same listing back -- an endless self-similar directory.
+func TestListDoesNotLoopOnNestedDirectories(t *testing.T) {
+	useTestClient(t)
+
+	address, rec := fakeUpstream(t, map[string][]ObjResp{
+		"/":                             {{Name: "drive", IsDir: true}, {Name: "public", IsDir: true}},
+		"/drive":                        {{Name: "concerts", IsDir: true}},
+		"/drive/concerts":               {{Name: "live-in-tokyo", IsDir: true}},
+		"/drive/concerts/live-in-tokyo": {{Name: "show.mkv"}},
+	})
+	d := newTestDriver(address, "/drive")
+	ctx := context.Background()
+
+	dir := model.Obj(&model.Object{Path: d.RootFolderPath, Name: "root", IsFolder: true})
+	for _, want := range []struct {
+		requested string
+		listing   []string
+	}{
+		{"/drive", []string{"concerts"}},
+		{"/drive/concerts", []string{"live-in-tokyo"}},
+		{"/drive/concerts/live-in-tokyo", []string{"show.mkv"}},
+	} {
+		objs, err := d.List(ctx, dir, model.ListArgs{})
+		if err != nil {
+			t.Fatalf("List(%q): %v", want.requested, err)
+		}
+		if got := names(objs); len(got) != 1 || got[0] != want.listing[0] {
+			t.Fatalf("listing under %q is %v, want %v", want.requested, got, want.listing)
+		}
+		dir = objs[0]
+	}
+
+	got := rec.get()
+	wantPaths := []string{"/drive", "/drive/concerts", "/drive/concerts/live-in-tokyo"}
+	if len(got) != len(wantPaths) {
+		t.Fatalf("upstream saw %v, want %v", got, wantPaths)
+	}
+	for i, want := range wantPaths {
+		if got[i] != want {
+			t.Errorf("request %d asked for %q, want %q", i, got[i], want)
+		}
+	}
+}

--- a/drivers/alist_v3/driver_test.go
+++ b/drivers/alist_v3/driver_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
@@ -15,159 +14,52 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-// useTestClient installs a resty client that does not read conf.Conf, which is
-// nil outside of a booted server.
-func useTestClient(t *testing.T) {
-	t.Helper()
-	prev := base.RestyClient
-	base.RestyClient = resty.New().SetTimeout(5 * time.Second)
-	t.Cleanup(func() { base.RestyClient = prev })
-}
-
-// recorder collects the paths a fake upstream was asked for.
-type recorder struct {
-	mu    sync.Mutex
-	paths []string
-}
-
-func (r *recorder) add(p string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.paths = append(r.paths, p)
-}
-
-func (r *recorder) get() []string {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return append([]string(nil), r.paths...)
-}
-
-// fakeUpstream serves /api/fs/list from a fixed tree.
-//
-// The important detail is the fallback: an OpenList server resolves an empty
-// path to its own root, so a request that lost its sub-path does not fail --
-// it silently returns the wrong directory.
-func fakeUpstream(t *testing.T, tree map[string][]ObjResp) (string, *recorder) {
-	t.Helper()
-	rec := &recorder{}
+// TestListSetsChildPaths descends two levels the way op.Get does, feeding an
+// object from one listing back into List as dir. Without a Path on that object
+// the driver asks upstream for "", which a real server answers with its own
+// root -- hence the fake upstream's fallback, and the endless self-similar tree.
+func TestListSetsChildPaths(t *testing.T) {
+	tree := map[string][]ObjResp{
+		"/":               {{Name: "root-marker", IsDir: true}},
+		"/drive":          {{Name: "concerts", IsDir: true}},
+		"/drive/concerts": {{Name: "show.mkv"}},
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req ListReq
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("undecodable request body: %v", err)
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		rec.add(req.Path)
+		_ = json.NewDecoder(r.Body).Decode(&req)
 		content, ok := tree[req.Path]
 		if !ok {
 			content = tree["/"]
 		}
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(map[string]any{
-			"code":    200,
-			"message": "success",
-			"data": map[string]any{
-				"content": content,
-				"total":   len(content),
-			},
-		}); err != nil {
-			t.Errorf("failed to encode response: %v", err)
-		}
+		w.Header().Set("Content-Type", "application/json") // resty only unmarshals JSON
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"code": 200, "message": "success",
+			"data": map[string]any{"content": content, "total": len(content)},
+		})
 	}))
 	t.Cleanup(srv.Close)
-	return srv.URL, rec
-}
 
-func newTestDriver(address, rootFolderPath string) *AListV3 {
-	return &AListV3{
-		Addition: Addition{
-			RootPath: driver.RootPath{RootFolderPath: rootFolderPath},
-			Address:  address,
-			Token:    "test-token",
-		},
-	}
-}
+	// conf.Conf is nil outside a booted server, so base.InitClient() is unusable.
+	prev := base.RestyClient
+	base.RestyClient = resty.New().SetTimeout(5 * time.Second)
+	t.Cleanup(func() { base.RestyClient = prev })
 
-func names(objs []model.Obj) []string {
-	out := make([]string, 0, len(objs))
-	for _, o := range objs {
-		out = append(out, o.GetName())
-	}
-	return out
-}
-
-// TestListSetsChildPaths pins the contract op.Get relies on: it returns the
-// child object from its parent's listing verbatim, so whatever Path that object
-// carries is what the next List sends upstream.
-func TestListSetsChildPaths(t *testing.T) {
-	useTestClient(t)
-
-	address, _ := fakeUpstream(t, map[string][]ObjResp{
-		"/":      {{Name: "root-marker", IsDir: true}},
-		"/drive": {{Name: "concerts", IsDir: true}, {Name: "movie.mkv"}},
-	})
-	d := newTestDriver(address, "/drive")
-
-	objs, err := d.List(context.Background(),
-		&model.Object{Path: d.RootFolderPath, Name: "root", IsFolder: true},
-		model.ListArgs{})
-	if err != nil {
-		t.Fatalf("List: %v", err)
-	}
-	if len(objs) != 2 {
-		t.Fatalf("got %d objects, want 2: %v", len(objs), names(objs))
-	}
-	for _, obj := range objs {
-		want := "/drive/" + obj.GetName()
-		if got := obj.GetPath(); got != want {
-			t.Errorf("child %q has path %q, want %q", obj.GetName(), got, want)
-		}
-	}
-}
-
-// TestListDoesNotLoopOnNestedDirectories is the regression proper. A child
-// without a Path makes the driver ask the upstream server for "", the server
-// answers with its own root, and every level below the mount point serves that
-// same listing back -- an endless self-similar directory.
-func TestListDoesNotLoopOnNestedDirectories(t *testing.T) {
-	useTestClient(t)
-
-	address, rec := fakeUpstream(t, map[string][]ObjResp{
-		"/":                             {{Name: "drive", IsDir: true}, {Name: "public", IsDir: true}},
-		"/drive":                        {{Name: "concerts", IsDir: true}},
-		"/drive/concerts":               {{Name: "live-in-tokyo", IsDir: true}},
-		"/drive/concerts/live-in-tokyo": {{Name: "show.mkv"}},
-	})
-	d := newTestDriver(address, "/drive")
-	ctx := context.Background()
-
-	dir := model.Obj(&model.Object{Path: d.RootFolderPath, Name: "root", IsFolder: true})
-	for _, want := range []struct {
-		requested string
-		listing   []string
-	}{
-		{"/drive", []string{"concerts"}},
-		{"/drive/concerts", []string{"live-in-tokyo"}},
-		{"/drive/concerts/live-in-tokyo", []string{"show.mkv"}},
-	} {
-		objs, err := d.List(ctx, dir, model.ListArgs{})
+	d := &AListV3{Addition: Addition{
+		RootPath: driver.RootPath{RootFolderPath: "/drive"},
+		Address:  srv.URL,
+	}}
+	dir := model.Obj(&model.Object{Path: "/drive", IsFolder: true})
+	for _, want := range []string{"/drive/concerts", "/drive/concerts/show.mkv"} {
+		objs, err := d.List(context.Background(), dir, model.ListArgs{})
 		if err != nil {
-			t.Fatalf("List(%q): %v", want.requested, err)
+			t.Fatalf("List(%q): %v", dir.GetPath(), err)
 		}
-		if got := names(objs); len(got) != 1 || got[0] != want.listing[0] {
-			t.Fatalf("listing under %q is %v, want %v", want.requested, got, want.listing)
+		if len(objs) != 1 {
+			t.Fatalf("List(%q) returned %d objects, want 1", dir.GetPath(), len(objs))
+		}
+		if got := objs[0].GetPath(); got != want {
+			t.Fatalf("child of %q has path %q, want %q", dir.GetPath(), got, want)
 		}
 		dir = objs[0]
-	}
-
-	got := rec.get()
-	wantPaths := []string{"/drive", "/drive/concerts", "/drive/concerts/live-in-tokyo"}
-	if len(got) != len(wantPaths) {
-		t.Fatalf("upstream saw %v, want %v", got, wantPaths)
-	}
-	for i, want := range wantPaths {
-		if got[i] != want {
-			t.Errorf("request %d asked for %q, want %q", i, got[i], want)
-		}
 	}
 }


### PR DESCRIPTION
## Summary / 摘要

`AListV3.List` never set `Path` on the objects it returns. `op.Get` resolves a
child by handing back the object from its parent's listing verbatim, so that
object is what the next `List` receives as `dir` — and with an empty `Path`, the
driver asked the upstream server for `""`.

An OpenList/AList server resolves an empty path to its own root, so the request
did not fail; it returned the wrong directory. Every level below the mount point
served the upstream root back, producing an endless self-similar directory: you
click into a folder, get the same listing again, and the breadcrumb grows one
segment each time.

User-visible behavior change:

- Subdirectories of an `AList V3` mount now open correctly. Previously only the
  mount root worked, because `op.Get` builds the root object itself from
  `IRootPath` and that one does carry a `Path`.

Implementation change:

- `List` now sets `Path: path.Join(dir.GetPath(), f.Name)` on each returned
  object, which is what `drivers/openlist` already does
  (`drivers/openlist/driver.go:98`).

This is a regression from `96cd7143` — *refactor(op): remove automatic Path
assignment* (#1734). That commit removed the block in `op.List` that used to
fill in a child's `Path`:

```go
- if s, ok := f.(model.SetPath); ok && f.GetPath() == "" && dir.GetPath() != "" {
-     s.SetPath(stdpath.Join(dir.GetPath(), f.GetName()))
```

on the stated grounds that "Path和Id只在驱动内使用，不应由op.List设置Path", and
migrated the affected drivers to set it themselves. `drivers/alist_v3` was
missed in that migration; `drivers/openlist`, which is otherwise a near-identical
file, was not.

Scope notes:

- `ListArchive` also returns objects without a `Path`, but `drivers/openlist`
  behaves identically there, so it is left untouched.
- `drivers/alist_v3` lacks `PassRefreshFlagToUpsteam`. That is a feature
  difference, not part of this defect.

No configuration, storage format, API or migration behavior is affected.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: N/A
- OpenList-Docs: N/A

## Related Issues / 关联 Issue

Fixes #2077 — reported as "点击任意子目录继续进入时，发现会出现套娃". That issue was
closed after the reporter switched to the `OpenList` driver, but the `AList V3`
driver bug itself was never fixed.

cc @xrgzs — you triaged #2077 and noted that this driver is a copy kept for
newer AList API compatibility, so you are probably the right person to check
that aligning it with `drivers/openlist` here is the intended direction.

## Testing / 测试

- [ ] `go test ./...`
- [x] Manual test / 手动测试:

`go test ./...` is **not** checked because it does not pass on `main` in this
environment, for reasons unrelated to this change:

- `go vet`'s printf analyzer, which `go test` runs by default, fails the build
  of `drivers/123`, `drivers/189`, `drivers/189pc`, `drivers/chaoxing`,
  `drivers/google_drive`, `drivers/google_photo`, `drivers/lanzou` and three
  `internal/offline_download/*` packages with `non-constant format string`.
- `drivers/onedrive_sharelink.TestNoRedirectClientUsesSharedSettings` panics
  with a nil pointer dereference at `internal/net/serve.go:289`, because
  `conf.Conf` is nil outside a booted server.

What was run instead:

```
go build ./...
go vet ./drivers/alist_v3/...
gofmt -l drivers/alist_v3/
go test -race -count=1 ./drivers/alist_v3/...
```

Manual test: an OpenList v4 instance mounting another OpenList v4 instance over
`AList V3`. Before the fix, every directory below the mount point returned the
upstream server's root. After the fix, a 384-entry directory and its children
list correctly, three levels deep.

Two tests are added in `drivers/alist_v3/driver_test.go`:

- `TestListSetsChildPaths` — every returned object carries
  `path.Join(dir.GetPath(), name)`.
- `TestListDoesNotLoopOnNestedDirectories` — descends three levels, feeding each
  listing's object back into `List` the way `op.Get` does, and asserts both the
  listings and the exact paths the upstream server was asked for.

The fake upstream deliberately falls back to its own root for an unknown path
instead of returning 404, because that is what a real server does. Answering 404
would turn the defect into a loud error and the loop would not reproduce.

Both tests fail on `main`:

```
--- FAIL: TestListSetsChildPaths
    child "concerts" has path "", want "/drive/concerts"
--- FAIL: TestListDoesNotLoopOnNestedDirectories
    listing under "/drive/concerts" is [drive public], want [live-in-tokyo]
```

Mutation-checked: `Path: f.Name`, `Path: dir.GetPath()` and `Path: ""` are each
caught by the tests.

The new tests install their own `resty` client rather than calling
`base.InitClient()`, to avoid the same nil `conf.Conf` dereference that makes
`drivers/onedrive_sharelink` panic.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [x] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [x] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [ ] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
