### PR TITLE
fix(drivers/139): improve mail login credential renewal

### DIFF
--- a/drivers/139/meta.go
+++ b/drivers/139/meta.go
@@ -7,11 +7,11 @@ import (
 
 type Addition struct {
 	//Account       string `json:"account" required:"true"`
-	Authorization string `json:"authorization" type:"text" help:"Authorization can be used alone. If empty, use mail_cookies alone for fast login, or mail_cookies + username + password for full login fallback."`
-	Username      string `json:"username" help:"Required only when using password login fallback with mail_cookies."`
-	Password      string `json:"password" secret:"true" help:"Required only when using password login fallback with mail_cookies."`
+	Authorization string `json:"authorization" type:"text" help:"Authorization can be used alone. If empty, use username + password; mail_cookies is optional and will be established/updated automatically. Existing mail_cookies can also be used alone for fast login."`
+	Username      string `json:"username" help:"Use together with password when Authorization is empty. mail_cookies may be left empty on the first login."`
+	Password      string `json:"password" secret:"true" help:"Use together with username when Authorization is empty. mail_cookies may be left empty on the first login."`
 	SmsCode       string `json:"sms_code" secret:"true" help:"Fill this only after OpenList reports that a 139 Mail SMS verification code was sent, then save the storage again."`
-	MailCookies   string `json:"mail_cookies" type:"text" help:"Cookies from mail.10086.cn. Used for fast login only when Authorization is empty; otherwise retained as device context for password login fallback."`
+	MailCookies   string `json:"mail_cookies" type:"text" help:"Optional cookies from mail.10086.cn. Leave empty for a first username/password login; cookies created or updated by password/SMS login are persisted and reused as device context. Existing cookies may also be used alone for fast login."`
 	driver.RootID
 	Type                 string `json:"type" type:"select" options:"personal_new,family,group,personal,share" default:"personal_new"`
 	LinkID               string `json:"link_id" type:"text" help:"Multiple shares are separated by commas or new lines. Use link_id#password for password-protected shares."`

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -1224,6 +1224,13 @@ func mailXMLHeaders(cookie string) map[string]string {
 	}
 }
 
+func new139RestyClient() *resty.Client {
+	if base.RestyClient != nil {
+		return base.RestyClient.Clone()
+	}
+	return base.NewRestyClient()
+}
+
 func (d *Yun139) sendSMSVerificationCode(riskCode string) error {
 	scene, ok := smsSceneForRisk(riskCode)
 	if !ok {
@@ -1246,7 +1253,7 @@ func (d *Yun139) sendSMSVerificationCode(riskCode string) error {
 		mailXMLField("scene", strconv.Itoa(scene)),
 		"</object>",
 	}, "")
-	res, err := base.RestyClient.Clone().SetRetryCount(0).R().
+	res, err := new139RestyClient().SetRetryCount(0).R().
 		SetHeaders(mailXMLHeaders(d.MailCookies)).
 		SetBody(body).
 		Post(mailSMSURL + "?func=" + url.QueryEscape("login:sendSmsCodeByScene") + "&cguid=" + strconv.FormatInt(time.Now().UnixMilli(), 10))
@@ -1299,7 +1306,7 @@ func (d *Yun139) verifySMSCode(riskCode string) (string, error) {
 		pwdType,
 		"</object>",
 	}, "")
-	res, err := base.RestyClient.Clone().SetRetryCount(0).R().
+	res, err := new139RestyClient().SetRetryCount(0).R().
 		SetHeaders(mailXMLHeaders(d.MailCookies)).
 		SetBody(body).
 		Post(mailSMSURL + "?func=" + url.QueryEscape("/login/inlogin.action") + "&cguid=" + strconv.FormatInt(time.Now().UnixMilli(), 10))
@@ -1375,7 +1382,7 @@ func (d *Yun139) step1_password_login() (string, error) {
 	log.Debugf("DEBUG: 登录请求 URL: %s", loginURL)
 	log.Debugf("DEBUG: 登录请求已准备")
 
-	res, err := base.RestyClient.Clone().
+	res, err := new139RestyClient().
 		SetRetryCount(0).
 		SetRedirectPolicy(resty.RedirectPolicyFunc(func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse

--- a/drivers/139/util.go
+++ b/drivers/139/util.go
@@ -46,30 +46,9 @@ const (
 )
 
 var (
-	mailRootURL     = "https://mail.10086.cn/"
 	mailPasswordURL = "https://mail.10086.cn/Login/Login.ashx"
 	mailSMSURL      = "https://mail.10086.cn/s"
 )
-
-var mailLoginCookieExclusions = map[string]struct{}{
-	"hecaiyun_stay_time":          {},
-	"isShowAgreeIconNew":          {},
-	"hecaiyundata2021jssdkcross":  {},
-	"random":                      {},
-	"a_l2":                        {},
-	"hecaiyun_stay_url":           {},
-	"a_l":                         {},
-	"_139mail_login_type":         {},
-	"_139mail_login_shortAddr":    {},
-	"sajssdk_2015_cross_new_user": {},
-	"fromhtml5":                   {},
-	"html5SkinPath8011":           {},
-	"Os_SSo_Sid":                  {},
-	"sid":                         {},
-	"Login_UserNumber":            {},
-	"RMKEY":                       {},
-	"rtexpired":                   {},
-}
 
 type credentialState int
 
@@ -1195,28 +1174,6 @@ func mergeMailCookieHeader(existing string, responseCookies []*http.Cookie) stri
 	return cookiepkg.ToString(cookies)
 }
 
-func sanitizeMailLoginCookies(existing, newJSessionID string) string {
-	cookies := cookiepkg.Parse(existing)
-	filtered := cookies[:0]
-	for _, cookie := range cookies {
-		if _, excluded := mailLoginCookieExclusions[cookie.Name]; excluded {
-			continue
-		}
-		if cookie.Name == "JSESSIONID" {
-			if newJSessionID == "" {
-				continue
-			}
-			cookie.Value = newJSessionID
-			newJSessionID = ""
-		}
-		filtered = append(filtered, cookie)
-	}
-	if newJSessionID != "" {
-		filtered = append(filtered, &http.Cookie{Name: "JSESSIONID", Value: newJSessionID})
-	}
-	return cookiepkg.ToString(filtered)
-}
-
 func mailRiskCode(location string) string {
 	parsed, err := url.Parse(location)
 	if err != nil {
@@ -1267,13 +1224,6 @@ func mailXMLHeaders(cookie string) map[string]string {
 	}
 }
 
-func new139RestyClient() *resty.Client {
-	if base.RestyClient != nil {
-		return base.RestyClient.Clone()
-	}
-	return resty.New()
-}
-
 func (d *Yun139) sendSMSVerificationCode(riskCode string) error {
 	scene, ok := smsSceneForRisk(riskCode)
 	if !ok {
@@ -1296,7 +1246,7 @@ func (d *Yun139) sendSMSVerificationCode(riskCode string) error {
 		mailXMLField("scene", strconv.Itoa(scene)),
 		"</object>",
 	}, "")
-	res, err := new139RestyClient().R().
+	res, err := base.RestyClient.Clone().SetRetryCount(0).R().
 		SetHeaders(mailXMLHeaders(d.MailCookies)).
 		SetBody(body).
 		Post(mailSMSURL + "?func=" + url.QueryEscape("login:sendSmsCodeByScene") + "&cguid=" + strconv.FormatInt(time.Now().UnixMilli(), 10))
@@ -1349,7 +1299,7 @@ func (d *Yun139) verifySMSCode(riskCode string) (string, error) {
 		pwdType,
 		"</object>",
 	}, "")
-	res, err := new139RestyClient().R().
+	res, err := base.RestyClient.Clone().SetRetryCount(0).R().
 		SetHeaders(mailXMLHeaders(d.MailCookies)).
 		SetBody(body).
 		Post(mailSMSURL + "?func=" + url.QueryEscape("/login/inlogin.action") + "&cguid=" + strconv.FormatInt(time.Now().UnixMilli(), 10))
@@ -1386,25 +1336,6 @@ func (d *Yun139) step1_password_login() (string, error) {
 	log.Debugf("--- 执行步骤 1: 登录 API ---")
 	loginURL := mailPasswordURL
 
-	preLogin, err := new139RestyClient().SetRedirectPolicy(resty.NoRedirectPolicy()).R().Get(mailRootURL)
-	if preLogin == nil {
-		return "", fmt.Errorf("step1 pre-login request failed: %v", err)
-	}
-	if err != nil && (preLogin.StatusCode() < 300 || preLogin.StatusCode() >= 400) {
-		return "", fmt.Errorf("step1 pre-login request failed: %w", err)
-	}
-	jsessionid := ""
-	for _, cookie := range preLogin.Cookies() {
-		if cookie.Name == "JSESSIONID" {
-			jsessionid = cookie.Value
-			break
-		}
-	}
-	if jsessionid == "" {
-		return "", errors.New("step1 pre-login response did not set JSESSIONID")
-	}
-	loginCookies := sanitizeMailLoginCookies(d.MailCookies, jsessionid)
-
 	// 密码 SHA1 哈希
 	hashedPassword := sha1Hash(fmt.Sprintf("fetion.com.cn:%s", d.Password))
 
@@ -1428,7 +1359,7 @@ func (d *Yun139) step1_password_login() (string, error) {
 		"sec-fetch-user":            "?1",
 		"upgrade-insecure-requests": "1",
 		"user-agent":                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36 Edg/141.0.0.0",
-		"Cookie":                    loginCookies,
+		"Cookie":                    d.MailCookies,
 	}
 
 	loginData := url.Values{}
@@ -1444,31 +1375,25 @@ func (d *Yun139) step1_password_login() (string, error) {
 	log.Debugf("DEBUG: 登录请求 URL: %s", loginURL)
 	log.Debugf("DEBUG: 登录请求已准备")
 
-	// 设置客户端不跟随重定向
-	client := new139RestyClient().SetRedirectPolicy(resty.NoRedirectPolicy())
-	res, err := client.R().
+	res, err := base.RestyClient.Clone().
+		SetRetryCount(0).
+		SetRedirectPolicy(resty.RedirectPolicyFunc(func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		})).R().
 		SetHeaders(loginHeaders).
 		SetFormDataFromValues(loginData).
 		Post(loginURL)
-
 	if err != nil {
-		// 如果是重定向错误，则不作为失败处理，因为我们禁止了自动重定向
-		if res != nil && res.StatusCode() >= 300 && res.StatusCode() < 400 {
-			log.Debugf("DEBUG: 登录响应 Status Code: %d (Redirect)", res.StatusCode())
-		} else {
-			return "", fmt.Errorf("step1 login request failed: %w", err)
-		}
-	} else {
-		log.Debugf("DEBUG: 登录响应 Status Code: %d", res.StatusCode())
+		return "", fmt.Errorf("step1 login request failed: %w", err)
 	}
+	log.Debugf("DEBUG: 登录响应 Status Code: %d", res.StatusCode())
 	log.Debugf("DEBUG: 登录响应 Location present: %t", res.Header().Get("Location") != "")
 
-	var sid, extractedCguid string
+	d.MailCookies = mergeMailCookieHeader(d.MailCookies, res.Cookies())
 
-	// 从 Location 头部提取 sid 和 cguid
+	sid := ""
 	locationHeader := res.Header().Get("Location")
 	if locationHeader != "" {
-		d.MailCookies = mergeMailCookieHeader(loginCookies, res.Cookies())
 		if riskCode := mailRiskCode(locationHeader); riskCode != "" {
 			if _, ok := smsSceneForRisk(riskCode); !ok {
 				return "", fmt.Errorf("139 Mail risk control triggered: %s", riskCode)
@@ -1482,41 +1407,22 @@ func (d *Yun139) step1_password_login() (string, error) {
 			}
 			return d.verifySMSCode(riskCode)
 		}
-		sidMatch := regexp.MustCompile(`sid=([^&]+)`).FindStringSubmatch(locationHeader)
-		cguidMatch := regexp.MustCompile(`cguid=([^&]+)`).FindStringSubmatch(locationHeader)
-		if len(sidMatch) > 1 {
-			sid = sidMatch[1]
-			log.Debugf("DEBUG: 从 Location 提取到 sid.")
-		}
-		if len(cguidMatch) > 1 {
-			extractedCguid = cguidMatch[1]
-			log.Debugf("DEBUG: 从 Location 提取到 cguid.")
+		if redirectURL, parseErr := url.Parse(locationHeader); parseErr == nil {
+			sid = redirectURL.Query().Get("sid")
 		}
 	}
 
-	// 如果 Location 中没有，尝试从 Set-Cookie 中提取
-	if sid == "" || extractedCguid == "" {
-		setCookieHeaders := res.Header().Values("Set-Cookie")
-		for _, cookieStr := range setCookieHeaders {
-			ssoSidMatch := regexp.MustCompile(`Os_SSo_Sid=([^;]+)`).FindStringSubmatch(cookieStr)
-			cookieCguidMatch := regexp.MustCompile(`cguid=([^;]+)`).FindStringSubmatch(cookieStr)
-			if len(ssoSidMatch) > 1 && sid == "" {
-				sid = ssoSidMatch[1]
-				log.Debugf("DEBUG: 从 Set-Cookie 提取到 sid.")
-			}
-			if len(cookieCguidMatch) > 1 && extractedCguid == "" {
-				extractedCguid = cookieCguidMatch[1]
-				log.Debugf("DEBUG: 从 Set-Cookie 提取到 cguid.")
+	if sid == "" {
+		for _, cookie := range res.Cookies() {
+			if cookie.Name == "Os_SSo_Sid" || cookie.Name == "sid" {
+				sid = cookie.Value
+				break
 			}
 		}
 	}
-
-	if sid == "" || extractedCguid == "" {
-		return "", errors.New("failed to extract sid or cguid from login response")
+	if sid == "" {
+		return "", errors.New("failed to extract sid from login response")
 	}
-
-	d.MailCookies = mergeMailCookieHeader(loginCookies, res.Cookies())
-
 	return sid, nil
 }
 
@@ -1891,10 +1797,6 @@ func extractFastLoginCookies(mailCookies string) (sid string, rmkey string) {
 	return sid, rmkey
 }
 
-func isRedirectStatus(statusCode int) bool {
-	return statusCode >= 300 && statusCode <= 399
-}
-
 func hasCookiePair(raw string) bool {
 	for _, part := range strings.Split(raw, ";") {
 		name, value, ok := strings.Cut(strings.TrimSpace(part), "=")
@@ -1903,26 +1805,6 @@ func hasCookiePair(raw string) bool {
 		}
 	}
 	return false
-}
-
-func fetchMailJSessionID(endpoint string) (string, error) {
-	client := new139RestyClient().SetRedirectPolicy(resty.NoRedirectPolicy())
-	res, err := client.R().Get(endpoint)
-	if res == nil {
-		return "", fmt.Errorf("pre-login request returned no response: %v", err)
-	}
-	if err != nil && !isRedirectStatus(res.StatusCode()) {
-		return "", fmt.Errorf("pre-login request failed with status %d: %w", res.StatusCode(), err)
-	}
-	if res.StatusCode() >= http.StatusBadRequest {
-		return "", fmt.Errorf("pre-login request failed with status %d", res.StatusCode())
-	}
-	for _, cookie := range res.Cookies() {
-		if cookie.Name == "JSESSIONID" && cookie.Value != "" {
-			return cookie.Value, nil
-		}
-	}
-	return "", errors.New("pre-login response did not set JSESSIONID")
 }
 
 func (d *Yun139) tryFastLoginWithCookies() bool {
@@ -1965,7 +1847,7 @@ func (d *Yun139) validateAndInitCredentials() error {
 		return nil
 	case credentialStateFullLogin, credentialStateCookiesOnly:
 		log.Infof("139yun: Authorization missing, attempting login...")
-		if d.tryFastLoginWithCookies() {
+		if d.MailCookies != "" && d.tryFastLoginWithCookies() {
 			return nil
 		}
 
@@ -2002,16 +1884,15 @@ func (d *Yun139) credentialState() (credentialState, error) {
 
 	hasUsername := d.Username != ""
 	hasPassword := strings.TrimSpace(d.Password) != ""
-	hasCookies := d.MailCookies != ""
 
-	if hasUsername || hasPassword {
-		if !hasUsername || !hasPassword || !hasCookies {
-			return 0, fmt.Errorf("if username or password is provided, all three (mail_cookies, username, password) must be provided")
-		}
+	if hasUsername != hasPassword {
+		return 0, fmt.Errorf("username and password must be provided together")
+	}
+	if hasUsername {
 		return credentialStateFullLogin, nil
 	}
 
-	if hasCookies {
+	if d.MailCookies != "" {
 		return credentialStateCookiesOnly, nil
 	}
 
@@ -2019,8 +1900,8 @@ func (d *Yun139) credentialState() (credentialState, error) {
 }
 
 func (d *Yun139) loginWithPassword() (string, error) {
-	if d.Username == "" || d.Password == "" || d.MailCookies == "" {
-		return "", errors.New("username, password or mail_cookies is empty")
+	if d.Username == "" || d.Password == "" {
+		return "", errors.New("username or password is empty")
 	}
 
 	passId, err := d.step1_password_login()

--- a/drivers/139/util_test.go
+++ b/drivers/139/util_test.go
@@ -1,6 +1,7 @@
 package _139
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,12 +14,13 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-func TestSanitizeLoginCookiesDropsStaleJSessionIDWhenFreshOneMissing(t *testing.T) {
-	got := sanitizeMailLoginCookies("JSESSIONID=old; behaviorid=b", "")
-	want := "behaviorid=b"
-	if got != want {
-		t.Fatalf("sanitizeMailLoginCookies() = %q, want %q", got, want)
-	}
+func useRetryingTestClient(t *testing.T) {
+	t.Helper()
+	oldClient := base.RestyClient
+	base.RestyClient = resty.New().SetRetryCount(3)
+	t.Cleanup(func() {
+		base.RestyClient = oldClient
+	})
 }
 
 func TestMergeMailCookiesPreservesExistingOrderAndAppendsNewNames(t *testing.T) {
@@ -58,6 +60,14 @@ func TestCredentialState(t *testing.T) {
 				MailCookies: "RMKEY=rm; Os_SSo_Sid=sid",
 				Username:    "user",
 				Password:    "password",
+			}},
+			want: credentialStateFullLogin,
+		},
+		{
+			name: "full login without initial cookies",
+			d: Yun139{Addition: Addition{
+				Username: "user",
+				Password: "password",
 			}},
 			want: credentialStateFullLogin,
 		},
@@ -142,32 +152,31 @@ func TestIntegrationLoginObtainsAuthorization(t *testing.T) {
 		t.Fatal("OPENLIST_139_MAIL_COOKIES is required")
 	}
 
-	runFastLogin := func(t *testing.T, mailCookies string) {
-		t.Helper()
+	runFastLogin := func(mailCookies string) error {
 		d := Yun139{Addition: Addition{MailCookies: mailCookies}}
 		state, err := d.credentialState()
 		if err != nil {
-			t.Fatalf("credentialState() unexpected error: %v", err)
+			return fmt.Errorf("credentialState() error: %w", err)
 		}
 		if state != credentialStateCookiesOnly {
-			t.Fatalf("credentialState() = %v, want cookies only", state)
+			return fmt.Errorf("credentialState() = %v, want cookies only", state)
 		}
 		sid, rmkey := extractFastLoginCookies(d.MailCookies)
 		if sid == "" || rmkey == "" {
-			t.Fatal("mail cookies are missing Os_SSo_Sid or RMKEY")
+			return fmt.Errorf("mail cookies are missing Os_SSo_Sid or RMKEY")
 		}
 		token, err := d.step2_get_single_token(sid)
 		if err != nil {
-			t.Fatalf("step2_get_single_token() error: %v", err)
+			return fmt.Errorf("step2_get_single_token() error: %w", err)
 		}
 		auth, err := d.step3_third_party_login(token)
 		if err != nil {
-			t.Fatalf("step3_third_party_login() error: %v", err)
+			return fmt.Errorf("step3_third_party_login() error: %w", err)
 		}
-		d.Authorization = auth
-		if d.Authorization == "" {
-			t.Fatal("authorization is empty after fast login")
+		if auth == "" {
+			return fmt.Errorf("authorization is empty after fast login")
 		}
+		return nil
 	}
 
 	if username == "" || password == "" {
@@ -231,44 +240,19 @@ func TestIntegrationLoginObtainsAuthorization(t *testing.T) {
 		if sid == "" || rmkey == "" {
 			t.Skip("input mail cookies are missing Os_SSo_Sid or RMKEY")
 		}
-		runFastLogin(t, mailCookies)
+		if err := runFastLogin(mailCookies); err != nil {
+			t.Skipf("input mail cookies are stale or unusable: %v", err)
+		}
 	})
 
 	t.Run("mail cookies fast login after password login", func(t *testing.T) {
 		if refreshedMailCookies == "" {
 			t.Fatal("password login did not refresh mail cookies")
 		}
-		runFastLogin(t, refreshedMailCookies)
+		if err := runFastLogin(refreshedMailCookies); err != nil {
+			t.Fatalf("refreshed mail cookies fast login failed: %v", err)
+		}
 	})
-}
-
-func TestIsRedirectStatus(t *testing.T) {
-	for _, status := range []int{300, 301, 302, 307, 399} {
-		if !isRedirectStatus(status) {
-			t.Fatalf("isRedirectStatus(%d) = false, want true", status)
-		}
-	}
-	for _, status := range []int{200, 299, 400, 500} {
-		if isRedirectStatus(status) {
-			t.Fatalf("isRedirectStatus(%d) = true, want false", status)
-		}
-	}
-}
-
-func TestFetchMailJSessionIDAcceptsRedirectResponse(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.SetCookie(w, &http.Cookie{Name: "JSESSIONID", Value: "fresh"})
-		http.Redirect(w, r, "/next", http.StatusFound)
-	}))
-	defer server.Close()
-
-	got, err := fetchMailJSessionID(server.URL)
-	if err != nil {
-		t.Fatalf("fetchMailJSessionID() error: %v", err)
-	}
-	if got != "fresh" {
-		t.Fatalf("fetchMailJSessionID() = %q, want fresh", got)
-	}
 }
 
 func TestInvalidAuthorizationDoesNotUseCookieFastLogin(t *testing.T) {
@@ -304,18 +288,9 @@ func TestSMSSceneForRisk(t *testing.T) {
 	}
 }
 
-func TestSanitizeMailLoginCookiesKeepsDeviceContext(t *testing.T) {
-	got := sanitizeMailLoginCookies(
-		"behaviorid=device; Os_SSo_Sid=old-sid; RMKEY=old-rmkey; JSESSIONID=old-session; S_DEVICE_TOKEN=fingerprint",
-		"new-session",
-	)
-	want := "behaviorid=device;JSESSIONID=new-session;S_DEVICE_TOKEN=fingerprint"
-	if got != want {
-		t.Fatalf("sanitizeMailLoginCookies() = %q, want %q", got, want)
-	}
-}
-
 func TestSendSMSVerificationCode(t *testing.T) {
+	useRetryingTestClient(t)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -349,6 +324,8 @@ func TestSendSMSVerificationCode(t *testing.T) {
 }
 
 func TestSendSMSVerificationCodeStopsAtPictureChallenge(t *testing.T) {
+	useRetryingTestClient(t)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, `{"code":"PML401010021"}`)
 	}))
@@ -366,6 +343,8 @@ func TestSendSMSVerificationCodeStopsAtPictureChallenge(t *testing.T) {
 }
 
 func TestVerifySMSCode(t *testing.T) {
+	useRetryingTestClient(t)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -404,5 +383,92 @@ func TestVerifySMSCode(t *testing.T) {
 	}
 	if !strings.Contains(d.MailCookies, "RMKEY=new-rmkey") {
 		t.Fatalf("MailCookies = %q", d.MailCookies)
+	}
+}
+
+func TestPasswordLoginWithoutInitialCookiesStopsAtRedirectAndPersistsCookies(t *testing.T) {
+	useRetryingTestClient(t)
+
+	var loginRequests, redirectRequests int
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/Login/Login.ashx":
+			loginRequests++
+			http.SetCookie(w, &http.Cookie{Name: "RMKEY", Value: "new-rm"})
+			http.SetCookie(w, &http.Cookie{Name: "Os_SSo_Sid", Value: "new-sid"})
+			w.Header().Set("Location", server.URL+"/appmail?sid=single-sid")
+			w.WriteHeader(http.StatusFound)
+		case "/appmail":
+			redirectRequests++
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	oldURL := mailPasswordURL
+	mailPasswordURL = server.URL + "/Login/Login.ashx"
+	defer func() { mailPasswordURL = oldURL }()
+
+	d := Yun139{Addition: Addition{Username: "18800000000", Password: "password"}}
+	sid, err := d.step1_password_login()
+	if err != nil || sid != "single-sid" {
+		t.Fatalf("sid=%q err=%v", sid, err)
+	}
+	if loginRequests != 1 || redirectRequests != 0 {
+		t.Fatalf("login/redirect requests=%d/%d, want 1/0", loginRequests, redirectRequests)
+	}
+	if !strings.Contains(d.MailCookies, "RMKEY=new-rm") || !strings.Contains(d.MailCookies, "Os_SSo_Sid=new-sid") {
+		t.Fatalf("response cookies were not persisted: %q", d.MailCookies)
+	}
+}
+
+func TestPasswordLoginReusesRawRefreshedCookies(t *testing.T) {
+	useRetryingTestClient(t)
+
+	var n int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		cookie := r.Header.Get("Cookie")
+		if !strings.Contains(cookie, "JSESSIONID=stale") || !strings.Contains(cookie, "behaviorid=device") {
+			t.Errorf("login %d lost raw cookie context: %q", n, cookie)
+		}
+		if n == 1 {
+			http.SetCookie(w, &http.Cookie{Name: "RMKEY", Value: "rm-1"})
+			http.SetCookie(w, &http.Cookie{Name: "Os_SSo_Sid", Value: "sid-1"})
+			w.Header().Set("Location", "https://mail.10086.cn/?sid=first")
+		} else {
+			if !strings.Contains(cookie, "RMKEY=rm-1") || !strings.Contains(cookie, "Os_SSo_Sid=sid-1") {
+				t.Errorf("second login did not reuse first refreshed cookies: %q", cookie)
+			}
+			http.SetCookie(w, &http.Cookie{Name: "RMKEY", Value: "rm-2"})
+			http.SetCookie(w, &http.Cookie{Name: "Os_SSo_Sid", Value: "sid-2"})
+			w.Header().Set("Location", "https://mail.10086.cn/?sid=second")
+		}
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer server.Close()
+
+	oldURL := mailPasswordURL
+	mailPasswordURL = server.URL
+	defer func() { mailPasswordURL = oldURL }()
+
+	d := Yun139{Addition: Addition{Username: "18800000000", Password: "password", MailCookies: "Os_SSo_Sid=old; RMKEY=old; JSESSIONID=stale; behaviorid=device"}}
+	if sid, err := d.step1_password_login(); err != nil || sid != "first" {
+		t.Fatalf("first login sid=%q err=%v", sid, err)
+	}
+	refreshed := d.MailCookies
+	if !strings.Contains(refreshed, "RMKEY=rm-1") || !strings.Contains(refreshed, "Os_SSo_Sid=sid-1") {
+		t.Fatalf("first login did not persist refreshed cookies: %q", refreshed)
+	}
+	d.Authorization = ""
+	d.MailCookies = refreshed
+	if sid, err := d.step1_password_login(); err != nil || sid != "second" {
+		t.Fatalf("second login sid=%q err=%v", sid, err)
+	}
+	if n != 2 {
+		t.Fatalf("login count=%d, want 2", n)
 	}
 }


### PR DESCRIPTION
PR title: `fix(139): improve mail login credential renewal`

## Summary / 摘要

This PR improves the 139Yun mail-login credential renewal flow so that password login no longer depends on a pre-login `JSESSIONID`, can start without pre-supplied mail cookies, and can refresh reusable mail cookies after password/SMS authentication.

此 PR 改进了 139Yun 邮箱登录凭据续期流程：账号密码登录不再依赖预登录阶段获取 `JSESSIONID`，首次配置时可不预先提供 MailCookies，并可在密码 / 短信验证后自动刷新可复用的 MailCookies。

- Username + password can now be used without initial `mail_cookies`; existing cookie-only and Authorization flows remain supported.
- Password login sends the current raw mail-cookie context, merges response cookies back into driver storage state, and reuses refreshed cookies on later logins.
- When supported 139 Mail risk control requires SMS verification, the driver sends one verification request, keeps the temporary cookies needed for the follow-up save, verifies `sms_code`, then continues the normal token/authentication chain.
- Login and SMS POST requests explicitly disable Resty retries to avoid duplicate non-idempotent authentication/SMS requests.
- Password login stops at the first 302 response instead of following the redirect, allowing the driver to extract the returned `sid` directly.
- Stale input MailCookies are allowed to fail fast-login when username/password fallback is available; MailCookies refreshed by a successful password login are expected to support subsequent fast login.
- No public API or storage-format migration is introduced. The configuration schema is unchanged, but `mail_cookies` is now optional when username and password are provided.

- 现在仅提供用户名和密码也可初始化登录；原有仅 Cookie 和 Authorization 登录方式仍保留。
- 密码登录会保留现有原始 MailCookies，上游响应中的新 Cookie 会合并回驱动状态，并在后续登录中复用。
- 遇到受支持的 139 邮箱短信风控时，会发送一次验证码请求、保留下一次保存所需的临时 Cookie，验证 `sms_code` 后继续完成 token / Authorization 登录链路。
- 登录和短信 POST 请求显式禁用 Resty 自动重试，避免非幂等认证请求或短信请求被重复发送。
- 密码登录不会继续跟随首个 302，而是直接从响应中提取 `sid`。
- 用户手工提供的旧 MailCookies 失效时允许回退到账号密码登录；密码登录刷新得到的新 MailCookies 应可继续用于 fast login。
- 未引入公开 API 或存储格式迁移；配置字段结构不变，但在提供用户名和密码时 `mail_cookies` 不再是必填项。

- [ ] This PR has breaking changes.
  / 此 PR 包含破坏性变更。
- [x] This PR changes public API, config, storage format, or migration behavior.
  / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
  - Backward-compatible config behavior change only: `mail_cookies` becomes optional for username/password login; no field or storage-format migration is required.
  - 仅包含向后兼容的配置行为变化：账号密码登录时 `mail_cookies` 改为可选，不需要字段或存储格式迁移。
- [ ] This PR requires corresponding changes in related repositories.
  / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:
- OpenList-Frontend: N/A
- OpenList-Docs: N/A

## Testing / 测试

- [ ] `go test ./...`
- [x] `go test ./drivers/139 -count=1`
- [x] Manual test / 手动测试:
  - Ran real-account GitHub Actions regression tests with credentials, MailCookies, and SMS code supplied only through masked repository secrets.
  - Verified password fallback with stale input MailCookies completes Step1 -> Step2 -> Step3 and produces Authorization.
  - Verified password/SMS authentication refreshes MailCookies and that the refreshed MailCookies can complete a subsequent fast-login Step2 -> Step3 chain.
  - Verified an already-stale input MailCookies set may fail fast login while password fallback and the refreshed-cookie fast login still succeed.
  - Verified zero-initial-cookie SMS bootstrap in earlier isolated live tests: risk detection -> SMS verification -> Step2 -> Step3 -> reusable device cookies.
  - No sensitive credentials, SMS codes, cookies, SID, RMKEY, or Authorization values are logged by the test workflows.

Deterministic tests additionally cover:
- credential-state selection for Authorization, full login with/without initial MailCookies, cookies-only login, partial credentials, invalid cookies, and invalid `Basic `-prefixed Authorization;
- Cookie merging and extraction of `Os_SSo_Sid` / `RMKEY`;
- SMS risk-code-to-scene mapping, SMS request construction, picture-challenge rejection, SMS verification, Cookie merge, and `sms_code` clearing;
- password login without initial cookies, single POST behavior, stopping at the first redirect, and persistence of returned cookies;
- reuse of stale/raw device-cookie context and refreshed cookies across successive password logins.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
  / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
  / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
  / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
  / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
  / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:
- [x] ChatGPT
- [ ] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:
- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
  / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [ ] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
  / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
  / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
