### PR TITLE
fix(drivers/189): decode JSON strings before parsing timestamps

### DIFF
--- a/drivers/189_tv/help.go
+++ b/drivers/189_tv/help.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -59,7 +60,13 @@ func timestamp() int64 {
 
 type Time time.Time
 
-func (t *Time) UnmarshalJSON(b []byte) error { return t.Unmarshal(b) }
+func (t *Time) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	return t.Unmarshal([]byte(s))
+}
 func (t *Time) UnmarshalXML(e *xml.Decoder, ee xml.StartElement) error {
 	b, err := e.Token()
 	if err != nil {

--- a/drivers/189_tv/help_test.go
+++ b/drivers/189_tv/help_test.go
@@ -1,6 +1,8 @@
 package _189_tv
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"testing"
 	"time"
 )
@@ -17,11 +19,13 @@ func TestTimeUnmarshal(t *testing.T) {
 		{"new format no tz", `"Aug 11, 2026, 10:37:18 PM"`, time.Date(2026, 8, 11, 22, 37, 18, 0, time.FixedZone("", 8*3600))},
 		{"narrow no-break space (U+202F)", "\"Aug 12, 2026, 12:35:41\u202fAM +08\"", time.Date(2026, 8, 12, 0, 35, 41, 0, time.FixedZone("", 8*3600))},
 		{"no-break space (U+00A0)", "\"Aug 12, 2026, 12:35:41\u00a0AM +08\"", time.Date(2026, 8, 12, 0, 35, 41, 0, time.FixedZone("", 8*3600))},
+		{"JSON escaped narrow space", `"Sep 4, 2026, 10:59:33\u202fPM +08"`, time.Date(2026, 9, 4, 22, 59, 33, 0, time.FixedZone("", 8*3600))},
+		{"JSON escaped space without timezone", `"Sep 4, 2026, 12:59:33\u00a0AM"`, time.Date(2026, 9, 4, 0, 59, 33, 0, time.FixedZone("", 8*3600))},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var tm Time
-			if err := tm.Unmarshal([]byte(tt.input)); err != nil {
+			if err := json.Unmarshal([]byte(tt.input), &tm); err != nil {
 				t.Fatalf("Unmarshal(%s) error: %v", tt.input, err)
 			}
 			if !tt.want.Equal(time.Time(tm)) {
@@ -35,5 +39,27 @@ func TestTimeUnmarshalRejectsInvalid(t *testing.T) {
 	var tm Time
 	if err := tm.Unmarshal([]byte("Aug 12, 2026, 25:32:44 AM")); err == nil {
 		t.Fatal("Unmarshal accepted an invalid time")
+	}
+}
+
+func TestTimeUnmarshalJSONRejectsInvalid(t *testing.T) {
+	for _, input := range []string{`"invalid"`, `123`, `null`, `"Sep 4, 2026, 10:59:33\uZZZZPM +08"`} {
+		t.Run(input, func(t *testing.T) {
+			var tm Time
+			if err := tm.UnmarshalJSON([]byte(input)); err == nil {
+				t.Fatalf("UnmarshalJSON(%s) accepted invalid input", input)
+			}
+		})
+	}
+}
+
+func TestTimeUnmarshalXML(t *testing.T) {
+	var tm Time
+	if err := xml.Unmarshal([]byte(`<time>Sep 4, 2026, 10:59:33&#x202f;PM +08</time>`), &tm); err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2026, 9, 4, 22, 59, 33, 0, time.FixedZone("", 8*3600))
+	if !want.Equal(time.Time(tm)) {
+		t.Fatalf("UnmarshalXML = %v, want %v", time.Time(tm), want)
 	}
 }

--- a/drivers/189pc/help.go
+++ b/drivers/189pc/help.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha1"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"encoding/xml"
 	"fmt"
@@ -102,7 +103,13 @@ func MustParseTime(str string) *time.Time {
 
 type Time time.Time
 
-func (t *Time) UnmarshalJSON(b []byte) error { return t.Unmarshal(b) }
+func (t *Time) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	return t.Unmarshal([]byte(s))
+}
 func (t *Time) UnmarshalXML(e *xml.Decoder, ee xml.StartElement) error {
 	b, err := e.Token()
 	if err != nil {

--- a/drivers/189pc/help_test.go
+++ b/drivers/189pc/help_test.go
@@ -1,6 +1,8 @@
 package _189pc
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"testing"
 	"time"
 )
@@ -17,11 +19,13 @@ func TestTimeUnmarshal(t *testing.T) {
 		{"new format no tz", `"Aug 11, 2026, 10:37:18 PM"`, time.Date(2026, 8, 11, 22, 37, 18, 0, time.FixedZone("", 8*3600))},
 		{"narrow no-break space (U+202F)", "\"Aug 12, 2026, 12:35:41\u202fAM +08\"", time.Date(2026, 8, 12, 0, 35, 41, 0, time.FixedZone("", 8*3600))},
 		{"no-break space (U+00A0)", "\"Aug 12, 2026, 12:35:41\u00a0AM +08\"", time.Date(2026, 8, 12, 0, 35, 41, 0, time.FixedZone("", 8*3600))},
+		{"JSON escaped narrow space", `"Sep 4, 2026, 10:59:33\u202fPM +08"`, time.Date(2026, 9, 4, 22, 59, 33, 0, time.FixedZone("", 8*3600))},
+		{"JSON escaped space without timezone", `"Sep 4, 2026, 12:59:33\u00a0AM"`, time.Date(2026, 9, 4, 0, 59, 33, 0, time.FixedZone("", 8*3600))},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var tm Time
-			if err := tm.Unmarshal([]byte(tt.input)); err != nil {
+			if err := json.Unmarshal([]byte(tt.input), &tm); err != nil {
 				t.Fatalf("Unmarshal(%s) error: %v", tt.input, err)
 			}
 			if !tt.want.Equal(time.Time(tm)) {
@@ -35,5 +39,27 @@ func TestTimeUnmarshalRejectsInvalid(t *testing.T) {
 	var tm Time
 	if err := tm.Unmarshal([]byte("Aug 12, 2026, 25:32:44 AM")); err == nil {
 		t.Fatal("Unmarshal accepted an invalid time")
+	}
+}
+
+func TestTimeUnmarshalJSONRejectsInvalid(t *testing.T) {
+	for _, input := range []string{`"invalid"`, `123`, `null`, `"Sep 4, 2026, 10:59:33\uZZZZPM +08"`} {
+		t.Run(input, func(t *testing.T) {
+			var tm Time
+			if err := tm.UnmarshalJSON([]byte(input)); err == nil {
+				t.Fatalf("UnmarshalJSON(%s) accepted invalid input", input)
+			}
+		})
+	}
+}
+
+func TestTimeUnmarshalXML(t *testing.T) {
+	var tm Time
+	if err := xml.Unmarshal([]byte(`<time>Sep 4, 2026, 10:59:33&#x202f;PM +08</time>`), &tm); err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2026, 9, 4, 22, 59, 33, 0, time.FixedZone("", 8*3600))
+	if !want.Equal(time.Time(tm)) {
+		t.Fatalf("UnmarshalXML = %v, want %v", time.Time(tm), want)
 	}
 }


### PR DESCRIPTION
## Summary / 摘要

Decode JSON strings before parsing timestamps in the 189pc and 189_tv drivers. JSON-escaped Unicode spaces such as `\u202f` and `\u00a0` now reach the existing whitespace normalization as decoded characters, preventing time parsing errors for these responses.

Extend regression coverage through JSON unmarshalling, including escaped spaces, invalid input, and XML compatibility. This fixes a source-level decoding gap; it has not been confirmed as the cause of the reported upload error because the original response is unavailable.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR: None.

## Testing / 测试

Targeted tests matching `TestTimeUnmarshal` passed for 189_tv with the default checks enabled. The same tests passed for 189pc with `-vet=off`; the default invocation was blocked by two pre-existing non-constant format string errors in calls to `fmt.Errorf`. Tests cover JSON-escaped Unicode spaces, existing date formats, invalid JSON input, and XML compatibility. Formatting and whitespace checks passed. Dependency downloads were disabled during testing.

- [ ] Full test suite.
- [ ] Manual upload test.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
- [x] I have requested review from relevant maintainers or code owners where applicable.

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.

Tools used / 使用工具:

- [x] Codex

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Documentation / 文档
- [x] Tests / 测试
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
