### PR TITLE
fix(s3): default upload content types and return partial content

### DIFF
--- a/server/s3/backend.go
+++ b/server/s3/backend.go
@@ -319,6 +319,9 @@ func (b *s3Backend) putStream(
 		Reader:   input,
 		Mimetype: meta["Content-Type"],
 	}
+	if stream.Mimetype == "" {
+		stream.Mimetype = "application/octet-stream"
+	}
 
 	err = fs.PutDirectly(ctx, reqPath, stream)
 	if err != nil {

--- a/server/s3/range.go
+++ b/server/s3/range.go
@@ -1,0 +1,47 @@
+package s3
+
+import "net/http"
+
+// gofakes3 sets Content-Range without selecting the partial-content status.
+func rangeStatusHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.Header.Get("Range") == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		rw := &rangeResponseWriter{ResponseWriter: w}
+		next.ServeHTTP(rw, r)
+		if !rw.wroteHeader {
+			rw.WriteHeader(http.StatusOK)
+		}
+	})
+}
+
+type rangeResponseWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (w *rangeResponseWriter) WriteHeader(status int) {
+	if w.wroteHeader {
+		return
+	}
+	if status >= 200 {
+		w.wroteHeader = true
+	}
+	if status == http.StatusOK && w.Header().Get("Content-Range") != "" {
+		status = http.StatusPartialContent
+	}
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *rangeResponseWriter) Write(p []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(p)
+}
+
+func (w *rangeResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}

--- a/server/s3/range_test.go
+++ b/server/s3/range_test.go
@@ -1,0 +1,55 @@
+package s3
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRangeStatusHandler(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		method       string
+		rangeHeader  string
+		contentRange string
+		status       int
+		body         string
+		want         int
+	}{
+		{"partial", "GET", "bytes=2-5", "bytes 2-5/16", 0, "2345", 206},
+		{"explicit OK", "GET", "bytes=2-5", "bytes 2-5/16", 200, "2345", 206},
+		{"already partial", "GET", "bytes=2-5", "bytes 2-5/16", 206, "2345", 206},
+		{"full", "GET", "", "", 0, "0123456789abcdef", 200},
+		{"range ignored", "GET", "bytes=2-5", "", 0, "0123456789abcdef", 200},
+		{"not modified", "GET", "bytes=2-5", "", 304, "", 304},
+		{"invalid range", "GET", "bytes=20-", "bytes */16", 416, "error", 416},
+		{"forbidden", "GET", "bytes=2-5", "", 403, "error", 403},
+		{"empty body", "GET", "bytes=2-5", "bytes 2-5/16", 0, "", 206},
+		{"head", "HEAD", "bytes=2-5", "", 0, "", 200},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.contentRange != "" {
+					w.Header().Set("Content-Range", tt.contentRange)
+				}
+				if tt.status != 0 {
+					w.WriteHeader(tt.status)
+				}
+				if tt.body != "" {
+					_, _ = io.WriteString(w, tt.body)
+				}
+			})
+			r := httptest.NewRequest(tt.method, "/bucket/object", nil)
+			r.Header.Set("Range", tt.rangeHeader)
+			w := httptest.NewRecorder()
+			rangeStatusHandler(next).ServeHTTP(w, r)
+			if w.Code != tt.want {
+				t.Fatalf("status = %d, want %d", w.Code, tt.want)
+			}
+			if w.Body.String() != tt.body || w.Header().Get("Content-Range") != tt.contentRange {
+				t.Fatalf("response changed: body=%q, range=%q", w.Body.String(), w.Header().Get("Content-Range"))
+			}
+		})
+	}
+}

--- a/server/s3/server.go
+++ b/server/s3/server.go
@@ -24,5 +24,5 @@ func NewServer(ctx context.Context) (h http.Handler, err error) {
 		gofakes3.WithIntegrityCheck(true), // Check Content-MD5 if supplied
 	)
 
-	return redirectHandler(faker.Server(), authPairs), nil
+	return redirectHandler(rangeStatusHandler(faker.Server()), authPairs), nil
 }


### PR DESCRIPTION
## Summary / 摘要

S3 uploads without Content-Type pass an empty MIME type to storage drivers, which causes Quark upload preflight to fail. Ranged downloads carry Content-Range but gofakes3 v0.8.1 does not select HTTP 206.

- Default a missing upload MIME type to application/octet-stream at the shared S3 upload entry point, covering ordinary and multipart uploads.
- Select HTTP 206 for successful ranged GET responses, preserving error statuses and non-range requests.
- Add 10 isolated response-status regression cases.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

## Related Issues / 关联 Issue

- Closes #3042: 由于用户使用自动化AI导致仓库对用户封号
- Closes #3043: 由于用户使用自动化AI导致仓库对用户封号
- Closes #3044: 由于用户使用自动化AI导致仓库对用户封号
- Closes #3045: 由于用户使用自动化AI导致仓库对用户封号
- Closes #3046: 由于用户使用自动化AI导致仓库对用户封号
- Closes #3047: 由于用户使用自动化AI导致仓库对用户封号

Review findings:
- #3042 / #3046: confirmed the empty MIME path; fix it at the S3 boundary so all storage drivers receive a usable type.
- #3043 / #3047: confirmed the missing 206 in [gofakes3 v0.8.1](https://github.com/OpenListTeam/gofakes3/blob/v0.8.1/gofakes3.go) and its [range headers](https://github.com/OpenListTeam/gofakes3/blob/v0.8.1/range.go). The backend already selects the requested byte range.
- #3044: current main includes multipart creation, part storage and completion; the reporter subsequently stated that the original failure predated that implementation. No additional change for this report.
- #3045: the reporter retracted the result as a harness error. Configured credentials are checked by gofakes3; the existing no-credentials mode is unchanged.
- #3047 also contains the MIME changes from #3046; this replacement handles the two underlying problems once.

## Testing / 测试

- [x] `GOTOOLCHAIN=local GOPROXY=off GOSUMDB=off go test server/s3/range.go server/s3/range_test.go`
- [x] Formatted all changed Go files with gofmt.
- [ ] `go test ./...`
- [ ] Manual test / 手动测试: Live Quark uploads and S3 requests were not exercised.

The isolated test uses only the standard library. The existing S3 package tests initialize SQLite and were not run under the no-database constraint. Full integration/build validation remains outstanding; no module dependency was added or upgraded.

## Checklist / 检查清单

- [ ] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [ ] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

Codex reviewed the referenced reports and proposed changes, implemented the fixes, and drafted the commit and PR descriptions under human direction.

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。
