### PR TITLE
feat(drivers/guangyapan): add md5-based instant upload support

### DIFF
--- a/drivers/guangyapan/driver.go
+++ b/drivers/guangyapan/driver.go
@@ -394,7 +394,13 @@ func (d *GuangYaPan) Put(ctx context.Context, dstDir model.Obj, file model.FileS
 
 	parentID := dstDir.GetID()
 
-	token, code, err := d.getUploadToken(ctx, parentID, name, file.GetSize())
+	// 优先秒传：先计算文件 MD5，后端命中相同文件时直接秒传完成，无需真实上传。
+	md5sum, err := d.fileMD5(file, up)
+	if err != nil {
+		return nil, err
+	}
+
+	token, code, err := d.getUploadToken(ctx, parentID, name, file.GetSize(), md5sum)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/guangyapan/util.go
+++ b/drivers/guangyapan/util.go
@@ -133,15 +133,39 @@ func (d *GuangYaPan) waitTaskDone(ctx context.Context, taskID string) error {
 
 // --- Upload helpers ---
 
-func (d *GuangYaPan) getUploadToken(ctx context.Context, parentID, name string, size int64) (*uploadTokenData, int, error) {
+// fileMD5 returns the MD5 of the file content, computing it from the stream when
+// the caller did not provide it (e.g. local uploads). The computed hash is used
+// to attempt instant upload (秒传) before falling back to the real OSS upload.
+// For force-stream uploads the whole file would have to be buffered just to hash
+// it, which defeats the purpose of streaming, so we skip 秒传 in that case.
+func (d *GuangYaPan) fileMD5(file model.FileStreamer, up driver.UpdateProgress) (string, error) {
+	if md5sum := file.GetHash().GetHash(utils.MD5); len(md5sum) == utils.MD5.Width {
+		return md5sum, nil
+	}
+	if file.IsForceStreamUpload() {
+		return "", nil
+	}
+	_, md5sum, err := streamPkg.CacheFullAndHash(file, &up, utils.MD5)
+	if err != nil {
+		return "", err
+	}
+	return md5sum, nil
+}
+
+func (d *GuangYaPan) getUploadToken(ctx context.Context, parentID, name string, size int64, md5sum string) (*uploadTokenData, int, error) {
 	var out uploadTokenResp
+	res := map[string]any{
+		"fileSize": size,
+	}
+	if md5sum != "" {
+		// 秒传：后端根据 md5 判断文件是否已存在，命中则返回 code 156 秒传完成。
+		res["md5"] = md5sum
+	}
 	err := d.postAPI(ctx, "/nd.bizuserres.s/v1/get_res_center_token", map[string]any{
 		"capacity": 2,
 		"name":     name,
 		"parentId": parentID,
-		"res": map[string]any{
-			"fileSize": size,
-		},
+		"res":      res,
 	}, &out)
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
<!--
PR title / PR 标题:
- Use Conventional Commits: `type(scope): summary`
- Allowed types: `feat`, `docs`, `fix`, `style`, `refactor`, `chore`
- Scope is required by the current PR title check.
-->

# feat(guangyapan): add md5-based instant upload (秒传) support

> **Author**: PIKACHUIM
> **Date**: 2026-09-04
> **Base branch**: `main`
> **Branch**: `feat/guangyapan-instant-upload`

## Summary / 摘要

This PR adds instant upload (秒传) support to the GuangYaPan (光鸭云盘) driver. Previously
the upload-token request to `/nd.bizuserres.s/v1/get_res_center_token` did not send the
file `md5`, so the backend could never match an already-stored file and always returned a
fresh OSS upload token. This PR computes (or reuses) the file MD5 and sends it in the
token request, so the backend can hit `code 156 / 上传已完成` and complete the upload
instantly without transferring any bytes.

<!--
- List user-visible behavior changes.
- List important implementation changes.
-->

- Uploads to GuangYaPan now attempt instant upload first: the file MD5 is computed and
  sent in `res.md5` of the `get_res_center_token` request.
- When the backend responds with `code 156` (or `Msg="上传已完成"` / `秒传成功`), the
  real OSS multipart upload is skipped and the driver waits for the async upload task to
  finish, returning success.
- MD5 acquisition priority:
  1. Reuse the caller-provided hash when available (e.g. cross-drive copy already carries
     `utils.MD5`).
  2. Otherwise compute it by caching the stream (`CacheFullAndHash`), which also warms the
     cache so a subsequent real upload does not re-read the source.
  3. Skip 秒传 for force-stream uploads (`IsForceStreamUpload`) to avoid buffering the
     whole file just to hash it.

## Changes / 变更文件清单

### Modified (2 files, +35 / -5)

| File | Change | Description |
|------|--------|-------------|
| `drivers/guangyapan/util.go` | +32 / -4 | Add `fileMD5` helper; `getUploadToken` gains `md5sum` param and sends `res.md5` |
| `drivers/guangyapan/driver.go` | +7 / -1 | `Put` computes MD5 first and passes it to `getUploadToken` |

### Key code path

```go
// util.go — send md5 in the token request
func (d *GuangYaPan) getUploadToken(ctx context.Context, parentID, name string, size int64, md5sum string) (*uploadTokenData, int, error) {
	res := map[string]any{"fileSize": size}
	if md5sum != "" {
		res["md5"] = md5sum
	}
	// POST /nd.bizuserres.s/v1/get_res_center_token
}

// driver.go — instant upload first, fall back to OSS upload
md5sum, err := d.fileMD5(file, up)
token, code, err := d.getUploadToken(ctx, parentID, name, file.GetSize(), md5sum)
if code == 156 || token.AlreadyDone {
	// wait for task, no OSS upload
}
```

## Behavior / 秒传流程

```mermaid
flowchart TD
    A[Put upload] --> B[fileMD5]
    B --> C{caller has MD5?}
    C -->|Yes| D[reuse md5]
    C -->|No| E{force stream?}
    E -->|Yes| F[skip 秒传, md5 empty]
    E -->|No| G[CacheFullAndHash compute md5]
    D --> H[get_res_center_token with res.md5]
    G --> H
    F --> H
    H --> I{code 156 / 上传已完成?}
    I -->|Yes| J[waitUploadTaskInfo -> done, no upload]
    I -->|No| K[OSS multipart upload -> done]
```

## Compatibility / 兼容性

- Go version: aligned with the project.
- No new third-party dependencies; reuses existing `pkg/utils` (MD5) and
  `internal/stream` (`CacheFullAndHash`).
- Backward compatible: when MD5 is unavailable (force-stream), the request falls back to
  the previous behavior (no `md5` field, normal OSS upload).
- No config, storage-format, or API surface changes.

## Testing / 测试

- [ ] `go build ./drivers/guangyapan/...`
- [ ] `go test ./drivers/guangyapan/...` (if tests exist)
- [ ] Manual test / 手动测试:
  - [ ] `read_lints` clean for `drivers/guangyapan` (0 errors).
  - [ ] Upload a file that already exists on GuangYaPan → verify `code 156` path returns
        success without OSS upload.
  - [ ] Upload a brand-new file → verify normal OSS multipart upload still works.
  - [ ] Cross-drive copy (caller-provided MD5) → verify instant upload is attempted with
        the reused hash.
  - [ ] Force-stream upload → verify 秒传 is skipped and streaming upload proceeds.

## Checklist / 检查清单

- [ ] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [ ] I have formatted the changed code with `gofmt` / `go fmt`.
      / 我已使用 `gofmt` / `go fmt` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [x] Claude

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Documentation / 文档

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
