### PR TITLE
fix(115_open): refresh expired OSS credentials during upload

### DIFF
--- a/drivers/115_open/upload.go
+++ b/drivers/115_open/upload.go
@@ -3,6 +3,7 @@ package _115_open
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"io"
 	"time"
 
@@ -70,6 +71,19 @@ func (d *Open115) singleUpload(ctx context.Context, tempF model.File, tokenResp 
 // 	} `json:"data"`
 // }
 
+// retryExpiredToken retries only the rejected OSS operation, preserving the upload ID.
+func retryExpiredToken(refresh func() error, operation func() error) error {
+	err := operation()
+	var serviceErr oss.ServiceError
+	if !errors.As(err, &serviceErr) || serviceErr.Code != "SecurityTokenExpired" {
+		return err
+	}
+	if err := refresh(); err != nil {
+		return err
+	}
+	return operation()
+}
+
 func (d *Open115) multpartUpload(ctx context.Context, stream model.FileStreamer, up driver.UpdateProgress, tokenResp *sdk.UploadGetTokenResp, initResp *sdk.UploadInitResp) error {
 	ossClient, err := netutil.NewOSSClient(tokenResp.Endpoint, tokenResp.AccessKeyId, tokenResp.AccessKeySecret, oss.SecurityToken(tokenResp.SecurityToken))
 	if err != nil {
@@ -80,7 +94,32 @@ func (d *Open115) multpartUpload(ctx context.Context, stream model.FileStreamer,
 		return err
 	}
 
-	imur, err := bucket.InitiateMultipartUpload(initResp.Object, oss.Sequential())
+	refresh := func() error {
+		if err := d.WaitLimit(ctx); err != nil {
+			return err
+		}
+		token, err := d.client.UploadGetToken(ctx)
+		if err != nil {
+			return err
+		}
+		client, err := netutil.NewOSSClient(token.Endpoint, token.AccessKeyId, token.AccessKeySecret, oss.SecurityToken(token.SecurityToken))
+		if err != nil {
+			return err
+		}
+		newBucket, err := client.Bucket(initResp.Bucket)
+		if err != nil {
+			return err
+		}
+		bucket = newBucket
+		return nil
+	}
+
+	var imur oss.InitiateMultipartUploadResult
+	err = retryExpiredToken(refresh, func() error {
+		var err error
+		imur, err = bucket.InitiateMultipartUpload(initResp.Object, oss.Sequential(), oss.WithContext(ctx))
+		return err
+	})
 	if err != nil {
 		return err
 	}
@@ -109,13 +148,17 @@ func (d *Open115) multpartUpload(ctx context.Context, stream model.FileStreamer,
 			return err
 		}
 		err = retry.Do(func() error {
-			rd.Seek(0, io.SeekStart)
-			part, err := bucket.UploadPart(imur, driver.NewLimitedUploadStream(ctx, rd), partSize, int(i))
-			if err != nil {
-				return err
-			}
-			parts[i-1] = part
-			return nil
+			return retryExpiredToken(refresh, func() error {
+				if _, err := rd.Seek(0, io.SeekStart); err != nil {
+					return err
+				}
+				part, err := bucket.UploadPart(imur, driver.NewLimitedUploadStream(ctx, rd), partSize, int(i), oss.WithContext(ctx))
+				if err != nil {
+					return err
+				}
+				parts[i-1] = part
+				return nil
+			})
 		},
 			retry.Context(ctx),
 			retry.Attempts(3),
@@ -134,14 +177,16 @@ func (d *Open115) multpartUpload(ctx context.Context, stream model.FileStreamer,
 		up(float64(offset) * 100 / float64(fileSize))
 	}
 
-	// callbackRespBytes := make([]byte, 1024)
-	_, err = bucket.CompleteMultipartUpload(
-		imur,
-		parts,
-		oss.Callback(base64.StdEncoding.EncodeToString([]byte(initResp.Callback.Value.Callback))),
-		oss.CallbackVar(base64.StdEncoding.EncodeToString([]byte(initResp.Callback.Value.CallbackVar))),
-		// oss.CallbackResult(&callbackRespBytes),
-	)
+	err = retryExpiredToken(refresh, func() error {
+		_, err := bucket.CompleteMultipartUpload(
+			imur,
+			parts,
+			oss.Callback(base64.StdEncoding.EncodeToString([]byte(initResp.Callback.Value.Callback))),
+			oss.CallbackVar(base64.StdEncoding.EncodeToString([]byte(initResp.Callback.Value.CallbackVar))),
+			oss.WithContext(ctx),
+		)
+		return err
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary / 摘要

Long-running 115 Open uploads fail when OSS credentials expire because retries keep using the original credentials. Refresh credentials on `SecurityTokenExpired` and retry the rejected multipart initiation, part upload, or completion once, preserving the upload ID, completed parts, and callbacks.

Part uploads retain their three outer attempts; each can make one additional attempt after refreshing expired credentials. Rewind the current part before resending it and pass the upload context to OSS requests. This PR changes only `drivers/115_open/upload.go`.

- [ ] This PR has breaking changes.
- [ ] This PR changes public API, config, storage format, or migration behavior.
- [ ] This PR requires corresponding changes in related repositories.

Related repository PRs / 关联仓库 PR: None.

## Related Issues / 关联 Issue

Fixes #1376

## Testing / 测试

Linux amd64, Go 1.27.1 in Docker:

- `go test -tags=jsoniter ./drivers/115_open -count=1` passed with local, untracked tests. Those tests are not included in this PR. They exercise credential replacement and retries for multipart initiation, part upload, and completion, plus non-expiration errors and refresh failures.
- `git diff --check` passed.
- Before the refresh-closure refactor, driver race tests, a full application/image build, and container `/ping` and frontend checks passed. The image was not rebuilt after that refactor.
- A related network-package test, `TestNewOSSClientUsesEnvironmentHTTPSProxy`, fails because it expects `*http.Transport` but receives `*net.safeTransport`. This was also reproduced on the unmodified base checkout.
- [ ] `go test ./...` — not run; validation focused on the affected driver and related network package.
- [ ] Manual test / 手动测试: Real 115 uploads spanning credential expiry have not been verified.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
- [ ] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
- [ ] I have requested review from relevant maintainers or code owners where applicable.

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.

Tools used / 使用工具:

- [x] Codex

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [x] Refactoring / 重构
- [x] Documentation / 文档 — commit and PR descriptions
- [x] Tests / 测试 — local validation only; test files are not included
- [x] Review assistance / 审查辅助

- [ ] I have reviewed and validated all AI-assisted content included in this PR.
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.

Codex implemented the change and performed the validation described above at the contributor's request. Human attestations not established during this work remain unchecked.
