### PR TITLE
fix(115_open): refresh expired OSS credentials during upload

### DIFF
--- a/drivers/115_open/upload.go
+++ b/drivers/115_open/upload.go
@@ -3,6 +3,7 @@ package _115_open
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"io"
 	"time"
 
@@ -70,6 +71,19 @@ func (d *Open115) singleUpload(ctx context.Context, tempF model.File, tokenResp 
 // 	} `json:"data"`
 // }
 
+// retryExpiredToken retries only the rejected OSS operation, preserving the upload ID.
+func retryExpiredToken(refresh func() error, operation func() error) error {
+	err := operation()
+	var serviceErr oss.ServiceError
+	if !errors.As(err, &serviceErr) || serviceErr.Code != "SecurityTokenExpired" {
+		return err
+	}
+	if err := refresh(); err != nil {
+		return err
+	}
+	return operation()
+}
+
 func (d *Open115) multpartUpload(ctx context.Context, stream model.FileStreamer, up driver.UpdateProgress, tokenResp *sdk.UploadGetTokenResp, initResp *sdk.UploadInitResp) error {
 	ossClient, err := netutil.NewOSSClient(tokenResp.Endpoint, tokenResp.AccessKeyId, tokenResp.AccessKeySecret, oss.SecurityToken(tokenResp.SecurityToken))
 	if err != nil {
@@ -80,7 +94,32 @@ func (d *Open115) multpartUpload(ctx context.Context, stream model.FileStreamer,
 		return err
 	}
 
-	imur, err := bucket.InitiateMultipartUpload(initResp.Object, oss.Sequential())
+	refresh := func() error {
+		if err := d.WaitLimit(ctx); err != nil {
+			return err
+		}
+		token, err := d.client.UploadGetToken(ctx)
+		if err != nil {
+			return err
+		}
+		client, err := netutil.NewOSSClient(token.Endpoint, token.AccessKeyId, token.AccessKeySecret, oss.SecurityToken(token.SecurityToken))
+		if err != nil {
+			return err
+		}
+		newBucket, err := client.Bucket(initResp.Bucket)
+		if err != nil {
+			return err
+		}
+		bucket = newBucket
+		return nil
+	}
+
+	var imur oss.InitiateMultipartUploadResult
+	err = retryExpiredToken(refresh, func() error {
+		var err error
+		imur, err = bucket.InitiateMultipartUpload(initResp.Object, oss.Sequential(), oss.WithContext(ctx))
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -109,13 +148,17 @@ func (d *Open115) multpartUpload(ctx context.Context, stream model.FileStreamer,
 			return err
 		}
 		err = retry.Do(func() error {
-			rd.Seek(0, io.SeekStart)
-			part, err := bucket.UploadPart(imur, driver.NewLimitedUploadStream(ctx, rd), partSize, int(i))
-			if err != nil {
-				return err
-			}
-			parts[i-1] = part
-			return nil
+			return retryExpiredToken(refresh, func() error {
+				if _, err := rd.Seek(0, io.SeekStart); err != nil {
+					return err
+				}
+				part, err := bucket.UploadPart(imur, driver.NewLimitedUploadStream(ctx, rd), partSize, int(i), oss.WithContext(ctx))
+				if err != nil {
+					return err
+				}
+				parts[i-1] = part
+				return nil
+			})
 		},
 			retry.Context(ctx),
 			retry.Attempts(3),
@@ -134,14 +177,16 @@ func (d *Open115) multpartUpload(ctx context.Context, stream model.FileStreamer,
 		up(float64(offset) * 100 / float64(fileSize))
 	}
 
-	// callbackRespBytes := make([]byte, 1024)
-	_, err = bucket.CompleteMultipartUpload(
-		imur,
-		parts,
-		oss.Callback(base64.StdEncoding.EncodeToString([]byte(initResp.Callback.Value.Callback))),
-		oss.CallbackVar(base64.StdEncoding.EncodeToString([]byte(initResp.Callback.Value.CallbackVar))),
-		// oss.CallbackResult(&callbackRespBytes),
-	)
+	err = retryExpiredToken(refresh, func() error {
+		_, err := bucket.CompleteMultipartUpload(
+			imur,
+			parts,
+			oss.Callback(base64.StdEncoding.EncodeToString([]byte(initResp.Callback.Value.Callback))),
+			oss.CallbackVar(base64.StdEncoding.EncodeToString([]byte(initResp.Callback.Value.CallbackVar))),
+			oss.WithContext(ctx),
+		)
+		return err
+	})
 	if err != nil {
 		return err
 	}

--- a/drivers/115_open/upload_test.go
+++ b/drivers/115_open/upload_test.go
@@ -1,0 +1,133 @@
+package _115_open
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+)
+
+func TestRetryExpiredToken(t *testing.T) {
+	expired := oss.ServiceError{StatusCode: 403, Code: "SecurityTokenExpired"}
+	denied := oss.ServiceError{StatusCode: 403, Code: "AccessDenied"}
+	refreshErr := errors.New("refresh failed")
+	for _, tt := range []struct {
+		name                    string
+		first, next, refreshErr error
+		calls, refreshes        int
+		want                    error
+	}{
+		{name: "success", calls: 1},
+		{name: "expired", first: expired, calls: 2, refreshes: 1},
+		{name: "wrapped", first: fmt.Errorf("upload: %w", expired), calls: 2, refreshes: 1},
+		{name: "access denied", first: denied, calls: 1, want: denied},
+		{name: "refresh failure", first: expired, refreshErr: refreshErr, calls: 1, refreshes: 1, want: refreshErr},
+		{name: "still expired", first: expired, next: expired, calls: 2, refreshes: 1, want: expired},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			old, fresh := &oss.Bucket{}, &oss.Bucket{}
+			bucket := old
+			calls, refreshes := 0, 0
+			err := retryExpiredToken(func() error {
+				refreshes++
+				if tt.refreshErr != nil {
+					return tt.refreshErr
+				}
+				bucket = fresh
+				return nil
+			}, func() error {
+				calls++
+				if calls == 1 {
+					return tt.first
+				}
+				if bucket != fresh {
+					t.Fatal("retry used old bucket")
+				}
+				return tt.next
+			})
+			if !errors.Is(err, tt.want) || calls != tt.calls || refreshes != tt.refreshes {
+				t.Fatalf("error=%v calls=%d refreshes=%d", err, calls, refreshes)
+			}
+		})
+	}
+}
+
+func TestRetryExpiredTokenMultipart(t *testing.T) {
+	for _, stage := range []string{"initiate", "part", "complete"} {
+		t.Run(stage, func(t *testing.T) {
+			requests := 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				body, _ := io.ReadAll(r.Body)
+				if stage != "initiate" && r.URL.Query().Get("uploadId") != "existing-upload" {
+					t.Error("upload ID changed")
+				}
+				if stage == "part" && (string(body) != "file contents" || r.URL.Query().Get("partNumber") != "2") {
+					t.Error("part content or number changed")
+				}
+				if stage == "complete" && (!strings.Contains(string(body), "part-etag") || r.Header.Get("x-oss-callback") != "callback") {
+					t.Error("completion parts or callback changed")
+				}
+				if requests == 1 {
+					w.WriteHeader(http.StatusForbidden)
+					fmt.Fprint(w, `<Error><Code>SecurityTokenExpired</Code><Message>expired</Message></Error>`)
+					return
+				}
+				if r.Header.Get("x-oss-security-token") != "fresh-token" || !strings.HasPrefix(r.Header.Get("Authorization"), "OSS fresh-key:") {
+					t.Error("credentials were not replaced")
+				}
+				w.Header().Set("ETag", `"part-etag"`)
+				if stage == "initiate" {
+					fmt.Fprint(w, `<InitiateMultipartUploadResult><Bucket>bucket</Bucket><Key>object</Key><UploadId>existing-upload</UploadId></InitiateMultipartUploadResult>`)
+				} else if stage == "complete" {
+					fmt.Fprint(w, `<CompleteMultipartUploadResult><Bucket>bucket</Bucket><Key>object</Key></CompleteMultipartUploadResult>`)
+				}
+			}))
+			defer srv.Close()
+			newBucket := func(key, token string) *oss.Bucket {
+				c, err := oss.New(srv.URL, key, "secret", oss.SecurityToken(token), oss.ForcePathStyle(true))
+				if err != nil {
+					t.Fatal(err)
+				}
+				b, err := c.Bucket("bucket")
+				if err != nil {
+					t.Fatal(err)
+				}
+				return b
+			}
+			bucket := newBucket("old-key", "old-token")
+			imur := oss.InitiateMultipartUploadResult{Bucket: "bucket", Key: "object", UploadID: "existing-upload"}
+			rd := strings.NewReader("file contents")
+			err := retryExpiredToken(func() error {
+				bucket = newBucket("fresh-key", "fresh-token")
+				return nil
+			}, func() error {
+				switch stage {
+				case "initiate":
+					_, err := bucket.InitiateMultipartUpload("object")
+					return err
+				case "part":
+					if _, err := rd.Seek(0, io.SeekStart); err != nil {
+						return err
+					}
+					_, err := bucket.UploadPart(imur, rd, int64(rd.Len()), 2)
+					return err
+				default:
+					_, err := bucket.CompleteMultipartUpload(imur, []oss.UploadPart{{PartNumber: 2, ETag: "part-etag"}}, oss.Callback("callback"))
+					return err
+				}
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if requests != 2 {
+				t.Fatalf("got %d requests", requests)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary / 摘要

Long-running 115 Open uploads reuse the OSS credentials obtained at upload startup. When these expire, existing part retries continue using the expired credentials and the upload fails with `SecurityTokenExpired`.

Refresh credentials and retry the rejected operation once for multipart initiation, part upload, and completion. Preserve the upload ID, completed parts, and callbacks, and rewind the current part before resending it. Keep the existing three outer part-upload attempts; each can perform one additional retry after refreshing expired credentials. Other OSS errors do not trigger credential refresh.

- [ ] This PR has breaking changes.
- [ ] This PR changes public API, config, storage format, or migration behavior.
- [ ] This PR requires corresponding changes in related repositories.

Related repository PRs / 关联仓库 PR: None.

## Related Issues / 关联 Issue

Fixes #1376

## Testing / 测试

Platform: Linux amd64, Go 1.27.1 in Docker.

- Passed on the final code: `go test -tags=jsoniter ./drivers/115_open -count=1`.
- Passed: `git diff --check`.
- Mock OSS tests cover expired credentials during initiation, part upload, and completion, replacement credentials, preserved upload IDs, part content and callbacks, refresh failure, non-expiration errors, and bounded retries in the helper.
- Before the behavior-preserving refresh-closure simplification, `go test -race ./drivers/115_open`, a full application/image build, and container `/ping` and frontend checks passed. The image was not rebuilt after that simplification.
- `go test ./internal/net` exposed an existing failure in `TestNewOSSClientUsesEnvironmentHTTPSProxy`: it expects `*http.Transport` but receives `*net.safeTransport`. The same failure was reproduced on an unmodified base checkout.
- [ ] `go test ./...` — not run; validation focused on the affected driver and related network package.
- [ ] Manual test / 手动测试: Real 115 uploads spanning credential expiry have not been verified.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
- [ ] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
- [ ] I have requested review from relevant maintainers or code owners where applicable.

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.

Tools used / 使用工具:

- [x] Codex

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [x] Documentation / 文档 — commit and PR descriptions
- [x] Tests / 测试
- [x] Review assistance / 审查辅助

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.

Codex generated the implementation and tests, ran the checks described above, and prepared this PR at the contributor's request. Human attestations not established during this work are left unchecked.
