### PR TITLE
fix(s3): encode multipart fixture paths

### DIFF
--- a/server/s3/multipart_test.go
+++ b/server/s3/multipart_test.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -67,11 +68,21 @@ func setupMultipartBackend(t *testing.T) (*s3Backend, string) {
 		t.Fatalf("mkdir local root: %v", err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(localRoot) })
+	addition, err := json.Marshal(struct {
+		RootFolderPath string `json:"root_folder_path"`
+		Thumbnail      bool   `json:"thumbnail"`
+	}{
+		RootFolderPath: localRoot,
+		Thumbnail:      false,
+	})
+	if err != nil {
+		t.Fatalf("marshal local storage addition: %v", err)
+	}
 
 	_, err = op.CreateStorage(ctx, model.Storage{
 		Driver:    "Local",
 		MountPath: mount,
-		Addition:  `{"root_folder_path":"` + localRoot + `","thumbnail":false}`,
+		Addition:  string(addition),
 	})
 	if err != nil {
 		t.Fatalf("create local storage: %+v", err)


### PR DESCRIPTION
## Summary / 摘要

- Serialize the Local storage addition used by S3 multipart tests instead of interpolating an OS path into JSON syntax.
- Escape Windows backslashes correctly while preserving the same decoded Local root and Linux behavior.
- Keep this test-only portability repair independent from #3071; the two PRs are based on the same `main` revision and modify disjoint files.

- [ ] This PR has breaking changes.
      / 此 PR 包含破坏性变更。
- [ ] This PR changes public API, config, storage format, or migration behavior.
      / 此 PR 修改了公开 API、配置、存储格式或迁移行为。
- [ ] This PR requires corresponding changes in related repositories.
      / 此 PR 需要关联仓库同步修改。

Related repository PRs / 关联仓库 PR:

- OpenList-Frontend: Not required.
- OpenList-Docs: Not required.

## Testing / 测试

- [ ] `go test ./...`
  - Not run; the change is isolated to the existing `server/s3` multipart fixture.
- [x] Windows amd64, Go 1.27.1: `go test ./server/s3 -run "^TestMultipart" -count=1`
- [x] Windows amd64, Go 1.27.1: `go test ./server/s3 -count=1`
- [x] Windows amd64, Go 1.27.1: `go vet ./server/s3`
- [x] Tumbleweed WSL, Go 1.27.1, CGO enabled, GCC 16.2.0: `go test -race ./server/s3 -run "^TestMultipart" -count=1`
- [ ] Manual test / 手动测试: Not applicable; this is test-fixture construction only.

Before the change, all four multipart tests fail on Windows while decoding the manually interpolated path. A repeated `-count=5` invocation was also attempted after the repair; later iterations expose a separate package-global in-memory database isolation issue because mount paths are reused. That issue is independent from JSON path encoding and is intentionally outside this PR.

## Checklist / 检查清单

- [x] I have read [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md).
      / 我已阅读 [CONTRIBUTING](https://github.com/OpenListTeam/OpenList/blob/main/CONTRIBUTING.md)。
- [x] I confirm this contribution follows the repository license, contribution policy, and code of conduct.
      / 我确认此贡献符合仓库许可证、贡献规范和行为准则。
- [x] I have formatted the changed code with `gofmt`, `go fmt`, or `prettier` where applicable.
      / 我已按适用情况使用 `gofmt`、`go fmt` 或 `prettier` 格式化变更代码。
- [ ] I have requested review from relevant maintainers or code owners where applicable.
      / 我已在适用情况下请求相关维护者或代码所有者审查。

## AI Disclosure / AI 使用声明

- [x] This PR includes AI-assisted content.
      / 此 PR 包含 AI 辅助内容。

Tools used / 使用工具:

- [ ] ChatGPT
- [x] Codex
- [ ] GitHub Copilot
- [ ] Claude
- [ ] Gemini
- [ ] Other (please specify) / 其他（请注明）:

Usage scope / 使用范围:

- [x] Code generation / 代码生成
- [ ] Refactoring / 重构
- [ ] Documentation / 文档
- [x] Tests / 测试
- [ ] Translation / 翻译
- [x] Review assistance / 审查辅助

- [x] I have reviewed and validated all AI-assisted content included in this PR.
      / 我已审核并验证此 PR 中的所有 AI 辅助内容。
- [x] I have ensured that all AI-assisted commits include `Co-Authored-By` attribution.
      / 我已确保所有 AI 辅助提交都包含 `Co-Authored-By` 归属信息。
- [ ] I can reproduce all AI-assisted content included in this PR without any AI tools.
      / 我可以在没有任何 AI 工具的情况下重现此 PR 中包含的所有 AI 辅助内容。

This draft intentionally leaves the human-review and reproducibility confirmations unchecked for the author.
