### PR TITLE
fix(drivers/quark): fallback to a mime type when upload has none

### DIFF
--- a/drivers/quark_uc/driver.go
+++ b/drivers/quark_uc/driver.go
@@ -192,7 +192,7 @@ func (d *QuarkOrUC) Put(ctx context.Context, dstDir model.Obj, stream model.File
 		}
 		err = retry.Do(func() error {
 			rd.Seek(0, io.SeekStart)
-			m, err := d.upPart(ctx, pre, stream.GetMimetype(), partIndex+1, driver.NewLimitedUploadStream(ctx, rd))
+			m, err := d.upPart(ctx, pre, uploadMimetype(stream), partIndex+1, driver.NewLimitedUploadStream(ctx, rd))
 			if err != nil {
 				return err
 			}

--- a/drivers/quark_uc/util.go
+++ b/drivers/quark_uc/util.go
@@ -167,13 +167,25 @@ func (d *QuarkOrUC) getTranscodingLink(file model.Obj) (*model.Link, error) {
 	return nil, errors.New("no link found")
 }
 
+// uploadMimetype returns the MIME type to report to quark for an upload.
+// Quark's /file/upload/pre endpoint rejects an empty format_type, so when the
+// caller did not supply a MIME type (e.g. an S3 PUT without Content-Type) we
+// fall back to guessing it from the file name; utils.GetMimeType never returns
+// an empty string.
+func uploadMimetype(file model.FileStreamer) string {
+	if mt := file.GetMimetype(); mt != "" {
+		return mt
+	}
+	return utils.GetMimeType(file.GetName())
+}
+
 func (d *QuarkOrUC) upPre(file model.FileStreamer, parentId string) (UpPreResp, error) {
 	now := time.Now()
 	data := base.Json{
 		"ccp_hash_update": true,
 		"dir_name":        "",
 		"file_name":       file.GetName(),
-		"format_type":     file.GetMimetype(),
+		"format_type":     uploadMimetype(file),
 		"l_created_at":    now.UnixMilli(),
 		"l_updated_at":    now.UnixMilli(),
 		"pdir_fid":        parentId,

--- a/drivers/quark_uc/util_test.go
+++ b/drivers/quark_uc/util_test.go
@@ -1,0 +1,35 @@
+package quark
+
+import (
+	"testing"
+
+	"github.com/OpenListTeam/OpenList/v4/internal/model"
+	"github.com/OpenListTeam/OpenList/v4/internal/stream"
+)
+
+func TestUploadMimetype(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileName string
+		mimetype string
+		want     string
+	}{
+		// Caller supplied a MIME type: it must win.
+		{"explicit content type", "clip.mp4", "video/mp4", "video/mp4"},
+		{"explicit octet-stream", "report.pdf", "application/octet-stream", "application/octet-stream"},
+		// Empty MIME type: fall back to guessing from the file name.
+		{"fallback by extension", "report.pdf", "", "application/pdf"},
+		{"fallback unknown extension", "archive.bin", "", "application/octet-stream"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &stream.FileStream{
+				Obj:      &model.Object{Name: tt.fileName},
+				Mimetype: tt.mimetype,
+			}
+			if got := uploadMimetype(s); got != tt.want {
+				t.Fatalf("uploadMimetype() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary / 摘要

Quark's `/file/upload/pre` endpoint rejects an empty `format_type`, so an S3 PUT that omits `Content-Type` (allowed by the S3 spec) fails with `Bad Parameter: [format_type is null!]` before any data is uploaded.

- Derive `format_type` from the file name when the stream has no MIME type (`utils.GetMimeType` never returns an empty string).
- Reuse the resolved MIME type for chunked upload part requests so both the preflight and the part `Content-Type` stay consistent.
- Add unit tests for explicit, empty and unknown-extension MIME cases.

## Related Issues / 关联 Issue

Closes #3042

## Testing / 测试

- [x] `go test ./drivers/quark_uc/ -count=1`
- [x] `go test ./server/s3/ -count=1`
- [x] `go build ./...`
- [x] `go vet ./drivers/quark_uc/ ./server/s3/`
- [x] Manual / 手动测试: reproduced the failure against a Quark bucket (S3 PUT without Content-Type -> InternalError `format_type is null!`); an A/B check confirmed PUTs that include Content-Type succeed, while PUTs without it always fail before this fix.

## Checklist / 检查清单

- [x] I have read CONTRIBUTING.
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
- [x] I have formatted the changed code with `gofmt`.

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
Tools used / 使用工具:
- [x] Other (please specify) / 其他（请注明）: opencode (assisted coding agent, session reviewed by a human)
Usage scope / 使用范围:
- [x] Code generation / 代码生成
- [x] Tests / 测试
- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。